### PR TITLE
Add support for podman

### DIFF
--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -13,6 +13,15 @@ fi
 
 set -e
 
+DOCKER=docker
+DOCKER_RUN=""
+IMAGE="c3c-builder"
+if type podman 2>/dev/null >/dev/null; then
+	DOCKER=podman
+	DOCKER_RUN="--userns=keep-id"
+	IMAGE="localhost/$IMAGE"
+fi
+
 if [ -z "$2" ]; then
 	CMAKE_BUILD_TYPE=Debug
 else
@@ -33,8 +42,9 @@ else
 	echo "ERROR: expected 20, 21 or 22 as Ubuntu version argument" 1>&2
 	exit 2
 fi
+IMAGE="$IMAGE:$TAG"
 
-cd docker && docker build -t c3c-builder:$TAG --build-arg UID=$(id -u) --build-arg GID=$(id -g) \
+cd docker && $DOCKER build -t $IMAGE --build-arg UID=$(id -u) --build-arg GID=$(id -g) \
 	--build-arg DEPS="llvm-$LLVM_VERSION-dev liblld-$LLVM_VERSION-dev clang-$LLVM_VERSION libllvm$LLVM_VERSION llvm-$LLVM_VERSION-runtime" \
 	--build-arg UBUNTU_VERSION="$UBUNTU_VERSION" .
 cd ..
@@ -42,5 +52,5 @@ cd ..
 rm -rf build bin
 mkdir -p build bin
 
-exec docker run -ti --rm -v "$PWD":/home/c3c/source -w /home/c3c/source c3c-builder:$TAG bash -c \
+exec $DOCKER run -ti --rm --tmpfs=/tmp $DOCKER_RUN -v "$PWD":/home/c3c/source -w /home/c3c/source $IMAGE bash -c \
 	"cd build && cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE -DC3_LLVM_VERSION=$LLVM_VERSION .. && cmake --build . && mv c3c lib ../bin/"


### PR DESCRIPTION
I have been using [podman](https://podman.io/) for a few years now, I like that you can run it in rootless mode.

Nonetheless, it is close to 100% compatible with Docker so little changes are necessary (that `--userns=keep-id` for example, the `localhost/` prefix is optional).

This PR switches to `podman` when using `build-with-docker.sh` (I am aware of the ugliness of that `docker` in the script name) if it is locally available.

`docker` is going to be around with us for many years to come so this offers a graceful optional "upgrade" when `podman` is locally available.

This PR should merge cleanly after #417.