### PR TITLE
lib/std/io: Add File.readbytes and File.writebytes

### DIFF
--- a/lib/std/io/io_file.c3
+++ b/lib/std/io/io_file.c3
@@ -95,11 +95,22 @@ fn bool File.eof(self) @inline
 }
 
 /**
+ * @require self.file `File must be initialized`
  * @param [in] buffer
  */
 fn usz! File.read(self, char[] buffer)
 {
-	return os::native_fread(self.file, buffer);
+	return os::native_fread(self.file, buffer, buffer.len);
+}
+
+/**
+ * @require self.file `File must be initialized`
+ * @param [in] buffer
+ */
+fn usz! File.readbytes(self, char[] buffer, usz size)
+{
+	if (size > buffer.len) return IoError.OVERFLOW?;
+	return os::native_fread(self.file, buffer, size);
 }
 
 /**
@@ -108,7 +119,17 @@ fn usz! File.read(self, char[] buffer)
  */
 fn usz! File.write(self, char[] buffer)
 {
-	return os::native_fwrite(self.file, buffer);
+	return os::native_fwrite(self.file, buffer, buffer.len);
+}
+
+/**
+ * @param [out] buffer
+ * @require self.file `File must be initialized`
+ */
+fn usz! File.writebytes(self, char[] buffer, usz size)
+{
+	if (size > buffer.len) return IoError.OVERFLOW?;
+	return os::native_fwrite(self.file, buffer, size);
 }
 
 /**

--- a/lib/std/io/os/file_libc.c3
+++ b/lib/std/io/os/file_libc.c3
@@ -70,14 +70,14 @@ fn usz! native_ftell(CFile file) @inline
 	return index >= 0 ? (usz)index : file_seek_errno()?;
 }
 
-fn usz! native_fwrite(CFile file, char[] buffer) @inline
+fn usz! native_fwrite(CFile file, char[] buffer, usz size) @inline
 {
-	return libc::fwrite(buffer.ptr, 1, buffer.len, file);
+	return libc::fwrite(buffer.ptr, 1, size, file);
 }
 
-fn usz! native_fread(CFile file, char[] buffer) @inline
+fn usz! native_fread(CFile file, char[] buffer, usz size) @inline
 {
-	return libc::fread(buffer.ptr, 1, buffer.len, file);
+	return libc::fread(buffer.ptr, 1, size, file);
 }
 
 macro anyfault file_open_errno() @local

--- a/lib/std/io/os/file_nolibc.c3
+++ b/lib/std/io/os/file_nolibc.c3
@@ -6,8 +6,8 @@ def FreopenFn = fn void*!(void*, String, String);
 def FcloseFn = fn void!(void*);
 def FseekFn = fn void!(void*, isz, Seek);
 def FtellFn = fn usz!(void*);
-def FwriteFn = fn usz!(void*, char[] buffer);
-def FreadFn = fn usz!(void*, char[] buffer);
+def FwriteFn = fn usz!(void*, char[] buffer, usz size);
+def FreadFn = fn usz!(void*, char[] buffer, usz size);
 def RemoveFn = fn void!(String);
 
 FopenFn native_fopen_fn @weak @if(!$defined(native_fopen_fn));
@@ -62,14 +62,14 @@ fn usz! native_ftell(CFile file) @inline
 	return IoError.UNSUPPORTED_OPERATION?;
 }
 
-fn usz! native_fwrite(CFile file, char[] buffer) @inline
+fn usz! native_fwrite(CFile file, char[] buffer, usz size) @inline
 {
-	if (native_fwrite_fn) return native_fwrite_fn(file, buffer);
+	if (native_fwrite_fn) return native_fwrite_fn(file, buffer, size);
 	return IoError.UNSUPPORTED_OPERATION?;
 }
 
-fn usz! native_fread(CFile file, char[] buffer) @inline
+fn usz! native_fread(CFile file, char[] buffer, usz size) @inline
 {
-	if (native_fread_fn) return native_fread_fn(file, buffer);
+	if (native_fread_fn) return native_fread_fn(file, buffer, size);
 	return IoError.UNSUPPORTED_OPERATION?;
 }


### PR DESCRIPTION
It is very common when reading files (using fread) to not read the full file.
Depending on the specific implementation, you can end up with a bigger buffer than the data you want to read.

This patch adds File.readbytes and File.writebytes for these cases.
File.read and File.write reamin identical.

In the case that the amount of bytes to read or write is larger than the buffer, then IoError.OVERFLOW is returned.