### PR TITLE
Fix paths in msvc_build_libraries.py

### DIFF
--- a/msvc_build_libraries.py
+++ b/msvc_build_libraries.py
@@ -213,8 +213,8 @@ with tempfile.TemporaryDirectory() as d:
 
 ### versions
 
-ucrt = list((OUTPUT / "Program Files/Windows Kits/").glob("*/Lib/*/ucrt"))[0]
-um = list((OUTPUT / "Program Files/Windows Kits/").glob("*/Lib/*/um"))[0]
+ucrt = list((OUTPUT / "Windows Kits/").glob("*/Lib/*/ucrt"))[0]
+um = list((OUTPUT / "Windows Kits/").glob("*/Lib/*/um"))[0]
 lib = list((OUTPUT / "VC/Tools/MSVC/").glob("*/lib"))[0]
 
 SDK_OUTPUT.mkdir(exist_ok=True)


### PR DESCRIPTION
On Windows, the script only works with this fix to the paths. Maybe "msiextract" unpacks it differently on Mac/Linux?