### PR TITLE
fix: standard library search paths

### DIFF
--- a/src/utils/file_utils.c
+++ b/src/utils/file_utils.c
@@ -381,15 +381,15 @@ const char *find_lib_dir(void)
 		path[strlen_path - 1] = '\0';
 	}
 	const char *lib_path = NULL;
-	if ((lib_path = lib_find(path, "/../lib/c3"))) goto DONE;
+	if ((lib_path = lib_find(path, "/../lib/c3/"))) goto DONE;
 	if ((lib_path = lib_find(path, "/../lib/"))) goto DONE;
-	if ((lib_path = lib_find(path, "/lib/c3"))) goto DONE;
+	if ((lib_path = lib_find(path, "/lib/c3/"))) goto DONE;
 	if ((lib_path = lib_find(path, "/lib/"))) goto DONE;
-	if ((lib_path = lib_find(path, "/c3"))) goto DONE;
+	if ((lib_path = lib_find(path, "/c3/"))) goto DONE;
 	if ((lib_path = lib_find(path, "/"))) goto DONE;
-	if ((lib_path = lib_find(path, "/../c3"))) goto DONE;
+	if ((lib_path = lib_find(path, "/../c3/"))) goto DONE;
 	if ((lib_path = lib_find(path, "/../"))) goto DONE;
-	if ((lib_path = lib_find(path, "/../../lib/c3"))) goto DONE;
+	if ((lib_path = lib_find(path, "/../../lib/c3/"))) goto DONE;
 	if ((lib_path = lib_find(path, "/../../lib/"))) goto DONE;
 
 	DEBUG_LOG("Could not find the standard library /lib/std/");


### PR DESCRIPTION
Path construction for locating the standard library expects ending slashes.