### PR TITLE
Add override flag to groupadd to support docker build on mac

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && export TERM=xterm && apt-get update
 ARG GID=1000
 ARG UID=1000
 
-RUN groupadd --gid=$GID c3c && useradd --gid=$GID --uid=$GID --create-home --shell /bin/bash c3c
+RUN groupadd -o --gid=$GID c3c && useradd --gid=$GID --uid=$GID --create-home --shell /bin/bash c3c
 
 USER c3c


### PR DESCRIPTION
MacOS docker build fails on the groupadd command:
```
RUN groupadd --gid=20 c3c && useradd --gid=20 --uid=20 --create-home --shell /bin/bash c3c:
#6 0.209 groupadd: GID '20' already exists
```
It can be fixed by adding the -o flag