### PR TITLE
Make the build more deterministic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 message(STATUS "Libraries located in: ${LLVM_LIBRARY_DIRS}")
 
+message(STATUS, "Using C compiler in: {CMAKE_C_COMPILER}")
+message(STATUS, "Using CXX compiler in: {CMAKE_CXX_COMPILER}")
+
 include_directories(${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ work on Windows. Also, parts of the code is still rough and needs to be made sol
 5. Enter the C3C directory `cd c3c`.
 6. Create a build directory `mkdir build`
 7. Change directory to the build directory `cd build`
-8. Set up CMake build for debug: `cmake -DLLVM_DIR=/usr/lib/llvm-11/cmake -DCMAKE_BUILD_TYPE=Debug ..`
+8. Set up CMake build for debug: `cmake -DLLVM_DIR=/usr/lib/llvm-11/cmake -DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11 -DCMAKE_BUILD_TYPE=Debug ..`
 9. Build: `cmake --build .`
 
 You should now have a `c3c` executable.

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -173,7 +173,7 @@ const char *concat_string_parts(const char **args)
 void platform_linker(const char *output_file, const char **files, unsigned file_count)
 {
 	const char **parts = NULL;
-	vec_add(parts, "cc");
+	vec_add(parts, "clang-11");
 	vec_add(parts, "-lm");
 	vec_add(parts, "-o");
 	vec_add(parts, output_file);


### PR DESCRIPTION
Clang-11 is expected to be installed and to be the clang version used to build the compiler. Forcing the use of clang-11 avoid miscompilations in two cases:

1. in the case other clang versions are present and the clang link does not link to clang-11.
2. in the case cc does not link to a suitable compiler.