### PR TITLE
Add support of builds for Ubuntu 18/20 through Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ dkms.conf
 /resources/lex.yy.c
 /resources/y.tab.c
 /resources/y.tab.h
+/bin/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.10)
 project(c3c)
 
 SET(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)

--- a/README.md
+++ b/README.md
@@ -130,9 +130,7 @@ work on Windows. Also, parts of the code is still rough and needs to be made sol
 - Are you a Windows dev? Please help make the compiler work on Windows!
 - Install instructions for other Linux and Unix variants are appreciated.
 
-#### Installing on Ubuntu
-
-(This installation has been tested on 20.10)
+#### Installing on Ubuntu 20.10
 
 1. Make sure you have a C compiler that handles C11 and a C++ compiler, such as GCC or Clang. Git also needs to be installed.
 2. Install CMake: `sudo apt install cmake`
@@ -147,6 +145,23 @@ work on Windows. Also, parts of the code is still rough and needs to be made sol
 You should now have a `c3c` executable.
 
 You can try it out by running some sample code: `./c3c compile ../resources/examples/hash.c3`
+
+#### Building via Docker
+
+You can build `c3c` using either an Ubuntu 18.04 or 20.04 container:
+
+```
+./build-with-docker.sh 18
+```
+
+Replace `18` with `20` to build through Ubuntu 20.04.
+
+For a release build specify:
+```
+./build-with-docker.sh 20 Release
+```
+
+A `c3c` executable will be found under `bin/`.
 
 #### Installing on OS X using Homebrew
 

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+## build-with-docker.sh
+## @author gdm85
+##
+## Script to build c3c for either Ubuntu 18 or Ubuntu 20.
+##
+#
+
+if [ $# -ne 1 -a $# -ne 2 ]; then
+	echo "Usage: build-with-docker.sh (18|20) [Debug|Release]" 1>&2
+	exit 1
+fi
+
+set -e
+
+if [ -z "$2" ]; then
+	CMAKE_BUILD_TYPE=Debug
+else
+	CMAKE_BUILD_TYPE="$2"
+fi
+
+if [ "$1" = 18 ]; then
+	UBUNTU_VERSION="18.04"
+	DEPS="llvm-10-dev liblld-10-dev libclang-10-dev"
+elif [ "$1" = 20 ]; then
+	UBUNTU_VERSION="20.04"
+	DEPS="llvm-11-dev liblld-11-dev clang-11 libllvm11 llvm-11-runtime"
+else
+	echo "ERROR: expected 18 or 20 as Ubuntu version argument" 1>&2
+	exit 2
+fi
+
+cd docker && docker build -t c3c-builder --build-arg UID=$(id -u) --build-arg GID=$(id -g) \
+	--build-arg DEPS="$DEPS" --build-arg UBUNTU_VERSION="$UBUNTU_VERSION" .
+cd ..
+
+rm -rf build bin
+mkdir -p build bin
+
+exec docker run -ti --rm -v "$PWD":/home/c3c/source -w /home/c3c/source c3c-builder bash -c \
+	"cd build && cmake -DLLVM_DIR=/usr/lib/llvm-11/cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE .. && cmake --build . && mv c3c ../bin/"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+
+ARG UBUNTU_VERSION
+FROM ubuntu:$UBUNTU_VERSION
+
+ARG DEPS
+
+RUN export DEBIAN_FRONTEND=noninteractive && export TERM=xterm && apt-get update && apt-get install -y build-essential cmake zlib1g zlib1g-dev  \
+        $DEPS && \
+	rm -rf /var/lib/apt/lists/*
+
+ARG GID=1000
+ARG UID=1000
+
+RUN groupadd --gid=$GID c3c && useradd --gid=$GID --uid=$GID --create-home --shell /bin/bash c3c
+
+USER c3c

--- a/src/compiler/llvm_codegen_module.c
+++ b/src/compiler/llvm_codegen_module.c
@@ -104,11 +104,14 @@ void gencontext_init_file_emit(GenContext *c, Context *ast)
 		                                                              emission_kind,
 		                                                              dwo_id,
 		                                                              split_debug_inlining,
-		                                                              emit_debug_info_for_profiling,
+		                                                              emit_debug_info_for_profiling
+#if LLVM_VERSION_MAJOR >= 11
+		                                                              ,
 		                                                              sysroot,
 		                                                              strlen(sysroot),
 		                                                              sdk,
 		                                                              strlen(sdk)
+#endif
 		                                                      );
 	}
 }


### PR DESCRIPTION
I was trying to build `c3c` on Ubuntu 18 (LTS) and found a few issues; in order to help others build it with ease I thought it would be a good idea to dockerize the build.

This PR allows to build `c3c` for either Ubuntu 18 or 20 through a Docker container, making the process very easy.

Unfortunately `c3c` binaries are not static so one still needs some library on host system, but the whole builds becomes more reproducible.