### PR TITLE
Fixes crash after using List.free

### DIFF
--- a/lib/std/list.c3
+++ b/lib/std/list.c3
@@ -113,6 +113,7 @@ fn void List.free(List *list)
     mem::free(list.entries);
     list.capacity = 0;
     list.size = 0;
+    list.entries = (Type*)0;
 }
 
 fn void List.swap(List *list, usize i, usize j)


### PR DESCRIPTION
entries needs to be reset to 0 otherwise the previous pointer will crash when realloc is called again.

If this is intended to prevent use after free that's a neat trick. It's not exactly clear from the docs if lifetime memory management is a feature in the language since it's built on top of C. Is `.free` is called like a destructor if a struct has it?