### PR TITLE
Add rotate_left and rotate_right macros

### DIFF
--- a/lib/std/bits.c3
+++ b/lib/std/bits.c3
@@ -59,3 +59,20 @@ macro fshr(hi, lo, shift) @builtin
 {
 	return $$fshr(hi, lo, ($typeof(hi))shift);
 }
+
+/**
+ * @require types::is_intlike($typeof(i)) && types::is_intlike($typeof(amount)) `The input must be an integer or integer vector`
+ **/
+macro rotate_left(i, amount) @builtin
+{
+	return $$fshl(i, i, ($typeof(i))amount);
+}
+
+/**
+ * @require types::is_intlike($typeof(i)) && types::is_intlike($typeof(amount)) `The input must be an integer or integer vector`
+ **/
+macro rotate_right(i, amount) @builtin
+{
+	return $$fshr(i, i, ($typeof(i))amount);
+}
+


### PR DESCRIPTION
Thanks for $$f(shl|shr) built-ins!
Test:
```rust
import std::io;
import std::bits;

fn void main()
{
    ushort i = 1;
    ushort irol = rotate_left(i, 1);
    ushort irol2 = rotate_left(i, -1);
    ushort iror = rotate_right(i, 1);
    ushort iror2 = rotate_right(i, -1);

    io::printf("i = %b\n", i);
    io::printf("irol = %b\n", irol);
    io::printf("irol2 = %b\n", irol2);
    io::printf("iror = %b\n", iror);
    io::printf("iror2 = %b\n", iror2);
}
```

> i = 1
irol = 10
irol2 = 1000000000000000
iror = 1000000000000000
iror2 = 10