### PR TITLE
Fixes `$$set_rounding_mode` builtin.

### DIFF
--- a/src/compiler/sema_builtins.c
+++ b/src/compiler/sema_builtins.c
@@ -321,7 +321,6 @@ bool sema_expr_analyse_builtin_call(SemaContext *context, Expr *expr)
 		case BUILTIN_SET_ROUNDING_MODE:
 			assert(arg_count == 1);
 			if (!sema_check_builtin_args(args, (BuiltinArg[]) { BA_INTEGER }, 1)) return false;
-			if (!sema_check_builtin_args_match(args, 1)) return false;
 			rtype = type_void;
 			break;
 		case BUILTIN_SYSCALL:

--- a/test/test_suite/builtins/rounding_builtins.c3t
+++ b/test/test_suite/builtins/rounding_builtins.c3t
@@ -29,6 +29,8 @@ fn void main()
     double[<2>] vd9 = $$round(vd);
     double[<2>] vd10 = $$roundeven(vd);
 
+    $$set_rounding_mode(0);
+
     return;
 }
 
@@ -46,3 +48,4 @@ fn void main()
   %19 = call <2 x double> @llvm.rint.v2f64(<2 x double> %18)
   %21 = call <2 x double> @llvm.round.v2f64(<2 x double> %20)
   %23 = call <2 x double> @llvm.roundeven.v2f64(<2 x double> %22)
+  call void @llvm.set.rounding(i32 0)


### PR DESCRIPTION
Added testing only `$$set_rounding_mode` because `$$get_rounding_mode()` calls `llvm.flt.rounds` for LLVM < 16.