### PR TITLE
Architecture generic Atomics (C11 + extras)

### DIFF
--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -8,16 +8,27 @@ module std::atomic;
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
+ * 
+ * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
  **/
 macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+
+  $StorageType* storage_ptr = ($StorageType*)ptr;
+
 	$typeof(*ptr) old_value;
   $typeof(*ptr) new_value;
+
+  $StorageType storage_old_value;
+  $StorageType storage_new_value;
   
   do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+    old_value = bitcast(storage_old_value, $typeof(*ptr));
     new_value = old_value + y;
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+    storage_new_value = bitcast(new_value, $StorageType);
+  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
   return old_value;
 }
@@ -27,16 +38,27 @@ macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
+ * 
+* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
  **/
 macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+
+  $StorageType* storage_ptr = ($StorageType*)ptr;
+
 	$typeof(*ptr) old_value;
   $typeof(*ptr) new_value;
+
+  $StorageType storage_old_value;
+  $StorageType storage_new_value;
   
   do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+    old_value = bitcast(storage_old_value, $typeof(*ptr));
     new_value = old_value - y;
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+    storage_new_value = bitcast(new_value, $StorageType);
+  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
   return old_value;
 }
@@ -46,16 +68,27 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
+ * 
+* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
  **/
 macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+
+  $StorageType* storage_ptr = ($StorageType*)ptr;
+
 	$typeof(*ptr) old_value;
   $typeof(*ptr) new_value;
+
+  $StorageType storage_old_value;
+  $StorageType storage_new_value;
   
   do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+    old_value = bitcast(storage_old_value, $typeof(*ptr));
     new_value = old_value | y;
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+    storage_new_value = bitcast(new_value, $StorageType);
+  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
   return old_value;
 }
@@ -65,16 +98,27 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
+ * 
+* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
  **/
 macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+
+  $StorageType* storage_ptr = ($StorageType*)ptr;
+
 	$typeof(*ptr) old_value;
   $typeof(*ptr) new_value;
+
+  $StorageType storage_old_value;
+  $StorageType storage_new_value;
   
   do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+    old_value = bitcast(storage_old_value, $typeof(*ptr));
     new_value = old_value ^ y;
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+    storage_new_value = bitcast(new_value, $StorageType);
+  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
   return old_value;
 }
@@ -84,16 +128,27 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
+ * 
+* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
  **/
 macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+
+  $StorageType* storage_ptr = ($StorageType*)ptr;
+
 	$typeof(*ptr) old_value;
   $typeof(*ptr) new_value;
+
+  $StorageType storage_old_value;
+  $StorageType storage_new_value;
   
   do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+    old_value = bitcast(storage_old_value, $typeof(*ptr));
     new_value = old_value & y;
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+    storage_new_value = bitcast(new_value, $StorageType);
+  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
   return old_value;
 }
