### PR TITLE
Update for 0.5

### DIFF
--- a/resources/grammar/Makefile
+++ b/resources/grammar/Makefile
@@ -1,0 +1,7 @@
+c3yacc: grammar.y c3.l
+	bison -d grammar.y; cc -c grammar.tab.c
+	flex c3.l; gcc -c lex.yy.c
+	cc -o c3yacc lex.yy.o grammar.tab.o
+
+clean:
+	rm -f c3yacc grammar.output *.o grammar.tab.* lex.yy.c

--- a/resources/grammar/c3.l
+++ b/resources/grammar/c3.l
@@ -8,10 +8,11 @@ UA          [A-Z_0-9]
 DC          [a-z]
 UC          [A-Z]
 E			[Ee][+-]?{D}+
+P           [Pp][+-]?{D}+
 
 %{
 #include <stdio.h>
-#include "y.tab.h"
+#include "grammar.tab.h"
 void count(void);
 void comment(void);
 
@@ -35,9 +36,11 @@ void comment(void);
 "for"			{ count(); return(FOR); }
 "foreach"		{ count(); return(FOREACH); }
 "foreach_r"		{ count(); return(FOREACH_R); }
-"fn"            { count(); return(FUNC); }
+"fn"            { count(); return(FN); }
 "if"			{ count(); return(IF); }
 "int"			{ count(); return(INT); }
+"inline"		{ count(); return(INLINE); }
+"ichar"         { count(); return(ICHAR); }
 "uint"			{ count(); return(UINT); }
 "long"			{ count(); return(LONG); }
 "nextcase"      { count(); return(NEXTCASE); }
@@ -45,7 +48,7 @@ void comment(void);
 "return"		{ count(); return(RETURN); }
 "short"			{ count(); return(SHORT); }
 "ushort"		{ count(); return(USHORT); }
-"fault"		    { count(); return(ERROR); }
+"fault"		    { count(); return(FAULT); }
 "module"        { count(); return(MODULE); }
 "struct"		{ count(); return(STRUCT); }
 "switch"		{ count(); return(SWITCH); }
@@ -54,17 +57,17 @@ void comment(void);
 "void"			{ count(); return(VOID); }
 "while"			{ count(); return(WHILE); }
 "null"          { count(); return(NUL); }
-"$for"          { count(); return(CTFOR); }
-"$foreach"      { count(); return(CTFOREACH); }
-"$case"         { count(); return(CTCASE); }
-"$switch"       { count(); return(CTSWITCH); }
-"$default"      { count(); return(CTDEFAULT); }
-"$if"           { count(); return(CTIF); }
-"$else"         { count(); return(CTELSE); }
-"$endif"        { count(); return(CTENDIF); }
-"$endswitch"    { count(); return(CTENDIF); }
-"$endforeach"   { count(); return(CTENDFOREACH); }
-"$endfor"       { count(); return(CTENDFOR); }
+"$for"          { count(); return(CT_FOR); }
+"$foreach"      { count(); return(CT_FOREACH); }
+"$case"         { count(); return(CT_CASE); }
+"$switch"       { count(); return(CT_SWITCH); }
+"$default"      { count(); return(CT_DEFAULT); }
+"$if"           { count(); return(CT_IF); }
+"$else"         { count(); return(CT_ELSE); }
+"$endif"        { count(); return(CT_ENDIF); }
+"$endswitch"    { count(); return(CT_ENDSWITCH); }
+"$endforeach"   { count(); return(CT_ENDFOREACH); }
+"$endfor"       { count(); return(CT_ENDFOR); }
 
 @[_]*[A-Z]{UA}*   { count(); return(AT_CONST_IDENT); }
 #[_]*[A-Z]{UA}*   { count(); return(HASH_CONST_IDENT); }
@@ -78,21 +81,22 @@ $[_]*[A-Z]{UA}*[a-z]{AN}* { count(); return(CT_TYPE_IDENT); }
 #[_]*[a-z]{AN}*    { count(); return(HASH_IDENT); }
 $[_]*[a-z]{AN}*    { count(); return(CT_IDENT); }
 [_]*[a-z]{AN}*    { count(); return(IDENT); }
-0[xX]{H}+	{ count(); return(CONSTANT); }
-0{D}+?		{ count(); return(CONSTANT); }
-{D}+		{ count(); return(CONSTANT); }
-L?'(\\.|[^\\'])+'	{ count(); return(CONSTANT); }
+0[xX]{H}+	{ count(); return(INTEGER); }
+0[oO]{D}+?		{ count(); return(INTEGER); }
+{D}+		{ count(); return(INTEGER); }
 
-{D}+{E}		{ count(); return(CONSTANT); }
-{D}*"."{D}+({E})?	{ count(); return(CONSTANT); }
-{D}+"."{D}*({E})?	{ count(); return(CONSTANT); }
+{D}+{E}		{ count(); return(REAL); }
+0[xX]{H}+{P}	{ count(); return(REAL); }
+{D}+"."{D}*({E})?	{ count(); return(REAL); }
+0[xX]{H}+"."{H}*({P})? { count(); return(REAL); }
 
-L?\"(\\.|[^\\"])*\"	{ count(); return(STRING_LITERAL); }
+\"(\\.|[^\\"])*\"	{ count(); return(STRING_LITERAL); }
+\'(\\.|[^\\'])*\'	{ count(); return(CHAR_LITERAL); }
 
 "..."			{ count(); return(ELLIPSIS); }
 ".."			{ count(); return(DOTDOT); }
-">>="			{ count(); return(RIGHT_ASSIGN); }
-"<<="			{ count(); return(LEFT_ASSIGN); }
+">>="			{ count(); return(SHR_ASSIGN); }
+"<<="			{ count(); return(SHL_ASSIGN); }
 "+="			{ count(); return(ADD_ASSIGN); }
 "-="			{ count(); return(SUB_ASSIGN); }
 "*="			{ count(); return(MUL_ASSIGN); }
@@ -101,8 +105,8 @@ L?\"(\\.|[^\\"])*\"	{ count(); return(STRING_LITERAL); }
 "&="			{ count(); return(AND_ASSIGN); }
 "^="			{ count(); return(XOR_ASSIGN); }
 "|="			{ count(); return(OR_ASSIGN); }
-">>"			{ count(); return(RIGHT_OP); }
-"<<"			{ count(); return(LEFT_OP); }
+">>"			{ count(); return(SHR_OP); }
+"<<"			{ count(); return(SHL_OP); }
 "++"			{ count(); return(INC_OP); }
 "--"			{ count(); return(DEC_OP); }
 "&&"			{ count(); return(AND_OP); }
@@ -120,7 +124,6 @@ L?\"(\\.|[^\\"])*\"	{ count(); return(STRING_LITERAL); }
 ":"			{ count(); return(':'); }
 "="			{ count(); return('='); }
 "("			{ count(); return('('); }
-"@"         { count(); return(AT);  }
 ")"			{ count(); return(')'); }
 ("[")		{ count(); return('['); }
 ("]")		{ count(); return(']'); }

