### PR TITLE
Constants are now variables. Constant compile time constants are type…

### DIFF
--- a/src/compiler/ast.c
+++ b/src/compiler/ast.c
@@ -112,6 +112,8 @@ const char *decl_var_to_string(VarDeclKind kind)
 	{
 		case VARDECL_CONST:
 			return "const";
+		case VARDECL_CONST_CT:
+			return "$const";
 		case VARDECL_GLOBAL:
 			return "global";
 		case VARDECL_LOCAL:
@@ -738,6 +740,7 @@ void fprint_decl_recursive(Context *context, FILE *file, Decl *decl, int indent)
 			DUMPTI(decl->var.type_info);
 			switch (decl->var.kind)
 			{
+				case VARDECL_CONST_CT:
 				case VARDECL_CONST:
 				case VARDECL_GLOBAL:
 				case VARDECL_LOCAL:

--- a/src/compiler/compiler_internal.h
+++ b/src/compiler/compiler_internal.h
@@ -272,7 +272,7 @@ typedef struct
 
 typedef struct _VarDecl
 {
-	VarDeclKind kind : 3;
+	VarDeclKind kind : 4;
 	bool constant : 1;
 	bool failable : 1;
 	bool unwrap : 1;

--- a/src/compiler/enums.h
+++ b/src/compiler/enums.h
@@ -508,7 +508,8 @@ typedef enum
 	VARDECL_MEMBER = 4,
 	VARDECL_LOCAL_CT = 5,
 	VARDECL_LOCAL_CT_TYPE = 6,
-	VARDECL_ALIAS = 7,
+	VARDECL_CONST_CT = 7,
+	VARDECL_ALIAS = 8,
 } VarDeclKind;
 
 typedef enum

--- a/src/compiler/llvm_codegen.c
+++ b/src/compiler/llvm_codegen.c
@@ -60,7 +60,9 @@ LLVMValueRef gencontext_emit_memclear(GenContext *context, LLVMValueRef ref, Typ
 
 static void gencontext_emit_global_variable_definition(GenContext *context, Decl *decl)
 {
-	assert(decl->var.kind == VARDECL_GLOBAL);
+	if (decl->var.kind == VARDECL_CONST_CT) return;
+
+	assert(decl->var.kind == VARDECL_GLOBAL || decl->var.kind == VARDECL_CONST);
 
 	// TODO fix name
 	decl->ref = LLVMAddGlobal(context->module, llvm_type(decl->type), decl->name);
@@ -73,7 +75,8 @@ static void gencontext_emit_global_variable_definition(GenContext *context, Decl
 	{
 		LLVMSetInitializer(decl->ref, LLVMConstNull(llvm_type(decl->type)));
 	}
-	// If read only: LLVMSetGlobalConstant(decl->var.backend_ref, 1);
+
+	LLVMSetGlobalConstant(decl->ref, decl->var.kind == VARDECL_CONST);
 
 	switch (decl->visibility)
 	{

--- a/src/compiler/parse_expr.c
+++ b/src/compiler/parse_expr.c
@@ -909,6 +909,7 @@ ParseRule rules[TOKEN_EOF + 1] = {
 		[TOKEN_CT_IDENT] = { parse_identifier, NULL, PREC_NONE },
 		[TOKEN_AT] = { parse_macro_ident, NULL, PREC_NONE },
 		[TOKEN_CONST_IDENT] = { parse_identifier, NULL, PREC_NONE },
+		[TOKEN_CT_CONST_IDENT] = { parse_identifier, NULL, PREC_NONE },
 		[TOKEN_STRING] = { parse_string_literal, NULL, PREC_NONE },
 		[TOKEN_REAL] = { parse_double, NULL, PREC_NONE },
 		[TOKEN_OR] = { NULL, parse_binary, PREC_LOGICAL },

--- a/src/compiler/sema_casts.c
+++ b/src/compiler/sema_casts.c
@@ -476,34 +476,6 @@ bool ixxbo(Context *context, Expr *left, Type *type)
 }
 
 
-bool ussi(Context *context, Expr* left, Type *from, Type *canonical, Type *type, CastType cast_type)
-{
-	if (type->type_kind != TYPE_ENUM) return sema_type_mismatch(context, left, type, CAST_TYPE_EXPLICIT);
-	if (cast_type != CAST_TYPE_EXPLICIT) EXIT_T_MISMATCH();
-
-	if (left->expr_kind == EXPR_IDENTIFIER && left->identifier_expr.decl->decl_kind == DECL_ENUM_CONSTANT)
-	{
-		// TODO
-		Expr *value = left->identifier_expr.decl->enum_constant.expr;
-		assert(value->expr_kind == EXPR_CONST);
-//		assert(value->const_expr.type == CONST_INT);
-		left->const_expr.i = value->const_expr.i;
-		// TODO narrowing
-	}
-	insert_cast(left, CAST_ENUMLOW, canonical);
-	return true;
-}
-
-bool sius(Context *context, Expr* left, Type *from, Type *canonical, Type *type, CastType cast_type)
-{
-	TODO
-}
-
-bool uius(Context *context, Expr* left, Type *from, Type *canonical, Type *type, CastType cast_type)
-{
-	TODO
-}
-
 /**
  * Cast comptime, signed or unsigned -> pointer.
  * @return true unless the constant value evaluates to zero.
@@ -592,6 +564,7 @@ bool enxi(Context *context, Expr* left, Type *from, Type *canonical, Type *type,
 		return false;
 	}
 	// 3. Dispatch to the right cast:
+	insert_cast(left, CAST_ENUMLOW, enum_type);
 	return xixi(context, left, enum_type_canonical, canonical, type, cast_type);
 }
 

--- a/src/compiler/sema_decls.c
+++ b/src/compiler/sema_decls.c
@@ -591,6 +591,8 @@ static inline bool expr_is_constant_eval(Expr *expr)
 
 static inline bool sema_analyse_global(Context *context, Decl *decl)
 {
+	if (decl->var.kind == VARDECL_CONST_CT) return true;
+
 	if (!sema_resolve_type_info(context, decl->var.type_info)) return false;
 	decl->type = decl->var.type_info->type;
 	if (decl->var.init_expr)
@@ -649,7 +651,6 @@ static inline bool sema_analyse_global(Context *context, Decl *decl)
 		default:
 			eprintf("Decl %s %d\n", decl->name, decl->var.kind);
 			UNREACHABLE
-			break;
 	}
 }
 

--- a/test/test_suite/constants/constant_paren.c3t
+++ b/test/test_suite/constants/constant_paren.c3t
@@ -1,7 +1,0 @@
-// #skip
-
-const uint AA = (~0);
-
-// #expect: constant_paren.ll
-
-#define test_AA (~0)

--- a/test/test_suite/constants/constants.c3t
+++ b/test/test_suite/constants/constants.c3t
@@ -1,0 +1,34 @@
+const byte AA = ~0;
+const byte BB = 200 ;
+const uint CC = ~0;
+const uint DD = $FOO;
+
+const $FOO = ~0;
+
+uint x = AA;
+uint z = CC;
+byte w = $FOO;
+ushort v = $FOO;
+uint z2 = DD;
+
+func void test()
+{
+    int xx = $FOO;
+}
+
+// #expect: constants.ll
+
+@AA = protected constant i8 -1
+@BB = protected constant i8 -56
+@CC = protected constant i32 -1
+@DD = protected constant i32 -1
+@x = protected global i32 255
+@z = protected global i32 -1
+@w = protected global i8 -1
+@v = protected global i16 -1
+@z2 = protected global i32 -1
+
+entry:
+    %xx = alloca i32
+    store i32 -1, i32* %xx
+    ret void

--- a/test/test_suite/expressions/casts/cast_enum_to_various.c3
+++ b/test/test_suite/expressions/casts/cast_enum_to_various.c3
@@ -1,4 +1,6 @@
-// #skip
+
+
+
 struct Struct
 {
     int x;

--- a/test/test_suite/globals/misplaced_const.c3
+++ b/test/test_suite/globals/misplaced_const.c3
@@ -1,0 +1,6 @@
+const $FOO = 3;
+$BAR = 4; // #error: Did you forget a 'const' before the name of this compile time constant?
+
+const $BAZ = "ofke";
+
+$FOOBAR; // #error: Compile time constant unexpectedly found


### PR DESCRIPTION
…less and act as #define and are now also correctly parsed. Enums are also correctly lowered. And expressions are copied when inlining constants. Compile time ints can no longer be bitnegated.