@@ -103,6 +158,8 @@ macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
+ * 
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  **/
 macro flag_test_and_set(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
@@ -121,6 +178,8 @@ macro flag_test_and_set(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
+ * 
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  **/
 macro flag_clear(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -1,6 +1,234 @@
 // Copyright (c) 2023 Eduardo José Gómez Hernández. All rights reserved.
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
+module std::atomic::types(<Type>);
+
+struct Atomic
+{
+	Type data;
+}
+
+fn Type Atomic.load(&self, AtomicOrdering ordering = SEQ_CONSISTENT)
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return $$atomic_load(data, false, AtomicOrdering.NOT_ATOMIC.ordinal);
+		case UNORDERED: return $$atomic_load(data, false, AtomicOrdering.UNORDERED.ordinal);
+		case MONOTONIC: return $$atomic_load(data, false, AtomicOrdering.MONOTONIC.ordinal);
+		case ACQUIRE: return $$atomic_load(data, false, AtomicOrdering.ACQUIRE.ordinal);
+		case RELEASE: return $$atomic_load(data, false, AtomicOrdering.RELEASE.ordinal);
+		case ACQUIRE_RELEASE: return $$atomic_load(data, false, AtomicOrdering.ACQUIRE_RELEASE.ordinal);
+
+		default:
+		case SEQ_CONSISTENT: return $$atomic_load(data, false, AtomicOrdering.SEQ_CONSISTENT.ordinal);
+  }
+}
+
+fn void Atomic.store(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: $$atomic_store(data, value, false, AtomicOrdering.NOT_ATOMIC.ordinal);
+		case UNORDERED: $$atomic_store(data, value, false, AtomicOrdering.UNORDERED.ordinal);
+		case MONOTONIC: $$atomic_store(data, value, false, AtomicOrdering.MONOTONIC.ordinal);
+		case ACQUIRE: $$atomic_store(data, value, false, AtomicOrdering.ACQUIRE.ordinal);
+		case RELEASE: $$atomic_store(data, value, false, AtomicOrdering.RELEASE.ordinal);
+		case ACQUIRE_RELEASE: $$atomic_store(data, value, false, AtomicOrdering.ACQUIRE_RELEASE.ordinal);
+
+		default:
+		case SEQ_CONSISTENT: $$atomic_store(data, value, false, AtomicOrdering.SEQ_CONSISTENT.ordinal);
+  }
+}
+
+fn Type Atomic.add(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_add(data, value, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_add(data, value, UNORDERED);
+		case MONOTONIC: return atomic::fetch_add(data, value, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_add(data, value, ACQUIRE);
+		case RELEASE: return atomic::fetch_add(data, value, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_add(data, value, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_add(data, value, SEQ_CONSISTENT);
+  }
+}
+
+fn Type Atomic.sub(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_sub(data, value, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_sub(data, value, UNORDERED);
+		case MONOTONIC: return atomic::fetch_sub(data, value, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_sub(data, value, ACQUIRE);
+		case RELEASE: return atomic::fetch_sub(data, value, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_sub(data, value, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_sub(data, value, SEQ_CONSISTENT);
+  }
+}
+
+fn Type Atomic.mul(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_mul(data, value, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_mul(data, value, UNORDERED);
+		case MONOTONIC: return atomic::fetch_mul(data, value, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_mul(data, value, ACQUIRE);
+		case RELEASE: return atomic::fetch_mul(data, value, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_mul(data, value, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_mul(data, value, SEQ_CONSISTENT);
+  }
+}
+
+fn Type Atomic.div(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_div(data, value, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_div(data, value, UNORDERED);
+		case MONOTONIC: return atomic::fetch_div(data, value, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_div(data, value, ACQUIRE);
+		case RELEASE: return atomic::fetch_div(data, value, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_div(data, value, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_div(data, value, SEQ_CONSISTENT);
+  }
+}
+
+fn Type Atomic.max(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_max(data, value, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_max(data, value, UNORDERED);
+		case MONOTONIC: return atomic::fetch_max(data, value, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_max(data, value, ACQUIRE);
+		case RELEASE: return atomic::fetch_max(data, value, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_max(data, value, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_max(data, value, SEQ_CONSISTENT);
+  }
+}
+
+fn Type Atomic.min(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_min(data, value, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_min(data, value, UNORDERED);
+		case MONOTONIC: return atomic::fetch_min(data, value, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_min(data, value, ACQUIRE);
+		case RELEASE: return atomic::fetch_min(data, value, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_min(data, value, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_min(data, value, SEQ_CONSISTENT);
+  }
+}
+
+fn Type Atomic.or(&self, ulong value, AtomicOrdering ordering = SEQ_CONSISTENT) @if(!types::is_float(Type))
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_or(data, value, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_or(data, value, UNORDERED);
+		case MONOTONIC: return atomic::fetch_or(data, value, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_or(data, value, ACQUIRE);
+		case RELEASE: return atomic::fetch_or(data, value, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_or(data, value, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_or(data, value, SEQ_CONSISTENT);
+  }
+}
+
+fn Type Atomic.xor(&self, ulong value, AtomicOrdering ordering = SEQ_CONSISTENT) @if(!types::is_float(Type))
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_xor(data, value, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_xor(data, value, UNORDERED);
+		case MONOTONIC: return atomic::fetch_xor(data, value, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_xor(data, value, ACQUIRE);
+		case RELEASE: return atomic::fetch_xor(data, value, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_xor(data, value, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_xor(data, value, SEQ_CONSISTENT);
+  }
+}
+
+fn Type Atomic.and(&self, ulong value, AtomicOrdering ordering = SEQ_CONSISTENT) @if(!types::is_float(Type))
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_and(data, value, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_and(data, value, UNORDERED);
+		case MONOTONIC: return atomic::fetch_and(data, value, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_and(data, value, ACQUIRE);
+		case RELEASE: return atomic::fetch_and(data, value, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_and(data, value, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_and(data, value, SEQ_CONSISTENT);
+  }
+}
+
+fn Type Atomic.shift_right(&self, ulong amount, AtomicOrdering ordering = SEQ_CONSISTENT) @if(!types::is_float(Type))
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_shift_right(data, amount, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_shift_right(data, amount, UNORDERED);
+		case MONOTONIC: return atomic::fetch_shift_right(data, amount, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_shift_right(data, amount, ACQUIRE);
+		case RELEASE: return atomic::fetch_shift_right(data, amount, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_shift_right(data, amount, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_shift_right(data, amount, SEQ_CONSISTENT);
+  }
+}
+
+fn Type Atomic.shift_left(&self, ulong amount, AtomicOrdering ordering = SEQ_CONSISTENT) @if(!types::is_float(Type))
+{
+	Type* data = &self.data;
+	switch(ordering) 
+	{
+		case NOT_ATOMIC: return atomic::fetch_shift_left(data, amount, NOT_ATOMIC);
+		case UNORDERED: return atomic::fetch_shift_left(data, amount, UNORDERED);
+		case MONOTONIC: return atomic::fetch_shift_left(data, amount, MONOTONIC);
+		case ACQUIRE: return atomic::fetch_shift_left(data, amount, ACQUIRE);
+		case RELEASE: return atomic::fetch_shift_left(data, amount, RELEASE);
+		case ACQUIRE_RELEASE: return atomic::fetch_shift_left(data, amount, ACQUIRE_RELEASE);
+
+		default:
+		case SEQ_CONSISTENT: return atomic::fetch_shift_left(data, amount, SEQ_CONSISTENT);
+  }
+}
+
 module std::atomic;
 
 /**
@@ -39,7 +267,7 @@ macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
-* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
  **/
 macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
@@ -69,17 +297,28 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
- * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
+ * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(y)) "The value for or must be an int"
  **/
 macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
+
+	$StorageType* storage_ptr = ($StorageType*)ptr;
+
 	$typeof(*ptr) old_value;
 	$typeof(*ptr) new_value;
 
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+	$StorageType storage_y = ($StorageType)y;
+	
 	do {
-		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-		new_value = old_value | y;
-	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = storage_old_value | storage_y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -90,17 +329,28 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
- * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
+ * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(y)) "The value for or must be an int"
  **/
 macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
+
+	$StorageType* storage_ptr = ($StorageType*)ptr;
+
 	$typeof(*ptr) old_value;
 	$typeof(*ptr) new_value;
 
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+	$StorageType storage_y = ($StorageType)y;
+	
 	do {
-		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-		new_value = old_value ^ y;
-	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = storage_old_value ^ storage_y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -111,17 +361,28 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
- * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
+ * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(y)) "The value for or must be an int"
  **/
 macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
+
+	$StorageType* storage_ptr = ($StorageType*)ptr;
+
 	$typeof(*ptr) old_value;
 	$typeof(*ptr) new_value;
 
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+	$StorageType storage_y = ($StorageType)y;
+	
 	do {
-		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-		new_value = old_value & y;
-	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = storage_old_value & storage_y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -132,17 +393,28 @@ macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
- * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
+ * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(y)) "The value for or must be an int"
  **/
 macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
+
+	$StorageType* storage_ptr = ($StorageType*)ptr;
+
 	$typeof(*ptr) old_value;
 	$typeof(*ptr) new_value;
 
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+	$StorageType storage_y = ($StorageType)y;
+	
 	do {
-		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-		new_value = old_value >> y;
-	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = storage_old_value >> storage_y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -153,17 +425,28 @@ macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
- * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
+ * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(y)) "The value for or must be an int"
  **/
 macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
+
+	$StorageType* storage_ptr = ($StorageType*)ptr;
+
 	$typeof(*ptr) old_value;
 	$typeof(*ptr) new_value;
 
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+	$StorageType storage_y = ($StorageType)y;
+	
 	do {
-		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-		new_value = old_value << y;
-	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = storage_old_value << storage_y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
 	return old_value;
 }

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -15,22 +15,22 @@ macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
-  $StorageType* storage_ptr = ($StorageType*)ptr;
+	$StorageType* storage_ptr = ($StorageType*)ptr;
 
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value;
+	$typeof(*ptr) new_value;
 
-  $StorageType storage_old_value;
-  $StorageType storage_new_value;
-  
-  do {
-    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-    old_value = bitcast(storage_old_value, $typeof(*ptr));
-    new_value = old_value + y;
-    storage_new_value = bitcast(new_value, $StorageType);
-  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+	
+	do {
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = old_value + y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -45,22 +45,22 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
-  $StorageType* storage_ptr = ($StorageType*)ptr;
+	$StorageType* storage_ptr = ($StorageType*)ptr;
 
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value;
+	$typeof(*ptr) new_value;
 
-  $StorageType storage_old_value;
-  $StorageType storage_new_value;
-  
-  do {
-    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-    old_value = bitcast(storage_old_value, $typeof(*ptr));
-    new_value = old_value - y;
-    storage_new_value = bitcast(new_value, $StorageType);
-  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+	
+	do {
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = old_value - y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -74,14 +74,14 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value;
+	$typeof(*ptr) new_value;
 
-  do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-    new_value = old_value | y;
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+	do {
+		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+		new_value = old_value | y;
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -95,14 +95,14 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value;
+	$typeof(*ptr) new_value;
 
-  do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-    new_value = old_value ^ y;
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+	do {
+		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+		new_value = old_value ^ y;
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -116,14 +116,14 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value;
+	$typeof(*ptr) new_value;
 
-  do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-    new_value = old_value & y;
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+	do {
+		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+		new_value = old_value & y;
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -137,14 +137,14 @@ macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value;
+	$typeof(*ptr) new_value;
 
-  do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-    new_value = old_value >> y;
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+	do {
+		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+		new_value = old_value >> y;
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -158,14 +158,14 @@ macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value;
+	$typeof(*ptr) new_value;
 
-  do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-    new_value = old_value << y;
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+	do {
+		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+		new_value = old_value << y;
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -179,13 +179,13 @@ macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 macro flag_test_and_set(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value = true;
-  
-  do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+	$typeof(*ptr) new_value = true;
+	
+	do {
+		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -199,11 +199,11 @@ macro flag_test_and_set(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 macro flag_clear(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value = false;
-  
-  do {
-    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+	$typeof(*ptr) new_value = false;
+	
+	do {
+		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 }
 
 /**
@@ -218,21 +218,21 @@ macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
-  $StorageType* storage_ptr = ($StorageType*)ptr;
+	$StorageType* storage_ptr = ($StorageType*)ptr;
 
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value = y;
+	$typeof(*ptr) new_value = y;
 
-  $StorageType storage_old_value;
-  $StorageType storage_new_value = bitcast(new_value, $StorageType);
-  
-  do {
-    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-    old_value = bitcast(storage_old_value, $typeof(*ptr));
-    if (old_value >= new_value) break;
-  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	$StorageType storage_old_value;
+	$StorageType storage_new_value = bitcast(new_value, $StorageType);
+	
+	do {
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		if (old_value >= new_value) break;
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -247,21 +247,21 @@ macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
-  $StorageType* storage_ptr = ($StorageType*)ptr;
+	$StorageType* storage_ptr = ($StorageType*)ptr;
 
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value = y;
+	$typeof(*ptr) new_value = y;
 
-  $StorageType storage_old_value;
-  $StorageType storage_new_value = bitcast(new_value, $StorageType);
-  
-  do {
-    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-    old_value = bitcast(storage_old_value, $typeof(*ptr));
-    if (old_value <= new_value) break;
-  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	$StorageType storage_old_value;
+	$StorageType storage_new_value = bitcast(new_value, $StorageType);
+	
+	do {
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		if (old_value <= new_value) break;
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -276,22 +276,22 @@ macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
-  $StorageType* storage_ptr = ($StorageType*)ptr;
+	$StorageType* storage_ptr = ($StorageType*)ptr;
 
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value;
+	$typeof(*ptr) new_value;
 
-  $StorageType storage_old_value;
-  $StorageType storage_new_value;
-  
-  do {
-    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-    old_value = bitcast(storage_old_value, $typeof(*ptr));
-    new_value = old_value * y;
-    storage_new_value = bitcast(new_value, $StorageType);
-  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+	
+	do {
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = old_value * y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
-  return old_value;
+	return old_value;
 }
 
 /**
@@ -306,20 +306,20 @@ macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
-  $StorageType* storage_ptr = ($StorageType*)ptr;
+	$StorageType* storage_ptr = ($StorageType*)ptr;
 
 	$typeof(*ptr) old_value;
-  $typeof(*ptr) new_value;
+	$typeof(*ptr) new_value;
 
-  $StorageType storage_old_value;
-  $StorageType storage_new_value;
-  
-  do {
-    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-    old_value = bitcast(storage_old_value, $typeof(*ptr));
-    new_value = old_value / y;
-    storage_new_value = bitcast(new_value, $StorageType);
-  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+	
+	do {
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = old_value / y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
-  return old_value;
+	return old_value;
 }

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -3,3 +3,131 @@
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::atomic;
 
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ **/
+macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value;
+  
+  do {
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    new_value = old_value + y;
+  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ **/
+macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value;
+  
+  do {
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    new_value = old_value - y;
+  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ **/
+macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value;
+  
+  do {
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    new_value = old_value | y;
+  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ **/
+macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value;
+  
+  do {
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    new_value = old_value ^ y;
+  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ **/
+macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value;
+  
+  do {
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    new_value = old_value & y;
+  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ **/
+macro flag_test_and_set(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value = true;
+  
+  do {
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ **/
+macro flag_clear(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value = false;
+  
+  do {
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+}

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -22,7 +22,7 @@ fn Type Atomic.load(&self, AtomicOrdering ordering = SEQ_CONSISTENT)
 
 		default:
 		case SEQ_CONSISTENT: return $$atomic_load(data, false, AtomicOrdering.SEQ_CONSISTENT.ordinal);
-  }
+	}
 }
 
 fn void Atomic.store(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
@@ -39,194 +39,89 @@ fn void Atomic.store(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT
 
 		default:
 		case SEQ_CONSISTENT: $$atomic_store(data, value, false, AtomicOrdering.SEQ_CONSISTENT.ordinal);
-  }
+	}
 }
 
 fn Type Atomic.add(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
 {
 	Type* data = &self.data;
-	switch(ordering) 
-	{
-		case NOT_ATOMIC: return atomic::fetch_add(data, value, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_add(data, value, UNORDERED);
-		case MONOTONIC: return atomic::fetch_add(data, value, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_add(data, value, ACQUIRE);
-		case RELEASE: return atomic::fetch_add(data, value, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_add(data, value, ACQUIRE_RELEASE);
-
-		default:
-		case SEQ_CONSISTENT: return atomic::fetch_add(data, value, SEQ_CONSISTENT);
-  }
+	return @atomic_exec(atomic::fetch_add, data, value, ordering);
 }
 
 fn Type Atomic.sub(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
 {
 	Type* data = &self.data;
-	switch(ordering) 
-	{
-		case NOT_ATOMIC: return atomic::fetch_sub(data, value, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_sub(data, value, UNORDERED);
-		case MONOTONIC: return atomic::fetch_sub(data, value, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_sub(data, value, ACQUIRE);
-		case RELEASE: return atomic::fetch_sub(data, value, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_sub(data, value, ACQUIRE_RELEASE);
-
-		default:
-		case SEQ_CONSISTENT: return atomic::fetch_sub(data, value, SEQ_CONSISTENT);
-  }
+	return @atomic_exec(atomic::fetch_sub, data, value, ordering);
 }
 
 fn Type Atomic.mul(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
 {
 	Type* data = &self.data;
-	switch(ordering) 
-	{
-		case NOT_ATOMIC: return atomic::fetch_mul(data, value, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_mul(data, value, UNORDERED);
-		case MONOTONIC: return atomic::fetch_mul(data, value, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_mul(data, value, ACQUIRE);
-		case RELEASE: return atomic::fetch_mul(data, value, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_mul(data, value, ACQUIRE_RELEASE);
-
-		default:
-		case SEQ_CONSISTENT: return atomic::fetch_mul(data, value, SEQ_CONSISTENT);
-  }
+	return @atomic_exec(atomic::fetch_mul, data, value, ordering);
 }
 
 fn Type Atomic.div(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
 {
 	Type* data = &self.data;
-	switch(ordering) 
-	{
-		case NOT_ATOMIC: return atomic::fetch_div(data, value, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_div(data, value, UNORDERED);
-		case MONOTONIC: return atomic::fetch_div(data, value, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_div(data, value, ACQUIRE);
-		case RELEASE: return atomic::fetch_div(data, value, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_div(data, value, ACQUIRE_RELEASE);
-
-		default:
-		case SEQ_CONSISTENT: return atomic::fetch_div(data, value, SEQ_CONSISTENT);
-  }
+	return @atomic_exec(atomic::fetch_div, data, value, ordering);
 }
 
 fn Type Atomic.max(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
 {
 	Type* data = &self.data;
-	switch(ordering) 
-	{
-		case NOT_ATOMIC: return atomic::fetch_max(data, value, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_max(data, value, UNORDERED);
-		case MONOTONIC: return atomic::fetch_max(data, value, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_max(data, value, ACQUIRE);
-		case RELEASE: return atomic::fetch_max(data, value, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_max(data, value, ACQUIRE_RELEASE);
-
-		default:
-		case SEQ_CONSISTENT: return atomic::fetch_max(data, value, SEQ_CONSISTENT);
-  }
+	return @atomic_exec(atomic::fetch_div, data, value, ordering);
 }
 
 fn Type Atomic.min(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT)
 {
 	Type* data = &self.data;
-	switch(ordering) 
-	{
-		case NOT_ATOMIC: return atomic::fetch_min(data, value, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_min(data, value, UNORDERED);
-		case MONOTONIC: return atomic::fetch_min(data, value, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_min(data, value, ACQUIRE);
-		case RELEASE: return atomic::fetch_min(data, value, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_min(data, value, ACQUIRE_RELEASE);
-
-		default:
-		case SEQ_CONSISTENT: return atomic::fetch_min(data, value, SEQ_CONSISTENT);
-  }
+	return @atomic_exec(atomic::fetch_min, data, value, ordering);
 }
 
 fn Type Atomic.or(&self, ulong value, AtomicOrdering ordering = SEQ_CONSISTENT) @if(!types::is_float(Type))
 {
 	Type* data = &self.data;
-	switch(ordering) 
-	{
-		case NOT_ATOMIC: return atomic::fetch_or(data, value, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_or(data, value, UNORDERED);
-		case MONOTONIC: return atomic::fetch_or(data, value, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_or(data, value, ACQUIRE);
-		case RELEASE: return atomic::fetch_or(data, value, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_or(data, value, ACQUIRE_RELEASE);
-
-		default:
-		case SEQ_CONSISTENT: return atomic::fetch_or(data, value, SEQ_CONSISTENT);
-  }
+	return @atomic_exec(atomic::fetch_or, data, value, ordering);
 }
 
 fn Type Atomic.xor(&self, ulong value, AtomicOrdering ordering = SEQ_CONSISTENT) @if(!types::is_float(Type))
 {
 	Type* data = &self.data;
-	switch(ordering) 
-	{
-		case NOT_ATOMIC: return atomic::fetch_xor(data, value, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_xor(data, value, UNORDERED);
-		case MONOTONIC: return atomic::fetch_xor(data, value, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_xor(data, value, ACQUIRE);
-		case RELEASE: return atomic::fetch_xor(data, value, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_xor(data, value, ACQUIRE_RELEASE);
-
-		default:
-		case SEQ_CONSISTENT: return atomic::fetch_xor(data, value, SEQ_CONSISTENT);
-  }
+	return @atomic_exec(atomic::fetch_xor, data, value, ordering);
 }
 
 fn Type Atomic.and(&self, ulong value, AtomicOrdering ordering = SEQ_CONSISTENT) @if(!types::is_float(Type))
 {
 	Type* data = &self.data;
-	switch(ordering) 
-	{
-		case NOT_ATOMIC: return atomic::fetch_and(data, value, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_and(data, value, UNORDERED);
-		case MONOTONIC: return atomic::fetch_and(data, value, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_and(data, value, ACQUIRE);
-		case RELEASE: return atomic::fetch_and(data, value, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_and(data, value, ACQUIRE_RELEASE);
-
-		default:
-		case SEQ_CONSISTENT: return atomic::fetch_and(data, value, SEQ_CONSISTENT);
-  }
+	return @atomic_exec(atomic::fetch_and, data, value, ordering);
 }
 
 fn Type Atomic.shift_right(&self, ulong amount, AtomicOrdering ordering = SEQ_CONSISTENT) @if(!types::is_float(Type))
 {
 	Type* data = &self.data;
-	switch(ordering) 
-	{
-		case NOT_ATOMIC: return atomic::fetch_shift_right(data, amount, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_shift_right(data, amount, UNORDERED);
-		case MONOTONIC: return atomic::fetch_shift_right(data, amount, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_shift_right(data, amount, ACQUIRE);
-		case RELEASE: return atomic::fetch_shift_right(data, amount, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_shift_right(data, amount, ACQUIRE_RELEASE);
-
-		default:
-		case SEQ_CONSISTENT: return atomic::fetch_shift_right(data, amount, SEQ_CONSISTENT);
-  }
+	return @atomic_exec(atomic::fetch_shift_right, data, amount, ordering);
 }
 
 fn Type Atomic.shift_left(&self, ulong amount, AtomicOrdering ordering = SEQ_CONSISTENT) @if(!types::is_float(Type))
 {
 	Type* data = &self.data;
+	return @atomic_exec(atomic::fetch_shift_left, data, amount, ordering);
+}
+
+macro @atomic_exec(#func, data, value, ordering) @local
+{
 	switch(ordering) 
 	{
-		case NOT_ATOMIC: return atomic::fetch_shift_left(data, amount, NOT_ATOMIC);
-		case UNORDERED: return atomic::fetch_shift_left(data, amount, UNORDERED);
-		case MONOTONIC: return atomic::fetch_shift_left(data, amount, MONOTONIC);
-		case ACQUIRE: return atomic::fetch_shift_left(data, amount, ACQUIRE);
-		case RELEASE: return atomic::fetch_shift_left(data, amount, RELEASE);
-		case ACQUIRE_RELEASE: return atomic::fetch_shift_left(data, amount, ACQUIRE_RELEASE);
+		case NOT_ATOMIC: return #func(data, value, NOT_ATOMIC);
+		case UNORDERED: return #func(data, value, UNORDERED);
+		case MONOTONIC: return #func(data, value, MONOTONIC);
+		case ACQUIRE: return #func(data, value, ACQUIRE);
+		case RELEASE: return #func(data, value, RELEASE);
+		case ACQUIRE_RELEASE: return #func(data, value, ACQUIRE_RELEASE);
 
 		default:
-		case SEQ_CONSISTENT: return atomic::fetch_shift_left(data, amount, SEQ_CONSISTENT);
-  }
+		case SEQ_CONSISTENT: return #func(data, value, SEQ_CONSISTENT);
+	}
 }
 
 module std::atomic;

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -190,3 +190,61 @@ macro flag_clear(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
     old_value = $$atomic_load(ptr, false, $ordering.ordinal);
   } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 }
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ * 
+* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ **/
+macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+
+  $StorageType* storage_ptr = ($StorageType*)ptr;
+
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value = y;
+
+  $StorageType storage_old_value;
+  $StorageType storage_new_value = bitcast(new_value, $StorageType);
+  
+  do {
+    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+    old_value = bitcast(storage_old_value, $typeof(*ptr));
+    if (old_value >= new_value) break;
+  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ * 
+* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ **/
+macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+
+  $StorageType* storage_ptr = ($StorageType*)ptr;
+
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value = y;
+
+  $StorageType storage_old_value;
+  $StorageType storage_new_value = bitcast(new_value, $StorageType);
+  
+  do {
+    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+    old_value = bitcast(storage_old_value, $typeof(*ptr));
+    if (old_value <= new_value) break;
+  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+
+  return old_value;
+}

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -4,7 +4,7 @@
 module std::atomic;
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -34,7 +34,7 @@ macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -64,7 +64,7 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -85,7 +85,7 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -106,7 +106,7 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -127,7 +127,7 @@ macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -148,7 +148,7 @@ macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -169,7 +169,7 @@ macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -189,7 +189,7 @@ macro flag_test_and_set(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -207,7 +207,7 @@ macro flag_clear(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -236,7 +236,7 @@ macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -265,7 +265,7 @@ macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
@@ -295,7 +295,7 @@ macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 }
 
 /**
- * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
  * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -175,7 +175,7 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 
 	$StorageType storage_old_value;
 	$StorageType storage_new_value;
-	
+
 	do {
 		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
@@ -192,7 +192,68 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
- * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ **/
+macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
+
+	$StorageType* storage_ptr = ($StorageType*)ptr;
+
+	$typeof(*ptr) old_value;
+	$typeof(*ptr) new_value;
+
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+
+
+	do {
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = old_value * y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+
+	return old_value;
+}
+
+/**
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ * 
+* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ **/
+macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
+
+	$StorageType* storage_ptr = ($StorageType*)ptr;
+
+	$typeof(*ptr) old_value;
+	$typeof(*ptr) new_value;
+
+	$StorageType storage_old_value;
+	$StorageType storage_new_value;
+	
+	do {
+		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		old_value = bitcast(storage_old_value, $typeof(*ptr));
+		new_value = old_value / y;
+		storage_new_value = bitcast(new_value, $StorageType);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+
+	return old_value;
+}
+
+/**
+ * @param [&in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ * 
+ * @require types::is_int($typeof(*ptr)) "Only intege pointers may be used."
  * @require types::is_int($typeof(y)) "The value for or must be an int"
  **/
 macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
@@ -224,7 +285,7 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
- * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  * @require types::is_int($typeof(y)) "The value for or must be an int"
  **/
 macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
@@ -256,7 +317,7 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
- * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  * @require types::is_int($typeof(y)) "The value for or must be an int"
  **/
 macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
@@ -288,7 +349,7 @@ macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
- * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  * @require types::is_int($typeof(y)) "The value for or must be an int"
  **/
 macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
@@ -320,7 +381,7 @@ macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
- * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  * @require types::is_int($typeof(y)) "The value for or must be an int"
  **/
 macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
@@ -348,40 +409,40 @@ macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 
 /**
  * @param [&in] ptr "the variable or dereferenced pointer to the data."
- * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
  * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  **/
-macro flag_test_and_set(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+macro flag_set(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	$typeof(*ptr) old_value;
 	$typeof(*ptr) new_value = true;
-	
+
 	do {
 		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
 	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
-
+	
 	return old_value;
 }
 
 /**
  * @param [&in] ptr "the variable or dereferenced pointer to the data."
- * @param [in] y "the value to be added to ptr."
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
  * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  **/
-macro flag_clear(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+macro flag_clear(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
 	$typeof(*ptr) old_value;
 	$typeof(*ptr) new_value = false;
-	
+
 	do {
 		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
 	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+
+	return old_value;
 }
 
 /**
@@ -437,66 +498,6 @@ macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		if (old_value <= new_value) break;
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
-
-	return old_value;
-}
-
-/**
- * @param [&in] ptr "the variable or dereferenced pointer to the data."
- * @param [in] y "the value to be added to ptr."
- * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
- * @return "returns the old value of ptr"
- * 
-* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
- **/
-macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
-{
-	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
-
-	$StorageType* storage_ptr = ($StorageType*)ptr;
-
-	$typeof(*ptr) old_value;
-	$typeof(*ptr) new_value;
-
-	$StorageType storage_old_value;
-	$StorageType storage_new_value;
-	
-	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-		old_value = bitcast(storage_old_value, $typeof(*ptr));
-		new_value = old_value * y;
-		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
-
-	return old_value;
-}
-
-/**
- * @param [&in] ptr "the variable or dereferenced pointer to the data."
- * @param [in] y "the value to be added to ptr."
- * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
- * @return "returns the old value of ptr"
- * 
-* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
- **/
-macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
-{
-	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
-
-	$StorageType* storage_ptr = ($StorageType*)ptr;
-
-	$typeof(*ptr) old_value;
-	$typeof(*ptr) new_value;
-
-	$StorageType storage_old_value;
-	$StorageType storage_new_value;
-	
-	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-		old_value = bitcast(storage_old_value, $typeof(*ptr));
-		new_value = old_value / y;
-		storage_new_value = bitcast(new_value, $StorageType);
 	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
 	return old_value;

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -17,7 +17,7 @@ macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
   do {
     old_value = $$atomic_load(ptr, false, $ordering.ordinal);
     new_value = old_value + y;
-  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
   return old_value;
 }
@@ -36,7 +36,7 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
   do {
     old_value = $$atomic_load(ptr, false, $ordering.ordinal);
     new_value = old_value - y;
-  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
   return old_value;
 }
@@ -55,7 +55,7 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
   do {
     old_value = $$atomic_load(ptr, false, $ordering.ordinal);
     new_value = old_value | y;
-  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
   return old_value;
 }
@@ -74,7 +74,7 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
   do {
     old_value = $$atomic_load(ptr, false, $ordering.ordinal);
     new_value = old_value ^ y;
-  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
   return old_value;
 }
@@ -93,7 +93,7 @@ macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
   do {
     old_value = $$atomic_load(ptr, false, $ordering.ordinal);
     new_value = old_value & y;
-  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
   return old_value;
 }
@@ -111,7 +111,7 @@ macro flag_test_and_set(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
   
   do {
     old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
   return old_value;
 }
@@ -129,5 +129,5 @@ macro flag_clear(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
   
   do {
     old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-  } while (!mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering));
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 }

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -69,26 +69,17 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
-* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  **/
 macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
-
-  $StorageType* storage_ptr = ($StorageType*)ptr;
-
 	$typeof(*ptr) old_value;
   $typeof(*ptr) new_value;
 
-  $StorageType storage_old_value;
-  $StorageType storage_new_value;
-  
   do {
-    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-    old_value = bitcast(storage_old_value, $typeof(*ptr));
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
     new_value = old_value | y;
-    storage_new_value = bitcast(new_value, $StorageType);
-  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
   return old_value;
 }
@@ -99,26 +90,17 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
-* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  **/
 macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
-
-  $StorageType* storage_ptr = ($StorageType*)ptr;
-
 	$typeof(*ptr) old_value;
   $typeof(*ptr) new_value;
 
-  $StorageType storage_old_value;
-  $StorageType storage_new_value;
-  
   do {
-    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-    old_value = bitcast(storage_old_value, $typeof(*ptr));
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
     new_value = old_value ^ y;
-    storage_new_value = bitcast(new_value, $StorageType);
-  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
   return old_value;
 }
@@ -129,26 +111,59 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
-* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  **/
 macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
-
-  $StorageType* storage_ptr = ($StorageType*)ptr;
-
 	$typeof(*ptr) old_value;
   $typeof(*ptr) new_value;
 
-  $StorageType storage_old_value;
-  $StorageType storage_new_value;
-  
   do {
-    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
-    old_value = bitcast(storage_old_value, $typeof(*ptr));
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
     new_value = old_value & y;
-    storage_new_value = bitcast(new_value, $StorageType);
-  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ * 
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
+ **/
+macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value;
+
+  do {
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    new_value = old_value >> y;
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ * 
+ * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
+ **/
+macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value;
+
+  do {
+    old_value = $$atomic_load(ptr, false, $ordering.ordinal);
+    new_value = old_value << y;
+  } while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
 
   return old_value;
 }
@@ -244,6 +259,66 @@ macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
     storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
     old_value = bitcast(storage_old_value, $typeof(*ptr));
     if (old_value <= new_value) break;
+  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ * 
+* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ **/
+macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+
+  $StorageType* storage_ptr = ($StorageType*)ptr;
+
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value;
+
+  $StorageType storage_old_value;
+  $StorageType storage_new_value;
+  
+  do {
+    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+    old_value = bitcast(storage_old_value, $typeof(*ptr));
+    new_value = old_value * y;
+    storage_new_value = bitcast(new_value, $StorageType);
+  } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+
+  return old_value;
+}
+
+/**
+ * @param [in] ptr "the variable or dereferenced pointer to the data."
+ * @param [in] y "the value to be added to ptr."
+ * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
+ * @return "returns the old value of ptr"
+ * 
+* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ **/
+macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
+{
+	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+
+  $StorageType* storage_ptr = ($StorageType*)ptr;
+
+	$typeof(*ptr) old_value;
+  $typeof(*ptr) new_value;
+
+  $StorageType storage_old_value;
+  $StorageType storage_new_value;
+  
+  do {
+    storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+    old_value = bitcast(storage_old_value, $typeof(*ptr));
+    new_value = old_value / y;
+    storage_new_value = bitcast(new_value, $StorageType);
   } while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
 
   return old_value;

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Christoffer Lerno. All rights reserved.
+// Copyright (c) 2023 Eduardo José Gómez Hernández. All rights reserved.
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::atomic;

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -112,8 +112,6 @@ macro @atomic_exec(#func, data, value, ordering) @local
 {
 	switch(ordering) 
 	{
-		case NOT_ATOMIC: return #func(data, value, NOT_ATOMIC);
-		case UNORDERED: return #func(data, value, UNORDERED);
 		case MONOTONIC: return #func(data, value, MONOTONIC);
 		case ACQUIRE: return #func(data, value, ACQUIRE);
 		case RELEASE: return #func(data, value, RELEASE);
@@ -133,9 +131,15 @@ module std::atomic;
  * @return "returns the old value of ptr"
  * 
  * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -151,7 +155,7 @@ macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = old_value + y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -163,9 +167,15 @@ macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @return "returns the old value of ptr"
  * 
  * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -181,7 +191,7 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = old_value - y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -193,9 +203,15 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @return "returns the old value of ptr"
  * 
 * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+* @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -212,7 +228,7 @@ macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = old_value * y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -224,9 +240,15 @@ macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @return "returns the old value of ptr"
  * 
 * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+* @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -242,7 +264,7 @@ macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = old_value / y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -255,9 +277,15 @@ macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * 
  * @require types::is_int($typeof(*ptr)) "Only intege pointers may be used."
  * @require types::is_int($typeof(y)) "The value for or must be an int"
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -274,7 +302,7 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = storage_old_value | storage_y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -287,9 +315,15 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * 
  * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  * @require types::is_int($typeof(y)) "The value for or must be an int"
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -306,7 +340,7 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = storage_old_value ^ storage_y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -319,9 +353,15 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * 
  * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  * @require types::is_int($typeof(y)) "The value for or must be an int"
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -338,7 +378,7 @@ macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = storage_old_value & storage_y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -351,9 +391,15 @@ macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * 
  * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  * @require types::is_int($typeof(y)) "The value for or must be an int"
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -370,7 +416,7 @@ macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = storage_old_value >> storage_y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -383,9 +429,15 @@ macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * 
  * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
  * @require types::is_int($typeof(y)) "The value for or must be an int"
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -402,7 +454,7 @@ macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = storage_old_value << storage_y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -413,6 +465,7 @@ macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @return "returns the old value of ptr"
  * 
  * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro flag_set(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
@@ -421,7 +474,7 @@ macro flag_set(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
 
 	do {
 		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $failure_ordering) != old_value);
 	
 	return old_value;
 }
@@ -432,6 +485,7 @@ macro flag_set(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @return "returns the old value of ptr"
  * 
  * @require types::is_int($typeof(*ptr)) "Only integer pointers may be used."
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro flag_clear(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
@@ -440,7 +494,7 @@ macro flag_clear(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
 
 	do {
 		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $ordering) != old_value);
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $failure_ordering) != old_value);
 
 	return old_value;
 }
@@ -451,10 +505,16 @@ macro flag_clear(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
-* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -469,7 +529,7 @@ macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		if (old_value >= new_value) break;
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -480,10 +540,16 @@ macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  * @param $ordering "atomic ordering of the load, defaults to SEQ_CONSISTENT"
  * @return "returns the old value of ptr"
  * 
-* @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require types::is_int($typeof(*ptr)) || types::is_float($typeof(*ptr)) "Only integer/float pointers may be used."
+ * @require $ordering != AtomicOrdering.NOT_ATOMIC && $ordering != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
  **/
 macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
+	var $failure_ordering = $ordering;
+	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
+	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	$endif
+	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
 	$StorageType* storage_ptr = ($StorageType*)ptr;
@@ -498,7 +564,7 @@ macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		if (old_value <= new_value) break;
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
 
 	return old_value;
 }

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -15,10 +15,8 @@ fn Type Atomic.load(&self, AtomicOrdering ordering = SEQ_CONSISTENT)
 	{
 		case NOT_ATOMIC: return $$atomic_load(data, false, AtomicOrdering.NOT_ATOMIC.ordinal);
 		case UNORDERED: return $$atomic_load(data, false, AtomicOrdering.UNORDERED.ordinal);
-		case MONOTONIC: return $$atomic_load(data, false, AtomicOrdering.MONOTONIC.ordinal);
+		case RELAXED: return $$atomic_load(data, false, AtomicOrdering.RELAXED.ordinal);
 		case ACQUIRE: return $$atomic_load(data, false, AtomicOrdering.ACQUIRE.ordinal);
-		case RELEASE: return $$atomic_load(data, false, AtomicOrdering.RELEASE.ordinal);
-		case ACQUIRE_RELEASE: return $$atomic_load(data, false, AtomicOrdering.ACQUIRE_RELEASE.ordinal);
 
 		default:
 		case SEQ_CONSISTENT: return $$atomic_load(data, false, AtomicOrdering.SEQ_CONSISTENT.ordinal);
@@ -32,10 +30,8 @@ fn void Atomic.store(&self, Type value, AtomicOrdering ordering = SEQ_CONSISTENT
 	{
 		case NOT_ATOMIC: $$atomic_store(data, value, false, AtomicOrdering.NOT_ATOMIC.ordinal);
 		case UNORDERED: $$atomic_store(data, value, false, AtomicOrdering.UNORDERED.ordinal);
-		case MONOTONIC: $$atomic_store(data, value, false, AtomicOrdering.MONOTONIC.ordinal);
-		case ACQUIRE: $$atomic_store(data, value, false, AtomicOrdering.ACQUIRE.ordinal);
+		case RELAXED: $$atomic_store(data, value, false, AtomicOrdering.RELAXED.ordinal);
 		case RELEASE: $$atomic_store(data, value, false, AtomicOrdering.RELEASE.ordinal);
-		case ACQUIRE_RELEASE: $$atomic_store(data, value, false, AtomicOrdering.ACQUIRE_RELEASE.ordinal);
 
 		default:
 		case SEQ_CONSISTENT: $$atomic_store(data, value, false, AtomicOrdering.SEQ_CONSISTENT.ordinal);
@@ -112,7 +108,7 @@ macro @atomic_exec(#func, data, value, ordering) @local
 {
 	switch(ordering) 
 	{
-		case MONOTONIC: return #func(data, value, MONOTONIC);
+		case RELAXED: return #func(data, value, RELAXED);
 		case ACQUIRE: return #func(data, value, ACQUIRE);
 		case RELEASE: return #func(data, value, RELEASE);
 		case ACQUIRE_RELEASE: return #func(data, value, ACQUIRE_RELEASE);
@@ -135,9 +131,9 @@ module std::atomic;
  **/
 macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -151,11 +147,11 @@ macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 	$StorageType storage_new_value;
 	
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = old_value + y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -171,9 +167,9 @@ macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -187,11 +183,11 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 	$StorageType storage_new_value;
 
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = old_value - y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -207,9 +203,9 @@ macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -224,11 +220,11 @@ macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 
 
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = old_value * y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -244,9 +240,9 @@ macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -260,11 +256,11 @@ macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 	$StorageType storage_new_value;
 	
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = old_value / y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -281,9 +277,9 @@ macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -298,11 +294,11 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 	$StorageType storage_y = ($StorageType)y;
 	
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = storage_old_value | storage_y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -319,9 +315,9 @@ macro fetch_or(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -336,11 +332,11 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 	$StorageType storage_y = ($StorageType)y;
 	
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = storage_old_value ^ storage_y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -357,9 +353,9 @@ macro fetch_xor(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -374,11 +370,11 @@ macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 	$StorageType storage_y = ($StorageType)y;
 	
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = storage_old_value & storage_y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -395,9 +391,9 @@ macro fetch_and(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -412,11 +408,11 @@ macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 	$StorageType storage_y = ($StorageType)y;
 	
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = storage_old_value >> storage_y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -433,9 +429,9 @@ macro fetch_shift_right(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -450,11 +446,11 @@ macro fetch_shift_left(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 	$StorageType storage_y = ($StorageType)y;
 	
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		new_value = storage_old_value << storage_y;
 		storage_new_value = bitcast(new_value, $StorageType);
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -474,7 +470,7 @@ macro flag_set(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
 
 	do {
 		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $failure_ordering) != old_value);
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $load_ordering) != old_value);
 	
 	return old_value;
 }
@@ -494,7 +490,7 @@ macro flag_clear(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
 
 	do {
 		old_value = $$atomic_load(ptr, false, $ordering.ordinal);
-	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $failure_ordering) != old_value);
+	} while (mem::compare_exchange(ptr, old_value, new_value, $ordering, $load_ordering) != old_value);
 
 	return old_value;
 }
@@ -510,9 +506,9 @@ macro flag_clear(ptr, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -526,10 +522,10 @@ macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 	$StorageType storage_new_value = bitcast(new_value, $StorageType);
 	
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		if (old_value >= new_value) break;
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }
@@ -545,9 +541,9 @@ macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $failure_ordering = $ordering;
+	var $load_ordering = $ordering;
 	$if $ordering == RELEASE || $ordering == ACQUIRE_RELEASE:
-	    $failure_ordering = AtomicOrdering.SEQ_CONSISTENT;
+	    $load_ordering = AtomicOrdering.SEQ_CONSISTENT;
 	$endif
 	
 	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
@@ -561,10 +557,10 @@ macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 	$StorageType storage_new_value = bitcast(new_value, $StorageType);
 	
 	do {
-		storage_old_value = $$atomic_load(storage_ptr, false, $ordering.ordinal);
+		storage_old_value = $$atomic_load(storage_ptr, false, $load_ordering.ordinal);
 		old_value = bitcast(storage_old_value, $typeof(*ptr));
 		if (old_value <= new_value) break;
-	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $failure_ordering) != storage_old_value);
+	} while (mem::compare_exchange(storage_ptr, storage_old_value, storage_new_value, $ordering, $load_ordering) != storage_old_value);
 
 	return old_value;
 }

--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -13,7 +13,7 @@ module std::atomic;
  **/
 macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
   $StorageType* storage_ptr = ($StorageType*)ptr;
 
@@ -43,7 +43,7 @@ macro fetch_add(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_sub(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
   $StorageType* storage_ptr = ($StorageType*)ptr;
 
@@ -216,7 +216,7 @@ macro flag_clear(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
   $StorageType* storage_ptr = ($StorageType*)ptr;
 
@@ -245,7 +245,7 @@ macro fetch_max(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
   $StorageType* storage_ptr = ($StorageType*)ptr;
 
@@ -274,7 +274,7 @@ macro fetch_min(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
   $StorageType* storage_ptr = ($StorageType*)ptr;
 
@@ -304,7 +304,7 @@ macro fetch_mul(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
  **/
 macro fetch_div(ptr, y, AtomicOrdering $ordering = SEQ_CONSISTENT)
 {
-	var $StorageType = $typefrom(types::get_atomic_compatible_type($typeof(*ptr)));
+	var $StorageType = $typefrom(types::lower_to_atomic_compatible_type($typeof(*ptr)));
 
   $StorageType* storage_ptr = ($StorageType*)ptr;
 

--- a/lib/std/core/mem.c3
+++ b/lib/std/core/mem.c3
@@ -62,11 +62,19 @@ macro void @atomic_store(&x, value, AtomicOrdering $ordering = SEQ_CONSISTENT, $
 	$$atomic_store(x, value, $volatile, (int)$ordering);
 }
 
+/**
+ * @require $success != AtomicOrdering.NOT_ATOMIC && $success != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
+ * @require $failure != AtomicOrdering.RELEASE && $failure != AtomicOrdering.ACQUIRE_RELEASE "Acquire release is not valid."
+ **/
 macro compare_exchange(ptr, compare, value, AtomicOrdering $success = SEQ_CONSISTENT, AtomicOrdering $failure = SEQ_CONSISTENT, bool $volatile = true, bool $weak = false, usz $alignment = 0)
 {
 	return $$compare_exchange(ptr, compare, value, $volatile, $weak, $success.ordinal, $failure.ordinal, $alignment);
 }
 
+/**
+ * @require $success != AtomicOrdering.NOT_ATOMIC && $success != AtomicOrdering.UNORDERED "Acquire ordering is not valid."
+ * @require $failure != AtomicOrdering.RELEASE && $failure != AtomicOrdering.ACQUIRE_RELEASE "Acquire release is not valid."
+ **/
 macro compare_exchange_volatile(ptr, compare, value, AtomicOrdering $success = SEQ_CONSISTENT, AtomicOrdering $failure = SEQ_CONSISTENT)
 {
 	return compare_exchange(ptr, compare, value, $success, $failure, true);

--- a/lib/std/core/types.c3
+++ b/lib/std/core/types.c3
@@ -208,14 +208,14 @@ macro bool may_load_atomic($Type)
 	$endswitch
 }
 
-macro get_atomic_compatible_type($Type) 
+macro lower_to_atomic_compatible_type($Type) 
 {
 	$switch ($Type.kindof)
     $case SIGNED_INT:
 	  $case UNSIGNED_INT:
       return $Type.typeid;
 		$case DISTINCT:
-			return get_atomic_compatible_type($Type.inner);
+			return lower_to_atomic_compatible_type($Type.inner);
 		$case FLOAT:
 			$switch ($Type)
 				$case float16: 

--- a/lib/std/core/types.c3
+++ b/lib/std/core/types.c3
@@ -208,6 +208,32 @@ macro bool may_load_atomic($Type)
 	$endswitch
 }
 
+macro get_atomic_compatible_type($Type) 
+{
+	$switch ($Type.kindof)
+    $case SIGNED_INT:
+	  $case UNSIGNED_INT:
+      return $Type.typeid;
+		$case DISTINCT:
+			return get_atomic_compatible_type($Type.inner);
+		$case FLOAT:
+			$switch ($Type)
+				$case float16: 
+					return ushort.typeid;
+				$case float: 
+					return uint.typeid;
+				$case double:
+					return ulong.typeid;
+				$case float128:
+					return uint128.typeid;
+				$default: 
+					return void.typeid;
+			$endswitch
+		$default:
+			return void.typeid;
+  $endswitch
+}
+
 macro bool is_promotable_to_floatlike($Type) => types::is_floatlike($Type) || types::is_int($Type);
 macro bool is_promotable_to_float($Type) => types::is_float($Type) || types::is_int($Type);
 

--- a/test/unit/stdlib/atomic.c3
+++ b/test/unit/stdlib/atomic.c3
@@ -79,6 +79,78 @@ fn void! sub() @test
 	assert(a == 0, "Threads returned %d, expected %d", a, 0);
 }
 
+fn void! max() @test
+{
+	Thread[100] ts;
+	a = 0;
+	foreach (&t : ts)
+	{
+    t.create(fn int(void* arg) {
+      uint la = 0;
+      thread::sleep_ms(5);
+      atomic::fetch_max(&a, la);
+      la++;
+      thread::sleep_ms(5);
+      atomic::fetch_max(&a, la);
+      la++;
+      thread::sleep_ms(5);
+      atomic::fetch_max(&a, la);
+      la++;
+      thread::sleep_ms(5);
+      atomic::fetch_max(&a, la);
+      la++;
+      thread::sleep_ms(5);
+      atomic::fetch_max(&a, la);
+      la++;
+      thread::sleep_ms(5);
+      atomic::fetch_max(&a, la);
+      la++;
+        return 0;
+    }, null)!;
+	}
+	foreach (&t : ts)
+  {
+    assert(t.join()! == 0);
+  }
+	assert(a == 5, "Threads returned %d, expected %d", a, 5);
+}
+
+fn void! min() @test
+{
+	Thread[100] ts;
+	a = 10;
+	foreach (&t : ts)
+	{
+    t.create(fn int(void* arg) {
+      uint la = 5;
+      thread::sleep_ms(5);
+      atomic::fetch_min(&a, la);
+      la--;
+      thread::sleep_ms(5);
+      atomic::fetch_min(&a, la);
+      la--;
+      thread::sleep_ms(5);
+      atomic::fetch_min(&a, la);
+      la--;
+      thread::sleep_ms(5);
+      atomic::fetch_min(&a, la);
+      la--;
+      thread::sleep_ms(5);
+      atomic::fetch_min(&a, la);
+      la--;
+      thread::sleep_ms(5);
+      atomic::fetch_min(&a, la);
+      la--;
+        return 0;
+    }, null)!;
+	}
+	foreach (&t : ts)
+  {
+    assert(t.join()! == 0);
+  }
+	assert(a == 0, "Threads returned %d, expected %d", a, 0);
+}
+
 fn void! fadd() @test
 {
 	Thread[100] ts;

--- a/test/unit/stdlib/atomic.c3
+++ b/test/unit/stdlib/atomic.c3
@@ -79,6 +79,25 @@ fn void! sub() @test
 	assert(a == 0, "Threads returned %d, expected %d", a, 0);
 }
 
+fn void! div() @test
+{
+	Thread[8] ts;
+	a = 8 * 8 * 8 * 8 * 8 * 8 * 8 * 8 * 8;
+	foreach (&t : ts)
+	{
+    t.create(fn int(void* arg) {
+      thread::sleep_ms(5);
+      atomic::fetch_div(&a, 8);
+        return 0;
+    }, null)!;
+	}
+	foreach (&t : ts)
+  {
+    assert(t.join()! == 0);
+  }
+	assert(a == 8, "Threads returned %d, expected %d", a, 8);
+}
+
 fn void! max() @test
 {
 	Thread[100] ts;

--- a/test/unit/stdlib/atomic.c3
+++ b/test/unit/stdlib/atomic.c3
@@ -3,6 +3,7 @@ import std::io;
 import std::atomic;
 
 uint a;
+float fa;
 
 fn void! add() @test
 {
@@ -76,4 +77,78 @@ fn void! sub() @test
     assert(t.join()! == 0);
   }
 	assert(a == 0, "Threads returned %d, expected %d", a, 0);
+}
+
+fn void! fadd() @test
+{
+	Thread[100] ts;
+	fa = 0;
+	foreach (&t : ts)
+	{
+    t.create(fn int(void* arg) {
+      thread::sleep_ms(5);
+      atomic::fetch_add(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&fa, 0.5f);
+        return 0;
+    }, null)!;
+	}
+	foreach (&t : ts)
+  {
+    assert(t.join()! == 0);
+  }
+	assert(fa == ts.len * 10 * 0.5, "Threads returned %f, expected %f", fa, ts.len * 10 * 0.5);
+}
+
+fn void! fsub() @test
+{
+	Thread[100] ts;
+	fa = ts.len * 10 * 0.5;
+	foreach (&t : ts)
+	{
+    t.create(fn int(void* arg) {
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&fa, 0.5f);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&fa, 0.5f);
+        return 0;
+    }, null)!;
+	}
+	foreach (&t : ts)
+  {
+    assert(t.join()! == 0);
+  }
+	assert(fa == 0, "Threads returned %f, expected %f", fa, 0);
 }

--- a/test/unit/stdlib/atomic.c3
+++ b/test/unit/stdlib/atomic.c3
@@ -11,34 +11,34 @@ fn void! add() @test
 	a = 0;
 	foreach (&t : ts)
 	{
-    t.create(fn int(void* arg) {
-      thread::sleep_ms(5);
-      atomic::fetch_add(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&a, 5);
-        return 0;
-    }, null)!;
+		t.create(fn int(void* arg) {
+			thread::sleep_ms(5);
+			atomic::fetch_add(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&a, 5);
+				return 0;
+		}, null)!;
 	}
 	foreach (&t : ts)
-  {
-    assert(t.join()! == 0);
-  }
+	{
+		assert(t.join()! == 0);
+	}
 	assert(a == ts.len * 10 * 5, "Threads returned %d, expected %d", a, ts.len * 10 * 5);
 }
 
@@ -48,34 +48,34 @@ fn void! sub() @test
 	a = ts.len * 10 * 5;
 	foreach (&t : ts)
 	{
-    t.create(fn int(void* arg) {
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&a, 5);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&a, 5);
-        return 0;
-    }, null)!;
+		t.create(fn int(void* arg) {
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&a, 5);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&a, 5);
+				return 0;
+		}, null)!;
 	}
 	foreach (&t : ts)
-  {
-    assert(t.join()! == 0);
-  }
+	{
+		assert(t.join()! == 0);
+	}
 	assert(a == 0, "Threads returned %d, expected %d", a, 0);
 }
 
@@ -85,16 +85,16 @@ fn void! div() @test
 	a = 8 * 8 * 8 * 8 * 8 * 8 * 8 * 8 * 8;
 	foreach (&t : ts)
 	{
-    t.create(fn int(void* arg) {
-      thread::sleep_ms(5);
-      atomic::fetch_div(&a, 8);
-        return 0;
-    }, null)!;
+		t.create(fn int(void* arg) {
+			thread::sleep_ms(5);
+			atomic::fetch_div(&a, 8);
+				return 0;
+		}, null)!;
 	}
 	foreach (&t : ts)
-  {
-    assert(t.join()! == 0);
-  }
+	{
+		assert(t.join()! == 0);
+	}
 	assert(a == 8, "Threads returned %d, expected %d", a, 8);
 }
 
@@ -104,33 +104,33 @@ fn void! max() @test
 	a = 0;
 	foreach (&t : ts)
 	{
-    t.create(fn int(void* arg) {
-      uint la = 0;
-      thread::sleep_ms(5);
-      atomic::fetch_max(&a, la);
-      la++;
-      thread::sleep_ms(5);
-      atomic::fetch_max(&a, la);
-      la++;
-      thread::sleep_ms(5);
-      atomic::fetch_max(&a, la);
-      la++;
-      thread::sleep_ms(5);
-      atomic::fetch_max(&a, la);
-      la++;
-      thread::sleep_ms(5);
-      atomic::fetch_max(&a, la);
-      la++;
-      thread::sleep_ms(5);
-      atomic::fetch_max(&a, la);
-      la++;
-        return 0;
-    }, null)!;
+		t.create(fn int(void* arg) {
+			uint la = 0;
+			thread::sleep_ms(5);
+			atomic::fetch_max(&a, la);
+			la++;
+			thread::sleep_ms(5);
+			atomic::fetch_max(&a, la);
+			la++;
+			thread::sleep_ms(5);
+			atomic::fetch_max(&a, la);
+			la++;
+			thread::sleep_ms(5);
+			atomic::fetch_max(&a, la);
+			la++;
+			thread::sleep_ms(5);
+			atomic::fetch_max(&a, la);
+			la++;
+			thread::sleep_ms(5);
+			atomic::fetch_max(&a, la);
+			la++;
+				return 0;
+		}, null)!;
 	}
 	foreach (&t : ts)
-  {
-    assert(t.join()! == 0);
-  }
+	{
+		assert(t.join()! == 0);
+	}
 	assert(a == 5, "Threads returned %d, expected %d", a, 5);
 }
 
@@ -140,33 +140,33 @@ fn void! min() @test
 	a = 10;
 	foreach (&t : ts)
 	{
-    t.create(fn int(void* arg) {
-      uint la = 5;
-      thread::sleep_ms(5);
-      atomic::fetch_min(&a, la);
-      la--;
-      thread::sleep_ms(5);
-      atomic::fetch_min(&a, la);
-      la--;
-      thread::sleep_ms(5);
-      atomic::fetch_min(&a, la);
-      la--;
-      thread::sleep_ms(5);
-      atomic::fetch_min(&a, la);
-      la--;
-      thread::sleep_ms(5);
-      atomic::fetch_min(&a, la);
-      la--;
-      thread::sleep_ms(5);
-      atomic::fetch_min(&a, la);
-      la--;
-        return 0;
-    }, null)!;
+		t.create(fn int(void* arg) {
+			uint la = 5;
+			thread::sleep_ms(5);
+			atomic::fetch_min(&a, la);
+			la--;
+			thread::sleep_ms(5);
+			atomic::fetch_min(&a, la);
+			la--;
+			thread::sleep_ms(5);
+			atomic::fetch_min(&a, la);
+			la--;
+			thread::sleep_ms(5);
+			atomic::fetch_min(&a, la);
+			la--;
+			thread::sleep_ms(5);
+			atomic::fetch_min(&a, la);
+			la--;
+			thread::sleep_ms(5);
+			atomic::fetch_min(&a, la);
+			la--;
+				return 0;
+		}, null)!;
 	}
 	foreach (&t : ts)
-  {
-    assert(t.join()! == 0);
-  }
+	{
+		assert(t.join()! == 0);
+	}
 	assert(a == 0, "Threads returned %d, expected %d", a, 0);
 }
 
@@ -176,34 +176,34 @@ fn void! fadd() @test
 	fa = 0;
 	foreach (&t : ts)
 	{
-    t.create(fn int(void* arg) {
-      thread::sleep_ms(5);
-      atomic::fetch_add(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_add(&fa, 0.5f);
-        return 0;
-    }, null)!;
+		t.create(fn int(void* arg) {
+			thread::sleep_ms(5);
+			atomic::fetch_add(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_add(&fa, 0.5f);
+				return 0;
+		}, null)!;
 	}
 	foreach (&t : ts)
-  {
-    assert(t.join()! == 0);
-  }
+	{
+		assert(t.join()! == 0);
+	}
 	assert(fa == ts.len * 10 * 0.5, "Threads returned %f, expected %f", fa, ts.len * 10 * 0.5);
 }
 
@@ -213,33 +213,33 @@ fn void! fsub() @test
 	fa = ts.len * 10 * 0.5;
 	foreach (&t : ts)
 	{
-    t.create(fn int(void* arg) {
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&fa, 0.5f);
-      thread::sleep_ms(5);
-      atomic::fetch_sub(&fa, 0.5f);
-        return 0;
-    }, null)!;
+		t.create(fn int(void* arg) {
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&fa, 0.5f);
+			thread::sleep_ms(5);
+			atomic::fetch_sub(&fa, 0.5f);
+				return 0;
+		}, null)!;
 	}
 	foreach (&t : ts)
-  {
-    assert(t.join()! == 0);
-  }
+	{
+		assert(t.join()! == 0);
+	}
 	assert(fa == 0, "Threads returned %f, expected %f", fa, 0);
 }

--- a/test/unit/stdlib/atomic.c3
+++ b/test/unit/stdlib/atomic.c3
@@ -1,0 +1,79 @@
+import std::thread;
+import std::io;
+import std::atomic;
+
+uint a;
+
+fn void! add() @test
+{
+	Thread[100] ts;
+	a = 0;
+	foreach (&t : ts)
+	{
+    t.create(fn int(void* arg) {
+      thread::sleep_ms(5);
+      atomic::fetch_add(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_add(&a, 5);
+        return 0;
+    }, null)!;
+	}
+	foreach (&t : ts)
+  {
+    assert(t.join()! == 0);
+  }
+	assert(a == ts.len * 10 * 5, "Threads returned %d, expected %d", a, ts.len * 10 * 5);
+}
+
+fn void! sub() @test
+{
+	Thread[100] ts;
+	a = ts.len * 10 * 5;
+	foreach (&t : ts)
+	{
+    t.create(fn int(void* arg) {
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&a, 5);
+      thread::sleep_ms(5);
+      atomic::fetch_sub(&a, 5);
+        return 0;
+    }, null)!;
+	}
+	foreach (&t : ts)
+  {
+    assert(t.join()! == 0);
+  }
+	assert(a == 0, "Threads returned %d, expected %d", a, 0);
+}

--- a/test/unit/stdlib/atomic_types.c3
+++ b/test/unit/stdlib/atomic_types.c3
@@ -1,0 +1,154 @@
+import std::thread;
+import std::io;
+import std::atomic::types;
+
+Atomic(<uint>) a;
+Atomic(<float>) fa;
+
+fn void! add() @test
+{
+	Thread[100] ts;
+	a.store(0);
+	foreach (&t : ts)
+	{
+		t.create(fn int(void* arg) {
+			thread::sleep_ms(5);
+			a.add(5);
+			thread::sleep_ms(5);
+			a.add(5);
+			thread::sleep_ms(5);
+			a.add(5);
+			thread::sleep_ms(5);
+			a.add(5);
+			thread::sleep_ms(5);
+			a.add(5);
+			thread::sleep_ms(5);
+			a.add(5);
+			thread::sleep_ms(5);
+			a.add(5);
+			thread::sleep_ms(5);
+			a.add(5);
+			thread::sleep_ms(5);
+			a.add(5);
+			thread::sleep_ms(5);
+			a.add(5);
+				return 0;
+		}, null)!;
+	}
+	foreach (&t : ts)
+	{
+		assert(t.join()! == 0);
+	}
+	assert(a.load() == ts.len * 10 * 5, "Threads returned %d, expected %d", a.load(), ts.len * 10 * 5);
+}
+
+fn void! sub() @test
+{
+	Thread[100] ts;
+	a.store(ts.len * 10 * 5);
+	foreach (&t : ts)
+	{
+		t.create(fn int(void* arg) {
+			thread::sleep_ms(5);
+			a.sub(5);
+			thread::sleep_ms(5);
+			a.sub(5);
+			thread::sleep_ms(5);
+			a.sub(5);
+			thread::sleep_ms(5);
+			a.sub(5);
+			thread::sleep_ms(5);
+			a.sub(5);
+			thread::sleep_ms(5);
+			a.sub(5);
+			thread::sleep_ms(5);
+			a.sub(5);
+			thread::sleep_ms(5);
+			a.sub(5);
+			thread::sleep_ms(5);
+			a.sub(5);
+			thread::sleep_ms(5);
+			a.sub(5);
+				return 0;
+		}, null)!;
+	}
+	foreach (&t : ts)
+	{
+		assert(t.join()! == 0);
+	}
+	assert(a.load() == 0, "Threads returned %d, expected %d", a.load(), 0);
+}
+
+fn void! fadd() @test
+{
+	Thread[100] ts;
+	fa.store(0);
+	foreach (&t : ts)
+	{
+		t.create(fn int(void* arg) {
+			thread::sleep_ms(5);
+			fa.add(0.5);
+			thread::sleep_ms(5);
+			fa.add(0.5);
+			thread::sleep_ms(5);
+			fa.add(0.5);
+			thread::sleep_ms(5);
+			fa.add(0.5);
+			thread::sleep_ms(5);
+			fa.add(0.5);
+			thread::sleep_ms(5);
+			fa.add(0.5);
+			thread::sleep_ms(5);
+			fa.add(0.5);
+			thread::sleep_ms(5);
+			fa.add(0.5);
+			thread::sleep_ms(5);
+			fa.add(0.5);
+			thread::sleep_ms(5);
+			fa.add(0.5);
+				return 0;
+		}, null)!;
+	}
+	foreach (&t : ts)
+	{
+		assert(t.join()! == 0);
+	}
+	assert(fa.load() == ts.len * 10 * 0.5, "Threads returned %f, expected %f", fa.load(), ts.len * 10 * 0.5);
+}
+
+fn void! fsub() @test
+{
+	Thread[100] ts;
+	fa.store(ts.len * 10 * 0.5);
+	foreach (&t : ts)
+	{
+		t.create(fn int(void* arg) {
+			thread::sleep_ms(5);
+			fa.sub(0.5);
+			thread::sleep_ms(5);
+			fa.sub(0.5);
+			thread::sleep_ms(5);
+			fa.sub(0.5);
+			thread::sleep_ms(5);
+			fa.sub(0.5);
+			thread::sleep_ms(5);
+			fa.sub(0.5);
+			thread::sleep_ms(5);
+			fa.sub(0.5);
+			thread::sleep_ms(5);
+			fa.sub(0.5);
+			thread::sleep_ms(5);
+			fa.sub(0.5);
+			thread::sleep_ms(5);
+			fa.sub(0.5);
+			thread::sleep_ms(5);
+			fa.sub(0.5);
+				return 0;
+		}, null)!;
+	}
+	foreach (&t : ts)
+	{
+		assert(t.join()! == 0);
+	}
+	assert(fa.load() == 0, "Threads returned %f, expected %f", fa.load(), 0);
+}


### PR DESCRIPTION
Using compare_exchange is possible to implement C11 atomics in a generic way.
The implementation used for these atomics use the well known do_while_cas loop.

- Most of c11 atomics is supported, also max and min have been added.
- Made in a way where floating point numbers is also supported
- Attached tests only account for add, sub, float add, float sub, max, min.

A later benchmark should be done when hardware atomics are implemented.