### PR TITLE
Allow omitting `= true` for designated initializers of bitstruct bools.

### DIFF
--- a/resources/grammar/grammar.y
+++ b/resources/grammar/grammar.y
@@ -441,6 +441,7 @@ param_path
 
 arg
 	: param_path '=' expr
+	| param_path
 	| type
 	| param_path '=' type
 	| expr

--- a/src/compiler/expr.c
+++ b/src/compiler/expr.c
@@ -211,6 +211,7 @@ bool expr_is_constant_eval(Expr *expr, ConstantEvalKind eval_kind)
 			return expr_list_is_constant_eval(expr->cond_expr, eval_kind);
 		case EXPR_DESIGNATOR:
 			expr = expr->designator_expr.value;
+			if (!expr) return true;
 			goto RETRY;
 		case EXPR_EXPR_BLOCK:
 		case EXPR_DECL:

--- a/src/compiler/parse_expr.c
+++ b/src/compiler/parse_expr.c
@@ -465,7 +465,7 @@ Expr *parse_vasplat(ParseContext *c)
 /**
  * param_list ::= ('...' arg | arg (',' arg)*)?
  *
- * parameter ::= (param_path '=')? expr
+ * parameter ::= ((param_path '=')? expr) | param_path
  */
 bool parse_arg_list(ParseContext *c, Expr ***result, TokenType param_end, bool *splat, bool vasplat)
 {
@@ -483,11 +483,9 @@ bool parse_arg_list(ParseContext *c, Expr ***result, TokenType param_end, bool *
 			expr = expr_new(EXPR_DESIGNATOR, start_span);
 			expr->designator_expr.path = path;
 
-			// Expect the '=' after.
-			CONSUME_OR_RET(TOKEN_EQ, false);
-
-			// Now parse the rest
-			ASSIGN_EXPR_OR_RET(expr->designator_expr.value, parse_expr(c), false);
+			if (try_consume(c, TOKEN_EQ)) {
+				ASSIGN_EXPR_OR_RET(expr->designator_expr.value, parse_expr(c), false);
+			}
 
 			RANGE_EXTEND_PREV(expr);
 		}

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -1331,6 +1331,10 @@ INLINE bool sema_call_expand_arguments(SemaContext *context, CalledDecl *callee,
 			}
 
 			// 8g. Set the parameter
+			if (!arg->designator_expr.value)
+			{
+				RETURN_SEMA_ERROR(arg, "Expected a value for this argument.");
+			}
 			actual_args[index] = arg->designator_expr.value;
 			continue;
 		}

--- a/test/test_suite/bitstruct/bitstruct_init.c3
+++ b/test/test_suite/bitstruct/bitstruct_init.c3
@@ -60,3 +60,45 @@ fn void test3()
 {
     Foo abc = { .x = -4, .z = 0, .y = 8 }; // #error: would be truncated
 }
+
+bitstruct Flags1 : int
+{
+    bool a;
+    bool b;
+    bool c;
+}
+
+distinct Bool = bool;
+
+bitstruct Flags2 : int
+{
+    bool a : 0;
+    Bool b : 1;
+    int  c : 2..3;
+    bool d : 6;
+}
+
+struct Flags2_Struct
+{
+    bool a;
+    bool b;
+    int c;
+    bool d;
+}
+
+fn void test4()
+{
+    Flags1 flags1 = {.a, .b, .c};
+    flags1 = {.a};
+    flags1 = {.a = true, .b = true, .c = false};
+    flags1 = {.a, .b = true, .c = true}; // #error: Mixing the omission
+    Foo foo = { .x = 0, .z }; // #error: needs a value
+
+    Flags2 flags2 = {.b, .d};
+    flags2 = {.b, .c, .d}; // #error: needs a value
+    flags2 = {.a, .c = 1, .d}; // #error: Mixing the omission
+
+    Flags2_Struct flags2s;
+    flags2s = {.b, .c, .d}; // #error: needs a value
+    flags2s = {.a, .c = 1, .d}; // #error: needs a value
+}


### PR DESCRIPTION
Allow the shorthand `{.flag1, .flag2, .flag3}` instead of `{.flag1 = true, .flag2 = true, .flag3 = true}` if all the initializers are bitstruct bools. Mixing the two is not allowed.