### PR TITLE
Removed func and rewrote typedefs.

### DIFF
--- a/resources/lib/std/mem.c3
+++ b/resources/lib/std/mem.c3
@@ -22,7 +22,7 @@ public error AllocationFailure
     AllocationFailureKind failureKind;
 }
 
-public typedef func void!(void *data, void** pointer, usize bytes, usize alignment, AllocationKind kind) as AllocatorFunction;
+public define AllocatorFunction = func void!(void *data, void** pointer, usize bytes, usize alignment, AllocationKind kind);
 
 public struct Allocator
 {

--- a/resources/testproject/foo.c3
+++ b/resources/testproject/foo.c3
@@ -9,7 +9,7 @@ public struct Foo
 
 extern func void printf(char *hello);
 
-local func void ofke()
+func void ofke()
 {}
 
 func void exple() {}

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -107,7 +107,7 @@ static const char* check_dir(const char *path)
 	}
 	if (chdir(path) == -1) error_exit("The path \"%s\" does not point to a valid directory.", path);
 	int err = chdir(original_path);
-	assert(!err);
+	if (err) FAIL_WITH_ERR("Failed to change path to %s.", original_path);
 	return path;
 }
 

--- a/src/compiler/compiler_internal.h
+++ b/src/compiler/compiler_internal.h
@@ -452,7 +452,7 @@ typedef struct
 		};
 		Decl *alias;
 	};
-	Expr **params;
+	TypeInfo **params;
 } DefineDecl;
 
 typedef struct
@@ -1697,6 +1697,17 @@ bool token_is_type(TokenType type);
 bool token_is_any_type(TokenType type);
 bool token_is_symbol(TokenType type);
 const char *token_type_to_string(TokenType type);
+static inline TokenType advance_token(TokenId *token)
+{
+	TokenType tok;
+	while (1)
+	{
+		token->index += 1;
+		tok = TOKTYPE(*token);
+		if (tok != TOKEN_COMMENT) return tok;
+	}
+}
+
 
 AlignSize type_abi_alignment(Type *type);
 AlignSize type_alloca_alignment(Type *type);

--- a/src/compiler/copying.c
+++ b/src/compiler/copying.c
@@ -24,7 +24,7 @@ static inline void copy_flow(Ast *ast)
 	ast->flow.label = decl_copy_label_from_macro(ast->flow.label, ast);
 }
 
