### PR TITLE
lib/std: display any caught error in tests

### DIFF
--- a/lib/std/core/runtime.c3
+++ b/lib/std/core/runtime.c3
@@ -62,7 +62,7 @@ fn bool TestRunner.run(TestRunner* runner)
 		{
 			if (catch err = runner.test_fns[i]())
 			{
-				io::printn("[failed]");
+				io::printfn("[failed] Failed due to: %s", err);
 				continue;
 			}
 			io::printn("[ok]");


### PR DESCRIPTION
As per the discussion in #798.