--- a/src/compiler/abi/c_abi_aarch64.c
+++ b/src/compiler/abi/c_abi_aarch64.c
@@ -6,7 +6,11 @@
 
 INLINE bool is_aarch64_illegal_vector(Type *type)
 {
-	if (type->type_kind != TYPE_VECTOR) return type->type_kind == TYPE_SCALED_VECTOR;
+	if (type->type_kind != TYPE_VECTOR)
+	{
+		// Return true if scaled vector
+		return false;
+	}
 	ArraySize len = type->array.len;
 	if (!is_power_of_two(len)) return true;
 	switch (type_size(type))
@@ -22,7 +26,7 @@ INLINE bool is_aarch64_illegal_vector(Type *type)
 
 ABIArgInfo *aarch64_coerce_illegal_vector(Type *type)
 {
-	if (type->type_kind == TYPE_SCALED_VECTOR)
+	if (false /*type->type_kind == TYPE_SCALED_VECTOR*/)
 	{
 		/*
 		Type *base_type = type->array.base;

--- a/src/compiler/abi/c_abi_x64.c
+++ b/src/compiler/abi/c_abi_x64.c
@@ -389,7 +389,6 @@ static void x64_classify(Type *type, ByteSize offset_base, X64Class *lo_class, X
 		case TYPE_FAULTTYPE:
 		case TYPE_BITSTRUCT:
 		case TYPE_OPTIONAL:
-		case TYPE_OPTIONAL_ANY:
 		case CT_TYPES:
 			UNREACHABLE
 		case TYPE_VOID:
@@ -435,9 +434,6 @@ static void x64_classify(Type *type, ByteSize offset_base, X64Class *lo_class, X
 			break;
 		case TYPE_VECTOR:
 			x64_classify_vector(type, offset_base, current, lo_class, hi_class, named);
-			break;
-		case TYPE_SCALED_VECTOR:
-			*current = CLASS_MEMORY;
 			break;
 	}
 }
@@ -584,7 +580,6 @@ AbiType x64_get_int_type_at_offset(Type *type, unsigned offset, Type *source_typ
 		case TYPE_FAULTTYPE:
 		case TYPE_BITSTRUCT:
 		case TYPE_OPTIONAL:
-		case TYPE_OPTIONAL_ANY:
 		case CT_TYPES:
 			UNREACHABLE
 		case TYPE_I128:
@@ -596,8 +591,6 @@ AbiType x64_get_int_type_at_offset(Type *type, unsigned offset, Type *source_typ
 		case TYPE_UNION:
 		case TYPE_VECTOR:
 			break;
-		case TYPE_SCALED_VECTOR:
-			return (AbiType) { .type = type };
 	}
 	ByteSize size = type_size(source_type);
 	assert(size != source_offset);

--- a/src/compiler/abi/c_abi_x86.c
+++ b/src/compiler/abi/c_abi_x86.c
@@ -119,11 +119,8 @@ static bool x86_should_return_type_in_reg(Type *type)
 		case TYPE_BITSTRUCT:
 		case CT_TYPES:
 		case TYPE_OPTIONAL:
-		case TYPE_OPTIONAL_ANY:
 		case TYPE_FLEXIBLE_ARRAY:
 			UNREACHABLE
-		case TYPE_SCALED_VECTOR:
-			return false;
 		case ALL_INTS:
 		case ALL_FLOATS:
 		case TYPE_BOOL:
@@ -468,7 +465,6 @@ static ABIArgInfo *x86_classify_argument(CallABI call, Regs *regs, Type *type)
 		case TYPE_TYPEID:
 		case TYPE_BITSTRUCT:
 		case TYPE_OPTIONAL:
-		case TYPE_OPTIONAL_ANY:
 		case CT_TYPES:
 		case TYPE_FLEXIBLE_ARRAY:
 			UNREACHABLE
@@ -485,8 +481,6 @@ static ABIArgInfo *x86_classify_argument(CallABI call, Regs *regs, Type *type)
 		case TYPE_ANY:
 		case TYPE_ARRAY:
 			return x86_classify_aggregate(call, regs, type);
-		case TYPE_SCALED_VECTOR:
-			// No scaled vectors in x86
 			UNREACHABLE
 	}
 	UNREACHABLE

--- a/src/compiler/codegen_general.c
+++ b/src/compiler/codegen_general.c
@@ -184,7 +184,6 @@ bool type_is_homogenous_aggregate(Type *type, Type **base, unsigned *elements)
 		case TYPE_FUNC:
 		case TYPE_SUBARRAY:
 		case CT_TYPES:
-		case TYPE_OPTIONAL_ANY:
 			return false;
 		case TYPE_ANY:
 			*base = type_iptr->canonical;
@@ -238,7 +237,7 @@ bool type_is_homogenous_aggregate(Type *type, Type **base, unsigned *elements)
 			}
 			goto TYPECHECK;
 		case TYPE_FLEXIBLE_ARRAY:
-		case TYPE_SCALED_VECTOR:
+			// Same with scaled vectors
 			return false;
 		case TYPE_ARRAY:
 			// Empty arrays? Not homogenous.

--- a/src/compiler/codegen_internal.h
+++ b/src/compiler/codegen_internal.h
@@ -41,6 +41,8 @@ static inline Type *type_lowering(Type *type)
 			case TYPE_BITSTRUCT:
 				type = type->decl->bitstruct.base_type->type;
 				continue;
+			case TYPE_WILDCARD:
+				type = type_void;
 			default:
 				return type;
 		}

--- a/src/compiler/copying.c
+++ b/src/compiler/copying.c
@@ -653,7 +653,7 @@ RETRY:
 			MACRO_COPY_ASTID(ast->if_stmt.else_body);
 			MACRO_COPY_ASTID(ast->if_stmt.then_body);
 			break;
-		case AST_NEXT_STMT:
+		case AST_NEXTCASE_STMT:
 			MACRO_COPY_EXPR(ast->nextcase_stmt.expr);
 			break;
 		case AST_NOP_STMT:
@@ -802,7 +802,6 @@ TypeInfo *copy_type_info(CopyStruct *c, TypeInfo *source)
 		case TYPE_INFO_INFERRED_ARRAY:
 		case TYPE_INFO_SUBARRAY:
 		case TYPE_INFO_INFERRED_VECTOR:
-		case TYPE_INFO_SCALED_VECTOR:
 			assert(source->resolve_status == RESOLVE_NOT_DONE);
 			copy->array.base = copy_type_info(c, source->array.base);
 			return copy;

--- a/src/compiler/enums.h
+++ b/src/compiler/enums.h
@@ -72,7 +72,7 @@ typedef enum
 	AST_RETURN_STMT,
 	AST_BLOCK_EXIT_STMT,
 	AST_SWITCH_STMT,
-	AST_NEXT_STMT,
+	AST_NEXTCASE_STMT,
 	AST_CONTRACT,
 } AstKind;
 
@@ -346,7 +346,7 @@ typedef enum
 	PREC_SHIFT,             // << >>
 	PREC_MULTIPLICATIVE,    // * / %
 	PREC_UNARY,             // ! - + ~ * & prefix ++/-- try? catch? (type)
-	PREC_CALL,              // . () [] postfix ++/--
+	PREC_CALL,              // . () [] postfix ++ -- !! ? !
 	PREC_MACRO,
 	PREC_FIRST = PREC_MACRO
 } Precedence;
@@ -379,7 +379,6 @@ typedef enum
 	TYPE_INFO_VECTOR,
 	TYPE_INFO_INFERRED_ARRAY,
 	TYPE_INFO_INFERRED_VECTOR,
-	TYPE_INFO_SCALED_VECTOR,
 	TYPE_INFO_SUBARRAY,
 	TYPE_INFO_POINTER,
 } TypeInfoKind;
@@ -541,7 +540,6 @@ typedef enum
 	TOKEN_MODULE,
 	TOKEN_NEXTCASE,
 	TOKEN_NULL,
-	TOKEN_PRIVATE,
 	TOKEN_RETURN,
 	TOKEN_STATIC,
 	TOKEN_STRUCT,
@@ -561,7 +559,6 @@ typedef enum
 	TOKEN_CT_DEFAULT,           // $default
 	TOKEN_CT_DEFINED,           // $defined
 	TOKEN_CT_ECHO,              // $echo
-	TOKEN_CT_ELIF,              // $elif
 	TOKEN_CT_ELSE,              // $else
 	TOKEN_CT_ENDFOR,            // $endfor
 	TOKEN_CT_ENDFOREACH,        // $endforeach
@@ -657,22 +654,23 @@ typedef enum
 	TYPE_TYPEDEF,
 	TYPE_DISTINCT,
 	TYPE_ARRAY,
+	TYPE_FIRST_ARRAYLIKE = TYPE_ARRAY,
 	TYPE_SUBARRAY,
-	TYPE_INFERRED_ARRAY,
 	TYPE_FLEXIBLE_ARRAY,
+	TYPE_INFERRED_ARRAY,
+	TYPE_VECTOR,
+	TYPE_INFERRED_VECTOR,
+	TYPE_LAST_ARRAYLIKE = TYPE_INFERRED_VECTOR,
 	TYPE_UNTYPED_LIST,
 	TYPE_OPTIONAL,
-	TYPE_OPTIONAL_ANY,
+	TYPE_WILDCARD,
 	TYPE_TYPEINFO,
 	TYPE_MEMBER,
-	TYPE_INFERRED_VECTOR,
-	TYPE_SCALED_VECTOR,
-	TYPE_VECTOR,
 	TYPE_LAST = TYPE_ANY
 } TypeKind;
 
 #define CT_TYPES TYPE_TYPEINFO: case TYPE_INFERRED_ARRAY: case TYPE_INFERRED_VECTOR: case TYPE_UNTYPED_LIST: \
-case TYPE_POISONED: case TYPE_MEMBER
+case TYPE_POISONED: case TYPE_MEMBER: case TYPE_WILDCARD
 #define ALL_INTS TYPE_I8: case TYPE_I16: case TYPE_I32: case TYPE_I64: case TYPE_I128: \
 case TYPE_U8: case TYPE_U16: case TYPE_U32: case TYPE_U64: case TYPE_U128
 #define ALL_SIGNED_INTS TYPE_I8: case TYPE_I16: case TYPE_I32: case TYPE_I64: case TYPE_I128

--- a/src/compiler/expr.c
+++ b/src/compiler/expr.c
@@ -554,6 +554,7 @@ void expr_rewrite_to_const_zero(Expr *expr, Type *type)
 		case TYPE_POISONED:
 		case TYPE_VOID:
 		case TYPE_INFERRED_VECTOR:
+		case TYPE_WILDCARD:
 			UNREACHABLE
 		case ALL_INTS:
 			expr_rewrite_const_int(expr, type, 0);
@@ -577,7 +578,6 @@ void expr_rewrite_to_const_zero(Expr *expr, Type *type)
 			break;
 		case TYPE_FUNC:
 		case TYPE_TYPEDEF:
-		case TYPE_OPTIONAL_ANY:
 		case TYPE_OPTIONAL:
 		case TYPE_TYPEINFO:
 		case TYPE_MEMBER:
@@ -590,7 +590,6 @@ void expr_rewrite_to_const_zero(Expr *expr, Type *type)
 		case TYPE_INFERRED_ARRAY:
 		case TYPE_FLEXIBLE_ARRAY:
 		case TYPE_UNTYPED_LIST:
-		case TYPE_SCALED_VECTOR:
 		case TYPE_VECTOR:
 		{
 			ConstInitializer *init = CALLOCS(ConstInitializer);

--- a/src/compiler/headers.c
+++ b/src/compiler/headers.c
@@ -47,7 +47,6 @@ static void header_print_type(FILE *file, Type *type)
 	{
 		case CT_TYPES:
 		case TYPE_OPTIONAL:
-		case TYPE_OPTIONAL_ANY:
 			UNREACHABLE
 		case TYPE_VOID:
 			OUTPUT("void");
@@ -104,8 +103,6 @@ static void header_print_type(FILE *file, Type *type)
 			header_print_type(file, type->pointer);
 			OUTPUT("*");
 			return;
-		case TYPE_SCALED_VECTOR:
-			error_exit("Scaled vectors are not supported yet.");
 		case TYPE_FUNC:
 			OUTPUT("%s", decl_get_extname(type->decl));
 			return;
@@ -367,8 +364,8 @@ RETRY:
 		case TYPE_TYPEINFO:
 		case TYPE_MEMBER:
 		case TYPE_INFERRED_VECTOR:
+		case TYPE_WILDCARD:
 			UNREACHABLE
-		case TYPE_OPTIONAL_ANY:
 		case TYPE_VOID:
 		case TYPE_BOOL:
 		case ALL_FLOATS:
@@ -447,8 +444,6 @@ RETRY:
 			type = type->optional;
 			goto RETRY;
 			break;
-		case TYPE_SCALED_VECTOR:
-			error_exit("Scaled vectors are not supported yet.");
 		case TYPE_VECTOR:
 			if (htable_get(table, type)) return;
 			OUTPUT("typedef ");

--- a/src/compiler/llvm_codegen_debug_info.c
+++ b/src/compiler/llvm_codegen_debug_info.c
@@ -534,7 +534,6 @@ static inline LLVMMetadataRef llvm_get_debug_type_internal(GenContext *c, Type *
 		case CT_TYPES:
 			UNREACHABLE
 		case TYPE_OPTIONAL:
-		case TYPE_OPTIONAL_ANY:
 			// If this is reachable then we're not doing the proper lowering.
 			UNREACHABLE
 		case TYPE_BOOL:
@@ -587,8 +586,6 @@ static inline LLVMMetadataRef llvm_get_debug_type_internal(GenContext *c, Type *
 			return type->backend_debug_type = llvm_debug_errunion_type(c, type);
 		case TYPE_ANY:
 			return type->backend_debug_type = llvm_debug_any_type(c, type);
-		case TYPE_SCALED_VECTOR:
-			UNSUPPORTED;
 	}
 	UNREACHABLE
 }

--- a/src/compiler/llvm_codegen_type.c
+++ b/src/compiler/llvm_codegen_type.c
@@ -317,7 +317,6 @@ LLVMTypeRef llvm_get_type(GenContext *c, Type *any_type)
 		case CT_TYPES:
 			UNREACHABLE
 		case TYPE_OPTIONAL:
-		case TYPE_OPTIONAL_ANY:
 		case TYPE_TYPEDEF:
 		case TYPE_DISTINCT:
 		case TYPE_ENUM:
@@ -368,8 +367,6 @@ LLVMTypeRef llvm_get_type(GenContext *c, Type *any_type)
 			LLVMStructSetBody(virtual_type, types, 2, false);
 			return any_type->backend_type = virtual_type;
 		}
-		case TYPE_SCALED_VECTOR:
-			return any_type->backend_type = LLVMScalableVectorType(llvm_get_type(c, any_type->array.base), any_type->array.len);
 		case TYPE_VECTOR:
 			return any_type->backend_type = LLVMVectorType(llvm_get_type(c, any_type->array.base), any_type->array.len);
 	}
@@ -660,12 +657,7 @@ LLVMValueRef llvm_get_typeid(GenContext *c, Type *type)
 		}
 		case TYPE_TYPEDEF:
 			return llvm_get_typeid(c, type->canonical);
-		case TYPE_INFERRED_ARRAY:
-		case TYPE_INFERRED_VECTOR:
-		case TYPE_UNTYPED_LIST:
-		case TYPE_OPTIONAL_ANY:
-		case TYPE_TYPEINFO:
-		case TYPE_MEMBER:
+		case CT_TYPES:
 			UNREACHABLE
 		case TYPE_VOID:
 			return llvm_get_introspection_for_builtin_type(c, type, INTROSPECT_TYPE_VOID, 0);
@@ -690,10 +682,6 @@ LLVMValueRef llvm_get_typeid(GenContext *c, Type *type)
 			return llvm_get_introspection_for_builtin_type(c, type, INTROSPECT_TYPE_VARIANT, 0);
 		case TYPE_TYPEID:
 			return llvm_get_introspection_for_builtin_type(c, type, INTROSPECT_TYPE_TYPEID, 0);
-		case TYPE_POISONED:
-			UNREACHABLE
-		case TYPE_SCALED_VECTOR:
-			UNSUPPORTED;
 	}
 	UNREACHABLE
 }

--- a/src/compiler/parse_stmt.c
+++ b/src/compiler/parse_stmt.c
@@ -5,12 +5,11 @@
 #include "compiler_internal.h"
 #include "parser_internal.h"
 
-
 // --- Internal functions
 
 static inline Expr *parse_asm_expr(ParseContext *c);
 
-static Ast *parse_declaration_statment_after_type(ParseContext *c, TypeInfo *type)
+static Ast *parse_decl_stmt_after_type(ParseContext *c, TypeInfo *type)
 {
 	Ast *ast = ast_calloc();
 	ast->span = type->span;
@@ -95,7 +94,7 @@ static inline Ast *parse_declaration_stmt(ParseContext *c)
 	bool is_static = !is_threadlocal && try_consume(c, TOKEN_STATIC);
 	is_static = is_threadlocal || is_static;
 	ASSIGN_TYPE_OR_RET(TypeInfo *type, parse_optional_type(c), poisoned_ast);
-	ASSIGN_AST_OR_RET(Ast *result, parse_declaration_statment_after_type(c, type), poisoned_ast);
+	ASSIGN_AST_OR_RET(Ast *result, parse_decl_stmt_after_type(c, type), poisoned_ast);
 	CONSUME_EOS_OR_RET(poisoned_ast);
 	if (result->ast_kind == AST_DECLARE_STMT)
 	{
@@ -411,8 +410,11 @@ static inline Ast* parse_asm_block_stmt(ParseContext *c)
 
 
 /**
- * do_stmt
- * 	: DO statement WHILE '(' expression ')' ';'
+ * do_stmt ::= DO optional_label compound_stmt (WHILE '(' expression ')')? ';'
+ *
+ * Note that we transform do to a for loop (with a special flag)
+ * – and in parsing we allow a regular statement, but disambiguate that
+ * during semantic analysis.
  */
 static inline Ast* parse_do_stmt(ParseContext *c)
 {
@@ -460,8 +462,7 @@ static inline Ast *parse_case_stmts(ParseContext *c, TokenType case_type, TokenT
 
 
 /**
- * defer_stmt
- * 	: DEFER statement
+ * defer_stmt ::= DEFER (TRY | CATCH)? statement
  */
 static inline Ast* parse_defer_stmt(ParseContext *c)
 {
@@ -480,8 +481,9 @@ static inline Ast* parse_defer_stmt(ParseContext *c)
 }
 
 /**
- * while_stmt
- *  : WHILE '(' control_expression ')' statement
+ * while_stmt ::= WHILE optional_label '(' cond ')' statement
+ *
+ * Note that during parsing we rewrite this as a for loop.
  */
 static inline Ast* parse_while_stmt(ParseContext *c)
 {
@@ -489,7 +491,6 @@ static inline Ast* parse_while_stmt(ParseContext *c)
 	advance_and_verify(c, TOKEN_WHILE);
 
 	ASSIGN_DECL_OR_RET(while_ast->for_stmt.flow.label, parse_optional_label(c, while_ast), poisoned_ast);
-
 	CONSUME_OR_RET(TOKEN_LPAREN, poisoned_ast);
 	ASSIGN_EXPRID_OR_RET(while_ast->for_stmt.cond, parse_cond(c), poisoned_ast);
 	CONSUME_OR_RET(TOKEN_RPAREN, poisoned_ast);
@@ -507,21 +508,9 @@ static inline Ast* parse_while_stmt(ParseContext *c)
 
 
 /**
- * if_expr
- *  : optional_type IDENT '=' initializer
- *  | optional_type IDENT NOFAIL_ASSIGN expression
- *  | expression
- *  ;
- *
- * if_cond_expr
- *  : if_expr
- *  | if_cond_expr ',' if_expr
- *  ;
- *
- * if_stmt
- * 	: IF '(' control_expression ')' statement
- *	| IF '(' control_expression ')' compound_statement ELSE compound_statement
- *	;
+ * if_stmt ::= IF optional_label '(' cond ')' switch_body (ELSE compound_stmt)?
+ *           | IF optional_label '(' cond ')' compound_stmt (ELSE compound_stmt)?
+ *           | IF optional_label '(' cond ')' statement
  */
 static inline Ast* parse_if_stmt(ParseContext *c)
 {
@@ -532,6 +521,7 @@ static inline Ast* parse_if_stmt(ParseContext *c)
 	ASSIGN_EXPRID_OR_RET(if_ast->if_stmt.cond, parse_cond(c), poisoned_ast);
 	unsigned row = c->span.row;
 	CONSUME_OR_RET(TOKEN_RPAREN, poisoned_ast);
+
 	// Special case, we might have if ( ) { case ... }
 	if (tok_is(c, TOKEN_LBRACE) && (peek(c) == TOKEN_CASE || peek(c) == TOKEN_DEFAULT))
 	{
@@ -551,11 +541,10 @@ static inline Ast* parse_if_stmt(ParseContext *c)
 			ast_poison(astptr(if_ast->if_stmt.then_body));
 		}
 	}
-	if (!try_consume(c, TOKEN_ELSE))
+	if (try_consume(c, TOKEN_ELSE))
 	{
-		return if_ast;
+		ASSIGN_ASTID_OR_RET(if_ast->if_stmt.else_body, parse_stmt(c), poisoned_ast);
 	}
-	ASSIGN_ASTID_OR_RET(if_ast->if_stmt.else_body, parse_stmt(c), poisoned_ast);
 	return if_ast;
 }
 
@@ -563,9 +552,9 @@ static inline Ast* parse_if_stmt(ParseContext *c)
 /**
  *
  * case_stmt
- * 	: CASE constant_expression ':' case_stmts
- * 	| CASE constant_expression ELLIPSIS constant_expression ':' cast_stmts
- * 	| CAST type ':' cast_stmts
+ * 	: CASE expression ':' case_stmts
+ * 	| CASE expression DOTDOT expression ':' case_stmts
+ * 	| CAST type ':' case_stmts
  * 	;
  */
 static inline Ast *parse_case_stmt(ParseContext *c, TokenType case_type, TokenType default_type)
@@ -642,8 +631,7 @@ bool parse_switch_body(ParseContext *c, Ast ***cases, TokenType case_type, Token
 
 
 /**
- * switch
- *  : SWITCH '(' decl_expr_list ')' '{' switch_body '}'
+ * switch ::= SWITCH optional_label ('(' cond ')')? switch_body
  */
 static inline Ast* parse_switch_stmt(ParseContext *c)
 {
@@ -652,9 +640,7 @@ static inline Ast* parse_switch_stmt(ParseContext *c)
 	ASSIGN_DECL_OR_RET(switch_ast->switch_stmt.flow.label, parse_optional_label(c, switch_ast), poisoned_ast);
 	if (!try_consume(c, TOKEN_LPAREN))
 	{
-		Expr *cond = expr_new(EXPR_COND, switch_ast->span);
-		vec_add(cond->cond_expr, expr_new_const_bool(switch_ast->span, type_bool, true));
-		switch_ast->switch_stmt.cond = exprid(cond);
+		switch_ast->switch_stmt.cond = 0;
 	}
 	else
 	{
@@ -668,52 +654,58 @@ static inline Ast* parse_switch_stmt(ParseContext *c)
 
 
 /**
- * for_statement
- * 	: FOR '(' decl_expr_list ';' expression ';' ')' statement
- *	| FOR '(' decl_expr_list ';' ';' expression_list ')' statement
- *	| FOR '(' decl_expr_list ';' expression ';' expression_list ')' statement
- * 	| FOR '(' ';' expression ';' ')' statement
- *	| FOR '(' ';' ';' expression_list ')' statement
- *	| FOR '(' ';' expression ';' expression_list ')' statement
- *	;
+ * for_stmt ::= IF optional_label '(' expression_list? ';' cond? ';' expression_list? ')' statement
  */
 static inline Ast* parse_for_stmt(ParseContext *c)
 {
 	Ast *ast = new_ast(AST_FOR_STMT, c->span);
 	advance_and_verify(c, TOKEN_FOR);
-	ASSIGN_DECL_OR_RET(ast->for_stmt.flow.label, parse_optional_label(c, ast), poisoned_ast);
-	CONSUME_OR_RET(TOKEN_LPAREN, poisoned_ast);
 
-	if (!tok_is(c, TOKEN_EOS))
-	{
-		ASSIGN_EXPRID_OR_RET(ast->for_stmt.init, parse_expression_list(c, true), poisoned_ast);
-	}
-	else
+	// Label
+	ASSIGN_DECL_OR_RET(ast->for_stmt.flow.label, parse_optional_label(c, ast), poisoned_ast);
+
+	CONSUME_OR_RET(TOKEN_LPAREN, poisoned_ast);
+	if (try_consume(c, TOKEN_EOS))
 	{
 		ast->for_stmt.init = 0;
 	}
-	CONSUME_EOS_OR_RET(poisoned_ast);
+	else
+	{
+		ASSIGN_EXPRID_OR_RET(ast->for_stmt.init, parse_expression_list(c, true), poisoned_ast);
+		CONSUME_EOS_OR_RET(poisoned_ast);
+	}
 
-	if (!tok_is(c, TOKEN_EOS))
+	if (try_consume(c, TOKEN_EOS))
+	{
+		ast->for_stmt.cond = 0;
+	}
+	else
 	{
 		ASSIGN_EXPRID_OR_RET(ast->for_stmt.cond, parse_cond(c), poisoned_ast);
+		CONSUME_EOS_OR_RET(poisoned_ast);
 	}
 
-	CONSUME_EOS_OR_RET(poisoned_ast);
-
-	if (!tok_is(c, TOKEN_RPAREN))
+	if (try_consume(c, TOKEN_RPAREN))
+	{
+		ast->for_stmt.incr = 0;
+	}
+	else
 	{
 		ASSIGN_EXPRID_OR_RET(ast->for_stmt.incr, parse_expression_list(c, false), poisoned_ast);
+		CONSUME_OR_RET(TOKEN_RPAREN, poisoned_ast);
 	}
 
-	CONSUME_OR_RET(TOKEN_RPAREN, poisoned_ast);
-
+	// Ast range does not include the body
 	RANGE_EXTEND_PREV(ast);
+
 	ASSIGN_AST_OR_RET(Ast *body, parse_stmt(c), poisoned_ast);
 	ast->for_stmt.body = astid(body);
 	return ast;
 }
 
+/**
+ * foreach_var ::= optional_type? '&'? IDENT
+ */
 static inline bool parse_foreach_var(ParseContext *c, Ast *foreach)
 {
 	TypeInfo *type = NULL;
@@ -733,21 +725,15 @@ static inline bool parse_foreach_var(ParseContext *c, Ast *foreach)
 	Decl *var = decl_new_var(symstr(c), c->span, type, VARDECL_LOCAL);
 	if (!try_consume(c, TOKEN_IDENT))
 	{
-		if (type)
-		{
-			SEMA_ERROR_HERE("Expected an identifier after the type.");
-			return false;
-		}
-		SEMA_ERROR_HERE("Expected an identifier or type.");
-		return false;
+		if (type) RETURN_SEMA_ERROR_HERE("Expected an identifier after the type.");
+		RETURN_SEMA_ERROR_HERE("Expected an identifier or type.");
 	}
 	foreach->foreach_stmt.variable = declid(var);
 	return true;
 }
 /**
- * foreach_statement
- * 	: FOREACH (CONST_IDENT ':')? '(' type? '*'? IDENT (',' type? '*'? IDENT) ':' expression ')' statement
- *	;
+ * foreach_stmt ::= (FOREACH | FOREACH_R) optional_label '(' foreach_vars ':' expression ')' statement
+ * foreach_vars ::= foreach_var (',' foreach_var)?
  */
 static inline Ast* parse_foreach_stmt(ParseContext *c)
 {
@@ -788,48 +774,52 @@ static inline Ast* parse_foreach_stmt(ParseContext *c)
 }
 
 /**
- * continue_stmt
- *  : CONTINUE
+ * continue_stmt ::= CONTINUE optional_label_target ';'
  */
-static inline Ast* parse_continue(ParseContext *c)
+static inline Ast* parse_continue_stmt(ParseContext *c)
 {
 	Ast *ast = new_ast(AST_CONTINUE_STMT, c->span);
 	advance_and_verify(c, TOKEN_CONTINUE);
 	parse_optional_label_target(c, &ast->contbreak_stmt.label);
 	if (ast->contbreak_stmt.label.name) ast->contbreak_stmt.is_label = true;
+	RANGE_EXTEND_PREV(ast);
+	CONSUME_EOS_OR_RET(poisoned_ast);
 	return ast;
 }
 
 
 /**
- * next ::= NEXTCASE ((CONST ':')? expression)?
+ * next ::= NEXTCASE ((CONST_IDENT ':')? expression)? ';'
  */
-static inline Ast* parse_next(ParseContext *c)
+static inline Ast* parse_nextcase_stmt(ParseContext *c)
 {
-	Ast *ast = new_ast(AST_NEXT_STMT, c->span);
+	Ast *ast = new_ast(AST_NEXTCASE_STMT, c->span);
 	advance_and_verify(c, TOKEN_NEXTCASE);
-	if (!tok_is(c, TOKEN_EOS))
+	if (try_consume(c, TOKEN_EOS))
 	{
-		if (tok_is(c, TOKEN_CONST_IDENT) && peek(c) == TOKEN_COLON)
-		{
-			parse_optional_label_target(c, &ast->nextcase_stmt.label);
-			advance_and_verify(c, TOKEN_COLON);
-		}
-		ASSIGN_EXPR_OR_RET(ast->nextcase_stmt.expr, parse_expr(c), poisoned_ast);
+		return ast;
 	}
+	if (tok_is(c, TOKEN_CONST_IDENT) && peek(c) == TOKEN_COLON)
+	{
+		parse_optional_label_target(c, &ast->nextcase_stmt.label);
+		advance_and_verify(c, TOKEN_COLON);
+	}
+	ASSIGN_EXPR_OR_RET(ast->nextcase_stmt.expr, parse_expr(c), poisoned_ast);
+	CONSUME_EOS_OR_RET(poisoned_ast);
 	return ast;
 }
 
 /**
- * break
- *  : BREAK
+ * break_stmt ::= BREAK optional_label_target ';'
  */
-static inline Ast* parse_break(ParseContext *c)
+static inline Ast* parse_break_stmt(ParseContext *c)
 {
 	Ast *ast = new_ast(AST_BREAK_STMT, c->span);
 	advance_and_verify(c, TOKEN_BREAK);
 	parse_optional_label_target(c, &ast->contbreak_stmt.label);
 	if (ast->contbreak_stmt.label.name) ast->contbreak_stmt.is_label = true;
+	RANGE_EXTEND_PREV(ast);
+	CONSUME_EOS_OR_RET(poisoned_ast);
 	return ast;
 }
 
@@ -851,7 +841,7 @@ static inline Ast *parse_expr_stmt(ParseContext *c)
 
 static inline Ast *parse_decl_or_expr_stmt(ParseContext *c)
 {
-	ASSIGN_EXPR_OR_RET(Expr * expr, parse_expr(c), poisoned_ast);
+	ASSIGN_EXPR_OR_RET(Expr *expr, parse_expr(c), poisoned_ast);
 	// We might be parsing "int!"
 	// If so we need to unwrap this.
 	if (expr->expr_kind == EXPR_OPTIONAL && expr->inner_expr->expr_kind == EXPR_TYPEINFO)
@@ -860,7 +850,7 @@ static inline Ast *parse_decl_or_expr_stmt(ParseContext *c)
 	}
 	if (expr->expr_kind == EXPR_TYPEINFO)
 	{
-		ASSIGN_AST_OR_RET(Ast *ast, parse_declaration_statment_after_type(c, expr->type_expr), poisoned_ast);
+		ASSIGN_AST_OR_RET(Ast *ast, parse_decl_stmt_after_type(c, expr->type_expr), poisoned_ast);
 		CONSUME_EOS_OR_RET(poisoned_ast);
 		return ast;
 	}
@@ -898,55 +888,36 @@ static inline bool parse_ct_compound_stmt(ParseContext *c, AstId *start)
 	while (1)
 	{
 		TokenType tok = c->tok;
-		if (tok == TOKEN_CT_ELSE || tok == TOKEN_CT_ELIF || tok == TOKEN_CT_ENDIF) break;
+		if (tok == TOKEN_CT_ELSE || tok == TOKEN_CT_ENDIF) break;
 		ASSIGN_AST_OR_RET(Ast *stmt, parse_stmt(c), false);
 		ast_append(&next, stmt);
 	}
 	return true;
 }
 
-/**
- * ct_else_stmt
- *  : CT_ELSE ':' ct_compound_stmt
- */
-static inline Ast* parse_ct_else_stmt(ParseContext *c)
-{
-	Ast *ast = new_ast(AST_CT_ELSE_STMT, c->span);
-	advance_and_verify(c, TOKEN_CT_ELSE);
-	consume_deprecated_symbol(c, TOKEN_COLON);
-	if (!parse_ct_compound_stmt(c, &ast->ct_else_stmt)) return poisoned_ast;
-	return ast;
-}
-
-
 
 /**
  * ct_if_stmt
- * 	: CT_IF '(' expression ')' ':' ct_compound_stmt (ct_elif_stmt | ct_else_stmt) CT_ENDIF EOS
+ * 	: CT_IF '(' expression ')' ct_compound_stmt (ct_elif_stmt | ct_else_stmt) CT_ENDIF EOS
  * 	;
  */
-static inline Ast* parse_ct_if_stmt(ParseContext *c, bool is_elif)
+static inline Ast *parse_ct_if_stmt(ParseContext *c)
 {
 	Ast *ast = ast_new_curr(c, AST_CT_IF_STMT);
-	if (is_elif) sema_warning_at(c->span, "$elif is deprecated, use $switch instead.");
-	advance_and_verify(c, is_elif ? TOKEN_CT_ELIF : TOKEN_CT_IF);
+	advance_and_verify(c, TOKEN_CT_IF);
 
 	ASSIGN_EXPR_OR_RET(ast->ct_if_stmt.expr, parse_const_paren_expr(c), poisoned_ast);
-	consume_deprecated_symbol(c, TOKEN_COLON);
 	if (!parse_ct_compound_stmt(c, &ast->ct_if_stmt.then)) return poisoned_ast;
 
-	if (tok_is(c, TOKEN_CT_ELIF))
+	if (tok_is(c, TOKEN_CT_ELSE))
 	{
-		ASSIGN_ASTID_OR_RET(ast->ct_if_stmt.elif, parse_ct_if_stmt(c, true), poisoned_ast);
+		Ast *else_ast = new_ast(AST_CT_ELSE_STMT, c->span);
+		advance_and_verify(c, TOKEN_CT_ELSE);
+		if (!parse_ct_compound_stmt(c, &else_ast->ct_else_stmt)) return poisoned_ast;
+		ast->ct_if_stmt.elif = astid(else_ast);
 	}
-	else if (tok_is(c, TOKEN_CT_ELSE))
-	{
-		ASSIGN_ASTID_OR_RET(ast->ct_if_stmt.elif, parse_ct_else_stmt(c), poisoned_ast);
-	}
-	if (is_elif) return ast;
 	advance_and_verify(c, TOKEN_CT_ENDIF);
 	RANGE_EXTEND_PREV(ast);
-	consume_deprecated_symbol(c, TOKEN_EOS);
 	return ast;
 }
 
@@ -958,7 +929,7 @@ static inline Ast* parse_ct_if_stmt(ParseContext *c, bool is_elif)
  * 	| RETURN
  * 	;
  */
-static inline Ast *parse_return(ParseContext *c)
+static inline Ast *parse_return_stmt(ParseContext *c)
 {
 	advance_and_verify(c, TOKEN_RETURN);
 	Ast *ast = ast_new_curr(c, AST_RETURN_STMT);
@@ -966,6 +937,7 @@ static inline Ast *parse_return(ParseContext *c)
 	{
 		ASSIGN_EXPR_OR_RET(ast->return_stmt.expr, parse_expr(c), poisoned_ast);
 	}
+	CONSUME_EOS_OR_RET(poisoned_ast);
 	return ast;
 }
 
@@ -976,11 +948,7 @@ static inline Ast *parse_return(ParseContext *c)
 
 
 /**
- * ct_foreach_stmt
- *  | CT_FOREACH '(' CT_IDENT (',' CT_IDENT)? ':' expr ')' ':' statement* CT_ENDFOREACH EOS
- *  ;
- *
- * @return
+ * ct_foreach_stmt ::= CT_FOREACH '(' CT_IDENT (',' CT_IDENT)? ':' expr ')' statement* CT_ENDFOREACH
  */
 static inline Ast* parse_ct_foreach_stmt(ParseContext *c)
 {
@@ -1000,7 +968,6 @@ static inline Ast* parse_ct_foreach_stmt(ParseContext *c)
 	TRY_CONSUME_OR_RET(TOKEN_COLON, "Expected ':'.", poisoned_ast);
 	ASSIGN_EXPRID_OR_RET(ast->ct_foreach_stmt.expr, parse_expr(c), poisoned_ast);
 	CONSUME_OR_RET(TOKEN_RPAREN, poisoned_ast);
-	consume_deprecated_symbol(c, TOKEN_COLON);
 	Ast *body = new_ast(AST_COMPOUND_STMT, ast->span);
 	ast->ct_foreach_stmt.body = astid(body);
 	AstId *current = &body->compound_stmt.first_stmt;
@@ -1010,7 +977,6 @@ static inline Ast* parse_ct_foreach_stmt(ParseContext *c)
 		*current = astid(stmt);
 		current = &stmt->next;
 	}
-	consume_deprecated_symbol(c, TOKEN_EOS);
 	return ast;
 }
 
@@ -1042,8 +1008,6 @@ static inline Ast* parse_ct_for_stmt(ParseContext *c)
 
 	CONSUME_OR_RET(TOKEN_RPAREN, poisoned_ast);
 
-	consume_deprecated_symbol(c, TOKEN_COLON);
-
 	Ast *body = new_ast(AST_COMPOUND_STMT, ast->span);
 	ast->for_stmt.body = astid(body);
 	AstId *current = &body->compound_stmt.first_stmt;
@@ -1053,33 +1017,23 @@ static inline Ast* parse_ct_for_stmt(ParseContext *c)
 		*current = astid(stmt);
 		current = &stmt->next;
 	}
-	consume_deprecated_symbol(c, TOKEN_EOS);
 	return ast;
 }
 
 /**
- * CTSWITCH '(' expression ')' ':' '{' ct_switch_body '}'
+ * ct_switch_stmt ::= CT_SWITCH const_paren_expr? ct_case_statement* CT_ENDSWITCH
  *
- * ct_switch_body
- *  	: ct_case_statement
- *		| ct_switch_body ct_case_statement
- *		;
- *
- * ct_case_statement
- * 		: CTCASE type_list ':' statement
- * 		| CTDEFAULT ':' statement
- * 		;
- *
- * @return
+ * ct_case_statement ::= (CT_CASE constant_expr | CT_DEFAULT) ':' opt_stmt_list
  */
 static inline Ast* parse_ct_switch_stmt(ParseContext *c)
 {
 	Ast *ast = ast_new_curr(c, AST_CT_SWITCH_STMT);
 	advance_and_verify(c, TOKEN_CT_SWITCH);
-	if (!tok_is(c, TOKEN_CT_CASE) && !tok_is(c, TOKEN_CT_DEFAULT) && !tok_is(c, TOKEN_CT_ENDSWITCH))
+
+	// Is it a paren expr?
+	if (tok_is(c, TOKEN_LPAREN))
 	{
 		ASSIGN_EXPRID_OR_RET(ast->ct_switch_stmt.cond, parse_const_paren_expr(c), poisoned_ast);
-		consume_deprecated_symbol(c, TOKEN_COLON);
 	}
 
 	Ast **cases = NULL;
@@ -1102,11 +1056,13 @@ static inline Ast* parse_ct_switch_stmt(ParseContext *c)
 		}
 		vec_add(cases, result);
 	}
-	consume_deprecated_symbol(c, TOKEN_EOS);
 	ast->ct_switch_stmt.body = cases;
 	return ast;
 }
 
+/**
+ * assert_stmt ::= ASSERT '(' assert_expr (',' expr)? ')' ';'
+ */
 static inline Ast *parse_assert_stmt(ParseContext *c)
 {
 	Ast *ast = ast_new_curr(c, AST_ASSERT_STMT);
@@ -1204,16 +1160,8 @@ Ast *parse_stmt(ParseContext *c)
 		case TOKEN_STATIC:   // Static means declaration!
 		case TOKEN_CONST:   // Const means declaration!
 			return parse_declaration_stmt(c);
-		case TOKEN_AT_TYPE_IDENT:
-		case TOKEN_AT_CONST_IDENT:
-		case TOKEN_AT:
-		case TOKEN_AT_IDENT:
-			return parse_expr_stmt(c);
 		case TOKEN_RETURN:
-		{
-			ASSIGN_AST_OR_RET(Ast *ast, parse_return(c), poisoned_ast);
-			RETURN_AFTER_EOS(ast);
-		}
+			return parse_return_stmt(c);
 		case TOKEN_IF:
 			return parse_if_stmt(c);
 		case TOKEN_WHILE:
@@ -1230,24 +1178,15 @@ Ast *parse_stmt(ParseContext *c)
 		case TOKEN_FOREACH_R:
 			return parse_foreach_stmt(c);
 		case TOKEN_CONTINUE:
-		{
-			ASSIGN_AST_OR_RET(Ast *ast, parse_continue(c), poisoned_ast);
-			RETURN_AFTER_EOS(ast);
-		}
+			return parse_continue_stmt(c);
 		case TOKEN_CASE:
 			SEMA_ERROR_HERE("'case' was found outside of 'switch', did you mismatch a '{ }' pair?");
 			advance(c);
 			return poisoned_ast;
 		case TOKEN_BREAK:
-		{
-			ASSIGN_AST_OR_RET(Ast *ast, parse_break(c), poisoned_ast);
-			RETURN_AFTER_EOS(ast);
-		}
+			return parse_break_stmt(c);
 		case TOKEN_NEXTCASE:
-		{
-			ASSIGN_AST_OR_RET(Ast *ast, parse_next(c), poisoned_ast);
-			RETURN_AFTER_EOS(ast);
-		}
+			return parse_nextcase_stmt(c);
 		case TOKEN_ASM:
 			return parse_asm_block_stmt(c);
 		case TOKEN_DEFAULT:
@@ -1259,7 +1198,7 @@ Ast *parse_stmt(ParseContext *c)
 		case TOKEN_CT_ASSERT:
 			return parse_ct_assert_stmt(c);
 		case TOKEN_CT_IF:
-			return parse_ct_if_stmt(c, false);
+			return parse_ct_if_stmt(c);
 		case TOKEN_CT_SWITCH:
 			return parse_ct_switch_stmt(c);
 		case TOKEN_CT_FOREACH:
@@ -1307,6 +1246,10 @@ Ast *parse_stmt(ParseContext *c)
 		case TOKEN_CT_VAEXPR:
 		case TOKEN_CT_VACONST:
 		case TOKEN_CT_VAREF:
+		case TOKEN_AT_TYPE_IDENT:
+		case TOKEN_AT_CONST_IDENT:
+		case TOKEN_AT:
+		case TOKEN_AT_IDENT:
 			return parse_expr_stmt(c);
 		case TOKEN_ASSERT:
 			return parse_assert_stmt(c);
@@ -1366,7 +1309,6 @@ Ast *parse_stmt(ParseContext *c)
 		case TOKEN_DOCS_END:
 		case TOKEN_DOC_COMMENT:
 		case TOKEN_CT_CASE:
-		case TOKEN_CT_ELIF:
 		case TOKEN_CT_ELSE:
 		case TOKEN_CT_DEFAULT:
 		case TOKEN_CT_ENDIF:
@@ -1374,7 +1316,6 @@ Ast *parse_stmt(ParseContext *c)
 		case TOKEN_RBRAPIPE:
 		case TOKEN_BANGBANG:
 		case TOKEN_UNDERSCORE:
-		case TOKEN_PRIVATE:
 		case TOKEN_BITSTRUCT:
 		case TOKEN_LVEC:
 		case TOKEN_RVEC:
@@ -1409,23 +1350,6 @@ Ast *parse_stmt(ParseContext *c)
 			return poisoned_ast;
 	}
 	UNREACHABLE
-}
-
-Ast *parse_jump_stmt_no_eos(ParseContext *c)
-{
-	switch (c->tok)
-	{
-		case TOKEN_NEXTCASE:
-			return parse_next(c);
-		case TOKEN_RETURN:
-			return parse_return(c);
-		case TOKEN_BREAK:
-			return parse_break(c);
-		case TOKEN_CONTINUE:
-			return parse_continue(c);
-		default:
-			UNREACHABLE
-	}
 }
 
 

--- a/src/compiler/parser_internal.h
+++ b/src/compiler/parser_internal.h
@@ -45,7 +45,6 @@ Expr *parse_cond(ParseContext *c);
 Expr *parse_assert_expr(ParseContext *c);
 Ast* parse_compound_stmt(ParseContext *c);
 Ast *parse_short_body(ParseContext *c, TypeInfoId return_type, bool require_eos);
-Ast *parse_jump_stmt_no_eos(ParseContext *c);
 bool parse_attribute(ParseContext *c, Attr **attribute_ref);
 bool parse_attributes(ParseContext *c, Attr ***attributes_ref, Visibility *visibility_ref);
 
@@ -79,7 +78,6 @@ bool try_consume(ParseContext *c, TokenType type);
 bool consume(ParseContext *c, TokenType type, const char *message, ...);
 bool consume_const_name(ParseContext *c, const char* type);
 Expr *parse_precedence_with_left_side(ParseContext *c, Expr *left_side, Precedence precedence);
-void consume_deprecated_symbol(ParseContext *c, TokenType type);
 
 INLINE const char *symstr(ParseContext *c)
 {

--- a/src/compiler/sema_initializers.c
+++ b/src/compiler/sema_initializers.c
@@ -558,9 +558,6 @@ bool sema_expr_analyse_initializer_list(SemaContext *context, Type *to, Expr *ex
 			if (!sema_analyse_expr(context, expr)) return false;
 			return cast(expr, to);
 		}
-		case TYPE_SCALED_VECTOR:
-			SEMA_ERROR(expr, "Scaled vectors cannot be initialized using an initializer list, since the length is not known at compile time.");
-			return false;
 		case TYPE_POINTER:
 			if (is_zero_init)
 			{
@@ -573,7 +570,6 @@ bool sema_expr_analyse_initializer_list(SemaContext *context, Type *to, Expr *ex
 		case TYPE_POISONED:
 		case TYPE_FUNC:
 		case TYPE_TYPEDEF:
-		case TYPE_OPTIONAL_ANY:
 		case TYPE_OPTIONAL:
 		case TYPE_TYPEINFO:
 		case TYPE_MEMBER:

--- a/src/compiler/sema_liveness.c
+++ b/src/compiler/sema_liveness.c
@@ -37,7 +37,7 @@ static void sema_trace_stmt_chain_liveness(AstId astid)
 			case AST_RETURN_STMT:
 			case AST_BREAK_STMT:
 			case AST_CONTINUE_STMT:
-			case AST_NEXT_STMT:
+			case AST_NEXTCASE_STMT:
 				return;
 			default:
 				break;
@@ -163,7 +163,7 @@ static void sema_trace_stmt_liveness(Ast *ast)
 		case AST_DEFAULT_STMT:
 			sema_trace_stmt_liveness(ast->case_stmt.body);
 			return;
-		case AST_NEXT_STMT:
+		case AST_NEXTCASE_STMT:
 			sema_trace_stmt_chain_liveness(ast->nextcase_stmt.defer_id);
 			sema_trace_expr_liveness(ast->nextcase_stmt.switch_expr);
 			return;

--- a/src/compiler/sema_name_resolution.c
+++ b/src/compiler/sema_name_resolution.c
@@ -626,10 +626,9 @@ bool sema_resolve_type_decl(SemaContext *context, Type *type)
 {
 	switch (type->type_kind)
 	{
-		case TYPE_OPTIONAL_ANY:
-			return true;
 		case TYPE_POISONED:
 			return false;
+		case TYPE_WILDCARD:
 		case TYPE_VOID:
 		case TYPE_BOOL:
 		case ALL_INTS:
@@ -641,7 +640,6 @@ bool sema_resolve_type_decl(SemaContext *context, Type *type)
 		case TYPE_UNTYPED_LIST:
 		case TYPE_MEMBER:
 		case TYPE_INFERRED_VECTOR:
-		case TYPE_SCALED_VECTOR:
 		case TYPE_VECTOR:
 		case TYPE_SUBARRAY:
 			return true;

--- a/src/compiler/tokens.c
+++ b/src/compiler/tokens.c
@@ -245,8 +245,6 @@ const char *token_type_to_string(TokenType type)
 			return "nextcase";
 		case TOKEN_NULL:
 			return "null";
-		case TOKEN_PRIVATE:
-			return "private";
 		case TOKEN_RETURN:
 			return "return";
 		case TOKEN_STATIC:
@@ -346,8 +344,6 @@ const char *token_type_to_string(TokenType type)
 			return "$foreach";
 		case TOKEN_CT_ELSE:
 			return "$else";
-		case TOKEN_CT_ELIF:
-			return "$elif";
 		case TOKEN_CT_ENDIF:
 			return "$endif";
 		case TOKEN_CT_ENDSWITCH:

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define COMPILER_VERSION "0.4.116"
+#define COMPILER_VERSION "0.4.117"

--- a/test/test_suite/bitstruct/bitstruct_simple_err_decl.c3
+++ b/test/test_suite/bitstruct/bitstruct_simple_err_decl.c3
@@ -1,11 +1,11 @@
 bitstruct Foo : char
 {
 	bool a : 1;
-	bool b; // #error: Expected a ':'
+	bool b; // #error: remove ranges from the other member
 }
 
 bitstruct Foo2 : char
 {
 	bool a;
-	bool b : 1; // #error: Expected ';'
+	bool b : 1; // #error: ranges to all other members
 }

--- a/test/test_suite/cast/cast_to_failable.c3
+++ b/test/test_suite/cast/cast_to_failable.c3
@@ -6,7 +6,9 @@ fault MyErr
 fn void test()
 {
     int! x;
-    int! d = ($typeof(MyErr.FOO!))(x); // #error: Casting to an optional type is not allowed
+    double! y;
+    int! d = ($typeof(MyErr.FOO!))(x); // #error: This optional expression is untyped
+    int! df = ($typeof(y))(x); // #error: Casting to an optional type is not allowed
 }
 
 

--- a/test/test_suite/compile_time/ct_switch_more_checks.c3
+++ b/test/test_suite/compile_time/ct_switch_more_checks.c3
@@ -26,7 +26,7 @@ fn void foo2()
 fn void foo3()
 {
 	int a;
-	$switch ({ 1, 3 }): // #error: Only types, strings, enums, integers, floats and booleans
+	$switch ({ 1, 3 }) // #error: Only types, strings, enums, integers, floats and booleans
 		$case 1:
 			io::printn("Hello");
 		$default:

--- a/test/test_suite/distinct/distinct_invalid.c3
+++ b/test/test_suite/distinct/distinct_invalid.c3
@@ -1,5 +1,7 @@
 fault Error
-{}
+{
+	ABC
+}
 
 typedef Foo1 = distinct Error; // #error: You cannot create a distinct type
 

--- a/test/test_suite/distinct/distinct_parse_errors.c3
+++ b/test/test_suite/distinct/distinct_parse_errors.c3
@@ -1,4 +1,0 @@
-import std::io;
-
-define foo = distinct x; // #error: can only be used with types
-define bar = distinct int; // #error: type name alias must start with an uppercase

--- a/test/test_suite/errors/empty_fault.c3
+++ b/test/test_suite/errors/empty_fault.c3
@@ -1,0 +1,4 @@
+module test;
+fault Foo
+{
+}  // #error: no values

--- a/test/test_suite/errors/no_common.c3
+++ b/test/test_suite/errors/no_common.c3
@@ -9,5 +9,5 @@ macro test()
 
 fn void main()
 {
-	test() ?? 2; // #error: Cannot find a common type for 'void' and 'int'
+	test() ?? 2; // No longer an error!
 }

--- a/test/test_suite/errors/optional_sizeof.c3
+++ b/test/test_suite/errors/optional_sizeof.c3
@@ -1,0 +1,38 @@
+fn int! abc()
+{
+	return 1;
+}
+macro test()
+{
+	abc()?;
+}
+
+fn void a()
+{
+	String s = $typeof(test()).qnameof; // #error: This optional expression is untyped.
+}
+
+fn void b()
+{
+	$sizeof(test()); // #error: This optional expression is untyped.
+}
+
+fn void c()
+{
+	$sizeof(test() ?? 1);
+}
+
+fn void! d()
+{
+	$typeof(test()?) g; // #error: This expression has no concrete type
+}
+
+macro e()
+{
+	var g = test()?; // #error: No type can be inferred from the optional result
+}
+
+fn void! h()
+{
+	e();
+}

--- a/test/test_suite/methods/access_private_method.c3
+++ b/test/test_suite/methods/access_private_method.c3
@@ -3,7 +3,7 @@ fn void TreeView.nodeNotifyHandler(TreeView* this, TreeNode* node, String prop, 
 
 struct TreeNode { int abc; NodeNotifyHandler notifyHandler; }
 struct TreeView { int abc; }
-private fn void TreeView.addNodeInternal(TreeView* this, int nop, TreeNode* node, TreeNode* pnode = null, int pos = -1)
+fn void TreeView.addNodeInternal(TreeView* this, int nop, TreeNode* node, TreeNode* pnode = null, int pos = -1) @private
 {
         node.notifyHandler = &TreeView.nodeNotifyHandler; // This is the line
 }

--- a/test/test_suite/methods/method_from_var.c3
+++ b/test/test_suite/methods/method_from_var.c3
@@ -1,9 +1,9 @@
 typedef NodeNotifyHandler = fn void(TreeView* this, TreeNode* node, String prop, void* data);
-private fn void TreeView.nodeNotifyHandler(TreeView* this, TreeNode* node, String prop, void* data) {}
+fn void TreeView.nodeNotifyHandler(TreeView* this, TreeNode* node, String prop, void* data) @private {}
 
 struct TreeNode { int abc; NodeNotifyHandler notifyHandler; }
 struct TreeView { int abc; }
-private fn void TreeView.addNodeInternal(TreeView* this, int nop, TreeNode* node, TreeNode* pnode = null, int pos = -1)
+fn void TreeView.addNodeInternal(TreeView* this, int nop, TreeNode* node, TreeNode* pnode = null, int pos = -1) @private
 {
 	 node.notifyHandler = &(this.nodeNotifyHandler); // #error: Taking the address of a method
 }


### PR DESCRIPTION
…ments. Empty faults is now an error. Remove "define" for types. Remove "private". Better errors on incorrect bitstruct syntax. Introduction of wildcard type rather than optional wildcard. Removal of scaled vector type. '?' now has much higher precedence.