### PR TITLE
Add more paths to search for the standard library

### DIFF
--- a/src/utils/file_utils.c
+++ b/src/utils/file_utils.c
@@ -381,10 +381,15 @@ const char *find_lib_dir(void)
 		path[strlen_path - 1] = '\0';
 	}
 	const char *lib_path = NULL;
+	if ((lib_path = lib_find(path, "/../lib/c3"))) goto DONE;
 	if ((lib_path = lib_find(path, "/../lib/"))) goto DONE;
+	if ((lib_path = lib_find(path, "/lib/c3"))) goto DONE;
 	if ((lib_path = lib_find(path, "/lib/"))) goto DONE;
+	if ((lib_path = lib_find(path, "/c3"))) goto DONE;
 	if ((lib_path = lib_find(path, "/"))) goto DONE;
+	if ((lib_path = lib_find(path, "/../c3"))) goto DONE;
 	if ((lib_path = lib_find(path, "/../"))) goto DONE;
+	if ((lib_path = lib_find(path, "/../../lib/c3"))) goto DONE;
 	if ((lib_path = lib_find(path, "/../../lib/"))) goto DONE;
 
 	DEBUG_LOG("Could not find the standard library /lib/std/");


### PR DESCRIPTION
Module `std` is searched first in a `c3` subdirectory. Search directories are, in order and relative to the compiler executable location:
- `lib/c3` relative to the parent directory
- `lib` relative to the parent directory
- `/lib/c3`
- `/lib`
- `/c3`
- `/`
- `c3` relative to the parent directory
- the parent directory
- `lib/c3` relative to the grand-parent directory
- `lib` relative to the grand-parent directory