### PR TITLE
Added AVR components to LLVM_LINK_COMPONENTS to fix the build on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ set(LLVM_LINK_COMPONENTS
         AMDGPUInfo
         AMDGPUAsmParser
         AMDGPUCodeGen
+        AVRAsmParser
+        AVRInfo
+        AVRDesc
+        AVRCodeGen
         BPFInfo
         BPFAsmParser
         BPFDisassembler


### PR DESCRIPTION
`-Werror` must still be removed from `target_compile_options` to build with GCC.
Presumably the build would work without any further modifications with Clang, but I have not tested it.

[The attached file includes the warnings given by GCC.](https://github.com/c3lang/c3c/files/4390384/build2.txt) These must be fixed (or `-Werror` must be disabled) to build with GCC.