### PR TITLE
Fix a warning/error where C compilers can not predict that a variable is initialized

### DIFF
--- a/src/compiler/llvm_codegen.c
+++ b/src/compiler/llvm_codegen.c
@@ -950,7 +950,8 @@ static inline void llvm_optimize(GenContext *c)
 #ifndef NDEBUG
 	should_debug = debug_log;
 #endif
-	LLVMOptLevels level;
+	LLVMOptLevels level = LLVM_O0;
+
 	switch (active_target.optsize)
 	{
 		case SIZE_OPTIMIZATION_SMALL:


### PR DESCRIPTION
I had an issue while trying to build the project because warnings are set to errors and the compiler can't tell that it is always initialized because of  the switch after it