### PR TITLE
Add `-o` option to allow setting output binary name

### DIFF
--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -79,6 +79,7 @@ static void usage(void)
 	OUTPUT("  -V --version          - Print version information.");
 	OUTPUT("  -E                    - Lex only.");
 	OUTPUT("  -P                    - Only parse and output the AST as S-expressions.");
+	OUTPUT("  -o                    - Set the output binary file name.");
 	OUTPUT("  -O0                   - Optimizations off.");
 	OUTPUT("  -O1                   - Simple optimizations only.");
 	OUTPUT("  -O2                   - Default optimization level.");
@@ -348,6 +349,10 @@ static void parse_option(BuildOptions *options)
 		case 'z':
 			if (at_end()) error_exit("error: -z needs a value");
 			options->linker_args[options->linker_arg_count++] = next_arg();
+			return;
+		case 'o':
+			if (at_end()) error_exit("error: -o needs a value");
+			options->output_name=next_arg();
 			return;
 		case 'O':
 			if (options->optimization_setting_override != OPT_SETTING_NOT_SET)

--- a/src/build/build_options.h
+++ b/src/build/build_options.h
@@ -183,6 +183,7 @@ typedef struct BuildOptions_
 	int linker_arg_count;
 	int build_threads;
 	const char** files;
+	const char* output_name;
 	const char* project_name;
 	const char* target_select;
 	const char* path;

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -532,7 +532,8 @@ static const char **target_expand_source_names(const char** dirs, const char *su
 
 void compile_target(BuildOptions *options)
 {
-	init_default_build_target(&active_target, options, DEFAULT_EXE);
+	if(options->output_name == NULL) options->output_name = DEFAULT_EXE;
+	init_default_build_target(&active_target, options, options->output_name);
 	compile();
 }
 


### PR DESCRIPTION
Add a simple `-o` flag to the cli to allow setting the name of the binary at runtime