### PR TITLE
Print file's full path and col number in compiler's error message

### DIFF
--- a/src/compiler/diagnostics.c
+++ b/src/compiler/diagnostics.c
@@ -114,7 +114,7 @@ static void print_error(SourceLocation *location, const char *message, PrintType
 	switch (print_type)
 	{
 		case PRINT_TYPE_ERROR:
-			eprintf("(%s:%d) Error: %s\n\n", file->name, location->row, message);
+			eprintf("(%s:%d:%d) Error: %s\n\n", file->full_path, location->row, location->col, message);
 			break;
 		case PRINT_TYPE_PREV:
 			eprintf("(%s:%d) %s\n\n", file->name, location->row, message);


### PR DESCRIPTION
It will be handy for IDE to parse the compiler's error message, then figure out the path of the file, row and column number, then jump to the location directly.