### PR TITLE
Fix build on x86_64-linux-musl

### DIFF
--- a/src/compiler/bigint.c
+++ b/src/compiler/bigint.c
@@ -193,7 +193,7 @@ static void to_twos_complement(BigInt *dest, const BigInt *source, size_t bit_co
 		if (dest->digit == 0) dest->digit_count = 0;
 		return;
 	}
-	dest->digits = malloc_arena(dest->digit_count * sizeof(u_int64_t));
+	dest->digits = malloc_arena(dest->digit_count * sizeof(uint64_t));
 	for (size_t i = 0; i < digits_to_copy; i += 1)
 	{
 		uint64_t digit = (i < source->digit_count) ? source_digits[i] : 0;

--- a/src/utils/file_utils.c
+++ b/src/utils/file_utils.c
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the GNU LGPLv3.0 license
 // a copy of which can be found in the LICENSE file.
 
+#include <sys/stat.h>
 #include "common.h"
 #include "errors.h"
 #include "lib.h"
@@ -9,8 +10,7 @@
 #include <dirent.h>
 #include <limits.h>
 #include <unistd.h>
-#include <sys/stat.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include "whereami.h"
 
 const char* expand_path(const char* path)


### PR DESCRIPTION
Hi, I fixed a typo caught by the compiler and also fixed some errors when I tried to compile on x86_64-linux-musl.

As to why I changed `sys/errno.h` to `errno.h` on musl ([source](https://git.musl-libc.org/cgit/musl/tree/include/sys/errno.h)):
```c
#warning redirecting incorrect #include <sys/errno.h> to <errno.h>
#include <errno.h>
```

And why I changed the order of `sys/stat.h` on musl ([source](https://git.musl-libc.org/cgit/musl/tree/arch/x86_64/bits/stat.h)):
```c
struct stat {
	/* .... omitted */
	long __unused[3];
	/* omitted ... */
};
```
which conflicts with:
https://github.com/c3lang/c3c/blob/1d50beb3303715a6e2df2478f58919e0716f2e8b/src/utils/common.h#L19-L21