### PR TITLE
CMakeLists.txt refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,22 @@
 cmake_minimum_required(VERSION 3.10)
 project(c3c)
+include(FeatureSummary)
 
-SET(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
-SET(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
+set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
+set(CMAKE_FIND_PACKAGE_SORT_DIRECTION DEC)
+set(C3_LLVM_VERSION "auto" CACHE STRING "Use LLVM version [default: auto]")
 
 #set(CMAKE_BUILD_TYPE Release)
 #set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
-find_package(LLVM REQUIRED CONFIG)
-
+if(NOT C3_LLVM_VERSION STREQUAL "auto")
+    if(${C3_LLVM_VERSION} VERSION_LESS 12 OR ${C3_LLVM_VERSION} VERSION_GREATER 14)
+        message(FATAL_ERROR "LLVM ${C3_LLVM_VERSION} is not supported!")
+    endif()
+    find_package(LLVM ${C3_LLVM_VERSION} REQUIRED CONFIG)
+else()
+   find_package(LLVM REQUIRED CONFIG)
+endif()
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
@@ -22,31 +30,31 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(LLVM_LINK_COMPONENTS
         AllTargetsAsmParsers
+        AllTargetsCodeGens
         AllTargetsDescs
         AllTargetsDisassemblers
         AllTargetsInfos
-        AllTargetsCodeGens
         Analysis
+        AsmPrinter
         BitReader
         Core
+        DebugInfoPDB
         InstCombine
+        IrReader
+        LibDriver
+        Linker
+        LTO
         MC
         MCDisassembler
+        native
+        nativecodegen
         Object
+        Option
         ScalarOpts
         Support
         Target
         TransformUtils
-        native
-        nativecodegen
-        AsmPrinter
-        Linker
-        LTO
         WindowsManifest
-        DebugInfoPDB
-        LibDriver
-        Option
-        IrReader
         )
 
 
@@ -60,14 +68,17 @@ if(UNIX)
 #    find_library(TB_LIB NAMES tinybackend.a PATHS ${CMAKE_SOURCE_DIR}/resources/tblib)
     find_library(LLD_COFF NAMES lldCOFF.a liblldCOFF.a PATHS ${LLVM_LIBRARY_DIRS})
     find_library(LLD_COMMON NAMES lldCommon.a liblldCommon.a PATHS ${LLVM_LIBRARY_DIRS})
-    find_library(LLD_CORE NAMES lldCore.a liblldCore.a PATHS ${LLVM_LIBRARY_DIRS})
-    find_library(LLD_WASM NAMES lldWasm.a liblldWasm.a PATHS ${LLVM_LIBRARY_DIRS})
-    find_library(LLD_MINGW NAMES lldMinGW.a liblldMinGW.a PATHS ${LLVM_LIBRARY_DIRS})
     find_library(LLD_ELF NAMES lldELF.a liblldELF.a PATHS ${LLVM_LIBRARY_DIRS})
-    find_library(LLD_DRIVER NAMES lldDriver.a liblldDriver.a PATHS ${LLVM_LIBRARY_DIRS})
-    find_library(LLD_READER_WRITER NAMES lldReaderWriter.a liblldReaderWriter.a PATHS ${LLVM_LIBRARY_DIRS})
     find_library(LLD_MACHO NAMES lldMachO.a liblldMachO.a PATHS ${LLVM_LIBRARY_DIRS})
-    find_library(LLD_YAML NAMES lldYAML.a liblldYAML.a PATHS ${LLVM_LIBRARY_DIRS})
+    find_library(LLD_MINGW NAMES lldMinGW.a liblldMinGW.a PATHS ${LLVM_LIBRARY_DIRS})
+    find_library(LLD_WASM NAMES lldWasm.a liblldWasm.a PATHS ${LLVM_LIBRARY_DIRS})
+
+    if(${LLVM_PACKAGE_VERSION} VERSION_LESS 14)
+        find_library(LLD_CORE NAMES lldCore.a liblldCore.a PATHS ${LLVM_LIBRARY_DIRS})
+        find_library(LLD_DRIVER NAMES lldDriver.a liblldDriver.a PATHS ${LLVM_LIBRARY_DIRS})
+        find_library(LLD_READER_WRITER NAMES lldReaderWriter.a liblldReaderWriter.a PATHS ${LLVM_LIBRARY_DIRS})
+        find_library(LLD_YAML NAMES lldYAML.a liblldYAML.a PATHS ${LLVM_LIBRARY_DIRS})
+    endif()
 
     set(lld_libs
         ${LLD_COFF}
@@ -84,77 +95,79 @@ if(UNIX)
     message(STATUS "linking to llvm libs ${llvm_libs} ${lld_libs}")
 endif()
 
+message(STATUS "Found LLD ${lld_libs}")
+
 add_library(c3c_wrappers STATIC wrapper/src/wrapper.cpp)
 
 add_executable(c3c
-        src/main.c
+        src/build/builder.c
         src/build/build_options.c
         src/build/project_creation.c
-        src/utils/errors.c
-        src/utils/file_utils.c
-        src/compiler/lexer.c
-        src/compiler/tokens.c
-        src/compiler/symtab.c
-        src/compiler/parser.c
-        src/compiler_tests/tests.c
-        src/compiler_tests/benchmark.c
-        src/utils/malloc.c
-        src/compiler/compiler.c
-        src/compiler/semantic_analyser.c
-        src/compiler/source_file.c
-        src/compiler/diagnostics.c
         src/compiler/ast.c
         src/compiler/bigint.c
-        src/compiler/context.c
-        src/compiler/sema_expr.c
-        src/compiler/enums.h
-        src/compiler/sema_casts.c
-        src/compiler/target.c
+        src/compiler/c_abi_internal.h
+        src/compiler/codegen_general.c
+        src/compiler/compiler.c
         src/compiler/compiler.h
-        src/compiler/types.c
-        src/compiler/module.c
-        src/compiler/tb_codegen.c
-        src/compiler/llvm_codegen.c
-        src/utils/stringutils.c
-        src/utils/find_msvc.c
-        src/compiler/dwarf.h
+        src/compiler/context.c
         src/compiler/copying.c
-        src/compiler/llvm_codegen_stmt.c
-        src/compiler/llvm_codegen_expr.c
-        src/compiler/llvm_codegen_debug_info.c
-        src/compiler/llvm_codegen_module.c
-        src/compiler/llvm_codegen_type.c
-        src/compiler/llvm_codegen_function.c
+        src/compiler/diagnostics.c
+        src/compiler/dwarf.h
+        src/compiler/enums.h
+        src/compiler/float.c
+        src/compiler/headers.c
+        src/compiler/lexer.c
+        src/compiler/linker.c
+        src/compiler/llvm_codegen.c
+        src/compiler/llvm_codegen_c_abi_aarch64.c
         src/compiler/llvm_codegen_c_abi.c
-        src/build/builder.c
-        src/utils/toml.c src/build/project.c
-        src/compiler/sema_name_resolution.c
-        src/target_info/target_info.c
+        src/compiler/llvm_codegen_c_abi_riscv.c
+        src/compiler/llvm_codegen_c_abi_wasm.c
+        src/compiler/llvm_codegen_c_abi_win64.c
+        src/compiler/llvm_codegen_c_abi_x64.c
+        src/compiler/llvm_codegen_c_abi_x86.c
+        src/compiler/llvm_codegen_debug_info.c
+        src/compiler/llvm_codegen_expr.c
+        src/compiler/llvm_codegen_function.c
+        src/compiler/llvm_codegen_module.c
+        src/compiler/llvm_codegen_stmt.c
+        src/compiler/llvm_codegen_type.c
+        src/compiler/module.c
+        src/compiler/number.c
         src/compiler/parse_expr.c
+        src/compiler/parse_global.c
+        src/compiler/parser.c
         src/compiler/parser_internal.h
         src/compiler/parse_stmt.c
-        src/compiler/parse_global.c
-        src/compiler/sema_passes.c
-        src/compiler/sema_internal.h
+        src/compiler/sema_casts.c
         src/compiler/sema_decls.c
-        src/compiler/sema_types.c
+        src/compiler/sema_expr.c
+        src/compiler/sema_internal.h
+        src/compiler/sema_name_resolution.c
+        src/compiler/semantic_analyser.c
+        src/compiler/sema_passes.c
         src/compiler/sema_stmts.c
-        src/compiler/number.c
-        src/compiler/float.c
-        src/compiler/linker.c
+        src/compiler/sema_types.c
+        src/compiler/source_file.c
+        src/compiler/symtab.c
+        src/compiler/target.c
+        src/compiler/tb_codegen.c
+        src/compiler_tests/benchmark.c
+        src/compiler_tests/tests.c
+        src/compiler/tokens.c
+        src/compiler/types.c
+        src/main.c
+        src/target_info/target_info.c
+        src/utils/errors.c
+        src/utils/file_utils.c
+        src/utils/find_msvc.c
+        src/utils/malloc.c
+        src/utils/stringutils.c
+        src/utils/taskqueue.c
+        src/utils/toml.c src/build/project.c
         src/utils/vmem.c
         src/utils/vmem.h
-        src/utils/whereami.c
-        src/utils/taskqueue.c
-        src/compiler/llvm_codegen_c_abi_x86.c
-        src/compiler/c_abi_internal.h
-        src/compiler/llvm_codegen_c_abi_x64.c
-        src/compiler/llvm_codegen_c_abi_win64.c
-        src/compiler/llvm_codegen_c_abi_aarch64.c
-        src/compiler/headers.c
-        src/compiler/codegen_general.c
-        src/compiler/llvm_codegen_c_abi_riscv.c
-        src/compiler/llvm_codegen_c_abi_wasm.c)
+        src/utils/whereami.c)
 
 if(NOT CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     message(STATUS "using gcc/clang warning switches")
@@ -172,7 +185,6 @@ target_include_directories(c3c_wrappers PRIVATE
         "${CMAKE_SOURCE_DIR}/wrapper/src/")
 
 
-message(STATUS "Found LLD ${lld_libs}")
 
 if(UNIX)
     target_link_libraries(c3c_wrappers ${llvm_libs} ${lld_libs})
@@ -197,3 +209,4 @@ endif()
 
 install(TARGETS c3c DESTINATION bin)
 
+feature_summary(WHAT ALL)


### PR DESCRIPTION
Unfortunately for LLVM 14.0 (installed from https://apt.llvm.org) I got this error: 

```
C3/c3c/src/compiler/llvm_codegen_stmt.c:1209:2: error: 'LLVMBuildCall' is deprecated: Use LLVMBuildCall2 instead to support opaque pointers [-Werror,-Wdeprecated-declarations]
        LLVMBuildCall(c->builder, assert_func, args, func_index > -1 ? 4 : 3, "");
        ^
/usr/lib/llvm-14/include/llvm-c/Core.h:3990:1: note: 'LLVMBuildCall' has been explicitly marked deprecated here
LLVM_ATTRIBUTE_C_DEPRECATED(
^
/usr/lib/llvm-14/include/llvm-c/Deprecated.h:26:23: note: expanded from macro 'LLVM_ATTRIBUTE_C_DEPRECATED'
  decl __attribute__((deprecated(message)))```