### PR TITLE
Fix posix virtual memory reserve.

### DIFF
--- a/src/utils/vmem.h
+++ b/src/utils/vmem.h
@@ -11,9 +11,7 @@ typedef struct
 	void *ptr;
 	size_t allocated;
 	size_t size;
-#if PLATFORM_WINDOWS
 	size_t committed;
-#endif
 } Vmem;
 
 void vmem_init(Vmem *vmem, size_t size_in_mb);


### PR DESCRIPTION
Use `mprotect` to "commit" pages that are required. Even though pages are not actually committed to physical memory until touched, setting `PROT_WRITE` on the initial reserve appears to to matter for overcommit handling.

This fixes the 2 GB initial reserve issue for environments with low physical memory and/or where overcommitting is not allowed.

Additional reference:
https://www.kernel.org/doc/html/latest/mm/overcommit-accounting.html