### PR TITLE
Fix docker build issue in ubuntu kinetic

### DIFF
--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -26,13 +26,21 @@ else
     CMAKE_BUILD_TYPE="$config"
 fi
 
-UBUNTU_VERSION="22.10"
-LLVM_VERSION="15"
+UBUNTU_VERSION="22.04"
+UBUNTU_CODENAME=$( \
+    if [ "${UBUNTU_VERSION}" = "22.04" ]; then echo "jammy"; \
+    elif [ "${UBUNTU_VERSION}" = "20.04" ]; then echo "focal"; \
+    elif [ "${UBUNTU_VERSION}" = "18.04" ]; then echo "bionic"; \
+    else echo "unknown"; fi)
+
+LLVM_VERSION="17"
 
 IMAGE="$IMAGE:22"
 
 cd docker && $DOCKER build -t $IMAGE\
-    --build-arg DEPS="llvm-$LLVM_VERSION-dev liblld-$LLVM_VERSION-dev clang-$LLVM_VERSION libllvm$LLVM_VERSION llvm-$LLVM_VERSION-runtime" \
+    --build-arg DEPS="llvm-$LLVM_VERSION-dev liblld-$LLVM_VERSION-dev clang-$LLVM_VERSION libllvm$LLVM_VERSION llvm-$LLVM_VERSION-runtime libpolly-$LLVM_VERSION-dev" \
+	--build-arg LLVM_VERSION="$LLVM_VERSION" \
+	--build-arg UBUNTU_CODENAME="$UBUNTU_CODENAME" \
     --build-arg UBUNTU_VERSION="$UBUNTU_VERSION" .
 cd ..
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,10 +3,21 @@ ARG UBUNTU_VERSION
 FROM ubuntu:$UBUNTU_VERSION
 
 ARG DEPS
+ARG LLVM_VERSION
+ARG UBUNTU_CODENAME
 
-RUN export DEBIAN_FRONTEND=noninteractive && export TERM=xterm && apt-get update && apt-get install -y build-essential cmake zlib1g zlib1g-dev  \
-        $DEPS && \
-	rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y wget software-properties-common
+
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    add-apt-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-${LLVM_VERSION} main" && \
+    apt-get update && \
+    apt-get install -y build-essential cmake zlib1g zlib1g-dev curl \
+    llvm-${LLVM_VERSION}-dev liblld-${LLVM_VERSION}-dev clang-${LLVM_VERSION} libllvm${LLVM_VERSION} llvm-${LLVM_VERSION}-runtime \
+    ${DEPS} && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN export DEBIAN_FRONTEND=noninteractive && export TERM=xterm && apt-get update && apt-get install -y build-essential cmake zlib1g zlib1g-dev
 
 ARG GID=1000
 ARG UID=1000


### PR DESCRIPTION
The official ubuntu image in DockerHub does not contain `22.10` aka `Kinetic`. This merge request changes the `UBUNTU_VERSION` to `22.04` aka `Jammy`.

Changelog:

- Update `UBUNTU_VERSION` to `22.04` to build on Jammy
- Update `LLVM_VERSION` from 15 to 17 due to this [line](https://github.com/c3lang/c3c/blob/8d6dabf65c6df420b9030bc049f5ce3092cec01c/CMakeLists.txt#L84C44-L84C46) in `CmakeLists.txt`
- Add an `UBUNTU_CODENAME` variable which is used to pull LLVM for a specific Ubuntu version