### PR TITLE
Fix resource leak in check_file function

### DIFF
--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -139,6 +139,7 @@ static const char* check_file(const char *file_path)
 	{
 		error_exit("Could not open file \"%s\".\n", file_path);
 	}
+	fclose(file);
 	return file_path;
 }
 


### PR DESCRIPTION
Discovered by cppcheck.
I propose use [some](https://github.com/marketplace?type=actions&query=cppcheck+) C/C++ checkers in CI.