### PR TITLE
Update docker script and dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && export TERM=xterm && apt-get update
 ARG GID=1000
 ARG UID=1000
 
-RUN groupadd --gid=$GID c3c && useradd --gid=$GID --uid=$GID --create-home --shell /bin/bash c3c
+RUN groupadd -o --gid=$GID c3c && useradd --gid=$GID --uid=$GID --create-home --shell /bin/bash c3c
 
 USER c3c


### PR DESCRIPTION
Using Ubuntu 23 throws an error `groupadd: GID '1000' already exists` when trying to build. Ubuntu 22 works fine.
There should be no difference between building C3 on Ubuntu 22 vs 23.

To avoid issues raised it's best to move to single Ubuntu version that builds the compiler.