### PR TITLE
Don't use -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ add_executable(c3c
         src/compiler/llvm_codegen_c_abi_riscv.c
         src/compiler/llvm_codegen_c_abi_wasm.c)
 
-target_compile_options(c3c PRIVATE -Wsign-compare -Wimplicit-int -Werror -Wall -Wno-unknown-pragmas -Wextra -Wno-unused-function -Wno-unused-variable -Wno-unused-parameter)
+target_compile_options(c3c PRIVATE -Wsign-compare -Wimplicit-int -Wall -Wno-unknown-pragmas -Wextra -Wno-unused-function -Wno-unused-variable -Wno-unused-parameter)
 
 target_include_directories(c3c PRIVATE
         "${CMAKE_SOURCE_DIR}/src/")


### PR DESCRIPTION
gcc version 10.2.0
>file_utils.c:131:2: error: ‘strncpy’ specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
  131 |  strncpy(path, full_path, path_len + 1);