### PR TITLE
Add enum_names builtin?

### DIFF
--- a/lib/std/core/builtin.c3
+++ b/lib/std/core/builtin.c3
@@ -113,3 +113,12 @@ macro enum_by_name($Type, char[] enum_name) @builtin
 	}
 	return SearchResult.MISSING!;
 }
+
+/**
+ * @require $Type.kind == TypeKind.ENUM `Only enums may be used`
+ **/
+macro enum_names($Type, char[] enum_name) @builtin
+{
+	typeid x = $Type.typeid;
+	return x.names;
+}


### PR DESCRIPTION
Note: currently enum_names is bugged, using enum_names on more than one enum will fail catastrophically at runtime.

```c
enum TestEnum {
    BAR,
    BAZ
}

enum TestEnum2 {
   FOO,
   BARR
}

extern fn void printf(char*, ...);

macro enum_names($Type) @builtin
{
    typeid x = $Type.typeid;
    return x.names;
}

fn int main(char[][] argv) {
   char[][] names = enum_names(TestEnum);
   char[][] other_names = enum_names(TestEnum2);
   
   for (usize i = 0; i < names.len; i++) {
     printf("%i:%s\n", i, names[i].ptr);
   }
   //should print:
   //0:BAR
   //1:BAZ
   //will fail here
   for (usize i = 0; i < other_names.len; i++) {
      printf("%i:%s\n", i, other_names[i].ptr);
   }
   //should print:
   //0:FOO
   //1:BARR
   return 0;
}
```

The error may have to do with enums from another module*.