### PR TITLE
Add single function declaration

### DIFF
--- a/src/compiler/parse_global.c
+++ b/src/compiler/parse_global.c
@@ -2104,9 +2104,18 @@ static inline Decl *parse_func_definition(ParseContext *c, Visibility visibility
 		return func;
 	}
 
-	TRY_EXPECT_OR_RET(TOKEN_LBRACE, "Expected the beginning of a block with '{'", poisoned_decl);
-
-	ASSIGN_ASTID_OR_RET(func->func_decl.body, parse_compound_stmt(c), poisoned_decl);
+	if (tok_is(c, TOKEN_EQ))
+	{
+		ASSIGN_ASTID_OR_RET(func->func_decl.body, parse_short_stmt(c, func->func_decl.signature.rtype), poisoned_decl);
+	}
+	else if (tok_is(c, TOKEN_LBRACE))
+	{
+		ASSIGN_ASTID_OR_RET(func->func_decl.body, parse_compound_stmt(c), poisoned_decl);
+	}
+	else
+	{
+		SEMA_ERROR_HERE("Expected the beginning of a block or a short statement.");
+	}
 
 	DEBUG_LOG("Finished parsing function %s", func->name);
 	return func;

--- a/src/compiler/parse_stmt.c
+++ b/src/compiler/parse_stmt.c
@@ -1361,8 +1361,6 @@ Ast* parse_compound_stmt(ParseContext *c)
 Ast* parse_short_stmt(ParseContext *c, TypeInfoId return_type)
 {
 	CONSUME_OR_RET(TOKEN_EQ, poisoned_ast);
-	// directly using AST_RETURN_STMT doesn't work
-	// embedding it in compound is fine
 	Ast *ast = ast_new_curr(c, AST_COMPOUND_STMT);
 	AstId *next = &ast->compound_stmt.first_stmt;
 
@@ -1375,9 +1373,6 @@ Ast* parse_short_stmt(ParseContext *c, TypeInfoId return_type)
 	}
 	else
 	{
-		// you can actually do
-		// fn void func() = 6 * 5;
-		// it will compile and works, even if it's not really useful
 		ASSIGN_AST_OR_RET(Ast *stmt, parse_stmt(c), poisoned_ast);
 		ast_append(&next, stmt);
 		return ast;

--- a/src/compiler/parser_internal.h
+++ b/src/compiler/parser_internal.h
@@ -35,6 +35,7 @@ void recover_top_level(ParseContext *c);
 Expr *parse_cond(ParseContext *c);
 Expr *parse_assert_expr(ParseContext *c);
 Ast* parse_compound_stmt(ParseContext *c);
+Ast* parse_short_stmt(ParseContext *c, TypeInfoId return_type);
 Ast *parse_jump_stmt_no_eos(ParseContext *c);
 bool parse_attribute(ParseContext *c, Attr **attribute_ref);
 bool parse_attributes(ParseContext *c, Attr ***attributes_ref);


### PR DESCRIPTION
Implementation of proposal 2 : #425 

Since the logic is very similar between proposals this feature can be easily modified accordingly to the chosen proposal.

I had to use COMPOUND_STMT since we can't directly use a RETURN_STMT.
Actually, `fn void myfunc() = 8 * 6 + 1;` will compile, works and return nothing.