### PR TITLE
Small fixes to stdlib.

### DIFF
--- a/lib/std/core/env.c3
+++ b/lib/std/core/env.c3
@@ -116,8 +116,8 @@ enum ArchType
 
 const OsType OS_TYPE = (OsType)$$OS_TYPE;
 const ArchType ARCH_TYPE = (ArchType)$$ARCH_TYPE;
-const bool ARCH_32_BIT = $$REGISTER_SIZE == 4;
-const bool ARCH_64_BIT = $$REGISTER_SIZE == 8;
+const bool ARCH_32_BIT = $$REGISTER_SIZE == 32;
+const bool ARCH_64_BIT = $$REGISTER_SIZE == 64;
 const bool LIBC = $$COMPILER_LIBC_AVAILABLE;
 const bool NO_LIBC = !$$COMPILER_LIBC_AVAILABLE;
 const CompilerOptLevel COMPILER_OPT_LEVEL = (CompilerOptLevel)$$COMPILER_OPT_LEVEL;

--- a/lib/std/os/win32/winuser.c3
+++ b/lib/std/os/win32/winuser.c3
@@ -131,7 +131,8 @@ extern fn Win32_BOOL showWindow(Win32_HWND, CInt) @extern("ShowWindow");
 extern fn Win32_BOOL translateMessage(Win32_MSG* lpMsg) @extern("TranslateMessage");
 extern fn Win32_BOOL updateWindow(Win32_HWND) @extern("UpdateWindow");
 
-macro getWindowLongPtr(Win32_HWND hWnd, CInt nIndex) {
+macro getWindowLongPtr(Win32_HWND hWnd, CInt nIndex)
+{
 	$if env::ARCH_64_BIT:
 		return getWindowLongPtrW(hWnd, nIndex);
 	$else
@@ -139,7 +140,8 @@ macro getWindowLongPtr(Win32_HWND hWnd, CInt nIndex) {
 	$endif
 }
 
-macro setWindowLongPtr(Win32_HWND hWnd, CInt nIndex, dwNewLong) {
+macro setWindowLongPtr(Win32_HWND hWnd, CInt nIndex, dwNewLong)
+{
 	$if env::ARCH_64_BIT:
 		return setWindowLongPtrW(hWnd, nIndex, dwNewLong);
 	$else

--- a/lib/std/threads/os/thread_posix.c3
+++ b/lib/std/threads/os/thread_posix.c3
@@ -62,7 +62,7 @@ fn void! NativeMutex.lock_timeout(&self, ulong ms)
 	{
 		if (!ms) break;
 		ulong sleep = min(5, ms);
-		if (!libc::nanosleep(&& TimeSpec { .s = 0, .ns = (CLong)sleep * 1000_000 }, null)) return ThreadFault.LOCK_FAILED?;
+		if (!libc::nanosleep(&&time::ms(ms).to_timespec(), null)) return ThreadFault.LOCK_FAILED?;
 		ms -= sleep;
 	}
 	switch (result)

--- a/lib/std/threads/os/thread_win32.c3
+++ b/lib/std/threads/os/thread_win32.c3
@@ -90,8 +90,9 @@ fn void! NativeMutex.lock(&mtx)
 /**
  * @require mtx.timed "Only available for timed locks"
  **/
-fn void! NativeMutex.lock_timeout(&mtx, usz ms)
+fn void! NativeMutex.lock_timeout(&mtx, ulong ms)
 {
+	if (ms > uint.max) ms = uint.max;
 	switch (win32::waitForSingleObject(mtx.handle, (uint)ms))
 	{
 		case win32::WAIT_OBJECT_0:
@@ -244,9 +245,10 @@ fn void! NativeConditionVariable.wait(&cond, NativeMutex* mtx) @inline
 	return timedwait(cond, mtx, win32::INFINITE) @inline;
 }
 
-fn void! NativeConditionVariable.wait_timeout(&cond, NativeMutex* mtx, uint time) @inline
+fn void! NativeConditionVariable.wait_timeout(&cond, NativeMutex* mtx, ulong ms) @inline
 {
-	return timedwait(cond, mtx, time) @inline;
+	if (ms > uint.max) ms = uint.max;
+	return timedwait(cond, mtx, (uint)ms) @inline;
 }
 
 fn void! NativeThread.create(&thread, ThreadFn func, void* args)

--- a/lib/std/threads/thread.c3
+++ b/lib/std/threads/thread.c3
@@ -53,9 +53,9 @@ macro void! ConditionVariable.wait(&cond, Mutex* mutex)
 {
 	return NativeConditionVariable.wait((NativeConditionVariable*)cond, (NativeMutex*)mutex);
 }
-macro void! ConditionVariable.wait_timeout(&cond, Mutex* mutex, ulong timeout)
+macro void! ConditionVariable.wait_timeout(&cond, Mutex* mutex, ulong ms)
 {
-	return NativeConditionVariable.wait_timeout((NativeConditionVariable*)cond, (NativeMutex*)mutex, timeout);
+	return NativeConditionVariable.wait_timeout((NativeConditionVariable*)cond, (NativeMutex*)mutex, ms);
 }
 
 

--- a/lib/std/time/time.c3
+++ b/lib/std/time/time.c3
@@ -6,6 +6,7 @@ distinct Duration = long;
 distinct Clock = ulong;
 distinct NanoDuration (Printable) = long;
 
+const Duration US = 1;
 const Duration MS = 1_000;
 const Duration SEC = 1_000_000;
 const Duration MIN = 60 * SEC;
@@ -15,6 +16,7 @@ const Duration WEEK = 7 * DAY;
 const Duration MONTH = 30 * WEEK;
 const Duration YEAR = 36525 * DAY / 100;
 
+fn Duration us(long l) @inline => (Duration)l * US;
 fn Duration ms(long l) @inline => (Duration)l * MS;
 fn Duration sec(long l) @inline => (Duration)l * SEC;
 fn Duration min(long l) @inline => (Duration)l * MIN;

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -55,6 +55,10 @@
 - Updated sorting API.
 - Insertion sort and counting sort added.
 - Added missing `mem` and `mem::allocator` functions for aligned allocations.
+- Fixed posix `NativeMutex.lock_timeout`.
+- Fixed `env::ARCH_32_BIT` and `env::ARCH_64_BIT`.
+- Added `time::us`.
+
 
 ## 0.6.0 Change list
 


### PR DESCRIPTION
Match the signature of `NativeConditionVariable.wait_timeout` and `NativeMutex.lock_timeout` of thread_win32.c3 to `ConditionVariable.wait_timeout` and `TimedMutex.lock_timeout` to avoid casting errors.