### PR TITLE
Disable 'unused-but-set-variable' warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ add_executable(c3c
         src/compiler/llvm_codegen_c_abi_wasm.c)
 
 target_compile_options(c3c PRIVATE -Wall -Werror -Wno-unknown-pragmas -Wno-unused-result
-        -Wno-unused-function -Wno-unused-variable -Wno-unused-parameter)
+        -Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-parameter)
 
 
 target_include_directories(c3c PRIVATE


### PR DESCRIPTION
For compatibility with clang+llvm 13.0.0 (tested with clang version 13.0.0 ccd1e087f3702d5ccdfcce24ac7f7d2877921165).