-static TypeInfo** type_info_copy_list_from_macro(Context *context, TypeInfo **to_copy)
+static TypeInfo** type_info_copy_list_from_macro(TypeInfo **to_copy)
 {
 	TypeInfo **result = NULL;
 	VECEACH(to_copy, i)
@@ -561,7 +561,7 @@ Decl *copy_decl(Decl *decl)
 		case DECL_ATTRIBUTE:
 			TODO
 		case DECL_DEFINE:
-			MACRO_COPY_EXPR_LIST(decl->define_decl.params);
+			MACRO_COPY_TYPE_LIST(decl->define_decl.params);
 			switch (decl->define_decl.define_kind)
 			{
 				case DEFINE_FUNC:

--- a/src/compiler/enums.h
+++ b/src/compiler/enums.h
@@ -433,7 +433,6 @@ typedef enum
 	TOKEN_SWITCH,
 	TOKEN_TRUE,
 	TOKEN_TRY,
-	TOKEN_TYPEDEF,
 	TOKEN_TYPEOF,
 	TOKEN_UNION,
 	TOKEN_VAR,              // Reserved

--- a/src/compiler/llvm_codegen_function.c
+++ b/src/compiler/llvm_codegen_function.c
@@ -168,7 +168,7 @@ static inline void llvm_process_parameter_value(GenContext *c, Decl *decl, unsig
 			LLVMValueRef hi_ptr = LLVMBuildStructGEP2(c->builder, struct_type, cast, 1, "hi");
 			// Store it in the struct.
 			AlignSize hi_alignment = MIN(llvm_abi_alignment(c, hi), decl_alignment);
-			llvm_store_aligned(c, hi_ptr, llvm_get_next_param(c, index), decl_alignment);
+			llvm_store_aligned(c, hi_ptr, llvm_get_next_param(c, index), hi_alignment);
 			return;
 		}
 		case ABI_ARG_DIRECT_COERCE:

--- a/src/compiler/parse_stmt.c
+++ b/src/compiler/parse_stmt.c
@@ -1149,7 +1149,6 @@ Ast *parse_stmt(Context *context)
 		case TOKEN_EXTERN:
 		case TOKEN_STRUCT:
 		case TOKEN_INTERFACE:
-		case TOKEN_TYPEDEF:
 		case TOKEN_UNION:
 		case TOKEN_ATTRIBUTE:
 		case TOKEN_VAR:

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -781,7 +781,6 @@ static inline bool sema_expr_analyse_intrinsic_fp_invocation(Context *context, E
 
 static inline bool sema_expr_analyse_intrinsic_invocation(Context *context, Expr *expr, Decl *decl, Type *to)
 {
-	unsigned arguments = vec_size(expr->call_expr.arguments);
 	if (decl->name == kw___ceil || decl->name == kw___trunc || decl->name == kw___round || decl->name == kw___sqrt)
 	{
 		return sema_expr_analyse_intrinsic_fp_invocation(context, expr, decl, to);
@@ -3488,6 +3487,7 @@ static bool sema_expr_analyse_add(Context *context, Type *to, Expr *expr, Expr *
 
 		// No need to check the cast we just ensured it was an integer.
 		assert(success && "This should always work");
+		(void)success;
 
 		// 3c. Set the type and other properties.
 		expr_copy_types(expr, left);
@@ -4172,8 +4172,6 @@ static bool sema_take_addr_of(Expr *inner, bool *is_constant)
  */
 static bool sema_expr_analyse_addr(Context *context, Type *to, Expr *expr, Expr *inner)
 {
-	Type *pointee = to ? to->canonical->pointer : NULL;
-
 	// 1. Evaluate the expression
 	REDO:
 	switch (inner->expr_kind)

--- a/src/compiler/tokens.c
+++ b/src/compiler/tokens.c
@@ -250,8 +250,6 @@ const char *token_type_to_string(TokenType type)
 			return "typeid";
 		case TOKEN_TYPEOF:
 			return "typeof";
-		case TOKEN_TYPEDEF:
-			return "typedef";
 		case TOKEN_UNION:
 			return "union";
 		case TOKEN_WHILE:

--- a/src/compiler_tests/tests.c
+++ b/src/compiler_tests/tests.c
@@ -61,10 +61,8 @@ static void test_lexer(void)
 	{
 		for (int i = 1; i < TOKEN_EOF; i++)
 		{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-variable"
 			volatile bool t = lexer_scan_ident_test(&lexer, tokens[i]);
-#pragma clang diagnostic pop
+			(void)t;
 		}
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -21,8 +21,6 @@ int main(int argc, const char *argv[])
 	// Init the compiler
 	compiler_init(build_options.std_lib_dir);
 
-	BuildTarget build_target = { .name = NULL };
-
 	switch (build_options.command)
 	{
 		case COMMAND_INIT:

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -288,7 +288,7 @@ static inline _VHeader* _vec_new(size_t element_size, size_t capacity)
 	return header;
 }
 
-static inline unsigned vec_size(const void*vec)
+static inline unsigned vec_size(const void *vec)
 {
 	return vec ? (((_VHeader *)vec) - 1)->size : 0;
 }

--- a/src/utils/stringutils.c
+++ b/src/utils/stringutils.c
@@ -20,6 +20,7 @@ char *strformat(const char *var, ...)
 	int new_len = vsnprintf(buffer, len + 1, var, list);
 	va_end(list);
 	assert(len == new_len);
+	(void)new_len;
 	return buffer;
 }
 

--- a/test/test_suite/distinct/distinct_invalid.c3
+++ b/test/test_suite/distinct/distinct_invalid.c3
@@ -1,10 +1,10 @@
 error Error
 {}
 
-typedef Error as distinct Foo1; // #error: You cannot create a distinct type from an error
+define Foo1 = distinct Error; // #error: You cannot create a distinct type from an error
 
-typedef error as distinct Foo2; // #error: You cannot create a distinct type from an error union
+define Foo2 = distinct error; // #error: You cannot create a distinct type from an error union
 
-typedef void as distinct Foo3; // #error: create a distinct type from 'void'
+define Foo3 = distinct void; // #error: create a distinct type from 'void'
 
-typedef typeid as distinct Foo4; // #error: create a distinct type from 'typeid'
+define Foo4 = distinct typeid; // #error: create a distinct type from 'typeid'

--- a/test/test_suite/distinct/distinct_struct.c3
+++ b/test/test_suite/distinct/distinct_struct.c3
@@ -5,7 +5,7 @@ struct Struct
     double y;
 }
 
-typedef Struct as distinct Foo;
+define Foo = distinct Struct;
 
 struct Struct2
 {

--- a/test/test_suite/distinct/distinct_struct_array.c3
+++ b/test/test_suite/distinct/distinct_struct_array.c3
@@ -1,6 +1,6 @@
 module test;
 
-typedef int as distinct Foo;
+define Foo = distinct int;
 
 struct Struct
 {
@@ -8,8 +8,8 @@ struct Struct
     int y;
 }
 
-typedef Struct as distinct Struct2;
-typedef Struct2[3] as distinct StructArr;
+define Struct2 = distinct Struct;
+define StructArr = distinct Struct2[3];
 
 func void test(int x)
 {

--- a/test/test_suite/distinct/distinct_union.c3
+++ b/test/test_suite/distinct/distinct_union.c3
@@ -6,7 +6,7 @@ union Union
     double y;
 }
 
-typedef Union as distinct Foo;
+define Foo = distinct Union;
 
 union Union2
 {
@@ -19,9 +19,9 @@ union Union2
 }
 Foo f = { .x = 1 };
 
-typedef Union2 as distinct Union3;
+define Union3 = distinct Union2;
 
-typedef Union3[3] as distinct UnionArr;
+define UnionArr = distinct Union3[3];
 
 func void test(int x)
 {

--- a/test/test_suite/distinct/test_errors.c3
+++ b/test/test_suite/distinct/test_errors.c3
@@ -1,6 +1,6 @@
 module test;
 
-typedef int as distinct Int2;
+define Int2 = distinct int;
 
 func void test()
 {

--- a/test/test_suite/distinct/test_ops_on_int.c3
+++ b/test/test_suite/distinct/test_ops_on_int.c3
@@ -1,6 +1,6 @@
 module test;
 
-typedef int as distinct Foo;
+define Foo = distinct int;
 
 func int test1()
 {

--- a/test/test_suite/distinct/test_ops_on_struct.c3
+++ b/test/test_suite/distinct/test_ops_on_struct.c3
@@ -6,7 +6,7 @@ struct Struct
     double y;
 }
 
-typedef Struct as distinct Foo;
+define Foo = distinct Struct;
 
 struct Struct2
 {

--- a/test/test_suite/expressions/assignability.c3
+++ b/test/test_suite/expressions/assignability.c3
@@ -1,4 +1,4 @@
-typedef int as Number;
+define Number = int;
 
 func void test1()
 {

--- a/test/test_suite/expressions/casts/cast_enum_to_various.c3
+++ b/test/test_suite/expressions/casts/cast_enum_to_various.c3
@@ -16,7 +16,7 @@ enum EnumB : char
     C, D
 }
 
-typedef func void(Enum) as Func;
+define Func = func void(Enum);
 
 func void test1(Enum e)
 {

--- a/test/test_suite/expressions/casts/cast_func_to_various.c3
+++ b/test/test_suite/expressions/casts/cast_func_to_various.c3
@@ -8,11 +8,9 @@ enum Enum : uptr
     A, B
 }
 
-typedef func void(int) as Func;
-
-typedef func bool(char*) as FuncOther;
-
-typedef func void(int) as FuncSame;
+define Func = func void(int);
+define FuncOther = func bool(char*);
+define FuncSame = func void(int);
 
 
 func void test1(Func arg)

--- a/test/test_suite/expressions/casts/cast_unknown.c3
+++ b/test/test_suite/expressions/casts/cast_unknown.c3
@@ -1,4 +1,4 @@
-typedef int as Number;
+define Number = int;
 
 func void test1()
 {

--- a/test/test_suite/expressions/casts/explicit_cast.c3
+++ b/test/test_suite/expressions/casts/explicit_cast.c3
@@ -1,5 +1,5 @@
-typedef char as Number8;
-typedef int as Number32;
+define Number8 = char;
+define Number32 = int;
 
 func void test1()
 {

--- a/test/test_suite/statements/default_args.c3
+++ b/test/test_suite/statements/default_args.c3
@@ -1,2 +1,2 @@
 
-typedef func void (int a = 10) as Foo;  // #error: Function types may not have default arguments.
+define Foo = func void(int a = 10);  // #error: Function types may not have default arguments.

--- a/test/test_suite/struct/member_expr.c3
+++ b/test/test_suite/struct/member_expr.c3
@@ -1,7 +1,7 @@
 
-typedef func int(int) as Func;
+define Func = func int(int);
 
-typedef func int(Foo*, int) as Func2;
+define Func2 = func int(Foo*, int);
 
 struct Foo
 {

--- a/test/test_suite/symbols/shadow_struct.c3
+++ b/test/test_suite/symbols/shadow_struct.c3
@@ -4,7 +4,7 @@ struct Foo
     int y;
 }
 
-typedef float as Foo; // #error: shadow a previous declaration
+define Foo = float; // #error: shadow a previous declaration
 
 enum Bar
 {
@@ -12,4 +12,4 @@ enum Bar
     TEST2
 }
 
-typedef float as Bar; // #error: shadow a previous declaration
+define Bar = float; // #error: shadow a previous declaration

--- a/test/test_suite/symbols/various.c3
+++ b/test/test_suite/symbols/various.c3
@@ -49,7 +49,7 @@ func void test7()
     int v = array[1];
 }
 
-typedef int as Number;
+define Number = int;
 
 func void test8()
 {

--- a/test/test_suite/types/enum_inference.c3
+++ b/test/test_suite/types/enum_inference.c3
@@ -13,7 +13,7 @@ enum Inf2 : char
     C = 129,
 }
 
-typedef Inf as BooInf;
+define BooInf = Inf;
 
 
 func void enumInferenceTest()

--- a/test/test_suite/types/enum_ok.c3
+++ b/test/test_suite/types/enum_ok.c3
@@ -4,7 +4,7 @@ enum EnumTest : long
     VALUE2
 }
 
-typedef long as Frob;
+define Frob = long;
 
 enum EnumTestAlias : Frob
 {

--- a/test/test_suite/types/recursive_typedef.c3
+++ b/test/test_suite/types/recursive_typedef.c3
@@ -1,9 +1,9 @@
-typedef Number1 as Number2; // #error: Recursive definition of 'Number2'
-typedef Number2 as Number1;
+define Number2 = Number1; // #error: Recursive definition of 'Number2'
+define Number1 = Number2;
 
-typedef Number as Number; // #error: Recursive definition of 'Number'
+define Number = Number; // #error: Recursive definition of 'Number'
 
 
-typedef Loop as Loop2; // #error: Recursive definition of 'Loop2'
-typedef Loop2 as Loop3;
-typedef Loop3 as Loop;
+define Loop2 = Loop; // #error: Recursive definition of 'Loop2'
+define Loop3 = Loop2;
+define Loop = Loop3;

--- a/test/test_suite/types/redefinition.c3
+++ b/test/test_suite/types/redefinition.c3
@@ -1,2 +1,2 @@
-typedef int as Number;
-typedef uint as Number;         // #error: 'Number' would shadow a previous declaration.
+define Number = int;
+define Number = uint;         // #error: 'Number' would shadow a previous declaration.

--- a/test/test_suite/types/typedefs.c3
+++ b/test/test_suite/types/typedefs.c3
@@ -1,4 +1,4 @@
-typedef int[4] as Arr;
+define Arr = int[4];
 
 Arr a = { 3, 4, 5, 6 };
 


### PR DESCRIPTION
This completely removes typedef, and for define the new syntax becomes:
```c
define Foo = OtherType;
define DFoo = distinct OtherType;
define FPtr = func void(int);
define IntBaz = some::module::Baz<int>;
define intFun = some::module::fun<int>;
```