### PR TITLE
Fix broken hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ func void main()
 It's possible to try out the current C3 compiler in the browser: https://ide.judge0.com/ – this is courtesy of the
 developer of Judge0. 
 
-Design work is still being done in the design draft here: https://c3lang.github.io/c3docs/. If you have any suggestions, send a mail to [christoffer@aegik.com](mailto:christoffer@aegik.com), [file an issue] (https://github.com/c3lang/c3c/issues) or discuss 
+Design work is still being done in the design draft here: https://c3lang.github.io/c3docs/. If you have any suggestions, send a mail to [christoffer@aegik.com](mailto:christoffer@aegik.com), [file an issue](https://github.com/c3lang/c3c/issues) or discuss 
 C3 on its dedicated Discord: https://discord.gg/qN76R87
 
 The compiler should compile on Linux and MacOS, but needs some development love to 


### PR DESCRIPTION
There was a space between the brackets, and as a result, the hyperlink didn't display properly.