### PR TITLE
sema_asm: Do not initialize asm multiple times

### DIFF
--- a/src/compiler/sema_asm.c
+++ b/src/compiler/sema_asm.c
@@ -488,7 +488,11 @@ bool sema_analyse_asm(SemaContext *context, AsmInlineBlock *block, Ast *asm_stmt
 		SEMA_ERROR(asm_stmt, "Unsupported architecture for asm.");
 		return false;
 	}
-	init_asm();
+	static bool initialized_asm = false;
+	if (!initialized_asm) {
+		init_asm();
+		initialized_asm = true;
+	}
 	AsmInstruction *instr = asm_instr_by_name(asm_stmt->asm_stmt.instruction);
 	if (!instr)
 	{


### PR DESCRIPTION
`init_asm` is called on each asm block. This is not needed.
At some point, with enough asm blocks, asm_target:reg_register will be stuck in the infinite loop.