### PR TITLE
Correctly deduce the return type for macros with implicit return. See…

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -170,6 +170,7 @@
 - Added posix socket functions.
 
 ### Fixes
+- Macros with implicit return didn't correctly deduct the return type.
 - Reevaluating a bitstruct (due to checked) would break.
 - Fix missing comparison between `any`.
 - Fix issue of designated initializers containing bitstructs.

--- a/src/compiler/sema_stmts.c
+++ b/src/compiler/sema_stmts.c
@@ -426,12 +426,16 @@ static inline bool sema_analyse_block_exit_stmt(SemaContext *context, Ast *state
 	statement->ast_kind = AST_BLOCK_EXIT_STMT;
 	context->active_scope.jump_end = true;
 	Type *block_type = context->expected_block_type;
+	if (type_is_optional(block_type))
+	{
+		puts("foek");
+	}
 	Expr *ret_expr = statement->return_stmt.expr;
 	if (ret_expr)
 	{
 		if (block_type)
 		{
-			if (!sema_analyse_expr_rhs(context, block_type, ret_expr, type_is_optional(block_type))) return false;
+			if (!sema_analyse_expr_rhs(context, block_type, ret_expr, true)) return false;
 		}
 		else
 		{

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define COMPILER_VERSION "0.4.662"
+#define COMPILER_VERSION "0.4.663"

--- a/test/test_suite/errors/no_common.c3
+++ b/test/test_suite/errors/no_common.c3
@@ -4,7 +4,7 @@ fn int! abc()
 }
 macro test()
 {
-	abc()!;
+	return @catch(abc())?;
 }
 
 fn void main()

--- a/test/test_suite/errors/optional_sizeof.c3
+++ b/test/test_suite/errors/optional_sizeof.c3
@@ -4,7 +4,7 @@ fn int! abc()
 }
 macro test()
 {
-	abc()!;
+	return @catch(abc())?;
 }
 
 fn void a()

--- a/test/test_suite/macros/implicit_return_opt.c3
+++ b/test/test_suite/macros/implicit_return_opt.c3
@@ -1,0 +1,19 @@
+module test;
+import std::io;
+
+fn void! main()
+{
+	int x = run()!; // #error: You cannot cast
+	io::printfn("x=%d", x);
+}
+
+macro run()
+{
+	int i;
+	while (true)
+	{
+		i++;
+		if (i > 10) break;
+		if (i > 100) return IoError.EOF?;
+	}
+}


### PR DESCRIPTION
… #1018.