### PR TITLE
Test both release and debug.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,3 +19,8 @@ jobs:
           mkdir build && cd build
           cmake -DLLVM_DIR=/usr/lib/llvm-11/cmake -DCMAKE_BUILD_TYPE=Debug ..
           cmake --build .
+          cd ..
+          rm -rf build
+          mkdir build && cd build
+          cmake -DLLVM_DIR=/usr/lib/llvm-11/cmake -DCMAKE_BUILD_TYPE=Release ..
+          cmake --build .

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -231,6 +231,11 @@ void compiler_compile(void)
 	bool create_exe = !active_target.test_output && (active_target.type == TARGET_TYPE_EXECUTABLE || active_target.type == TARGET_TYPE_TEST);
 
 	size_t output_file_count = vec_size(gen_contexts);
+	if (!output_file_count)
+	{
+		error_exit("No output files found.");
+	}
+
 	const char **obj_files = malloc(sizeof(char*) * output_file_count);
 
 #if USE_PTHREAD


### PR DESCRIPTION
This adds release versions to the CI tests for Linux, and also has a fix to avoid warnings on Linux.