### PR TITLE
Ignore EINTR returned from waitpid

### DIFF
--- a/src/compiler/subprocess.c
+++ b/src/compiler/subprocess.c
@@ -127,8 +127,11 @@ int run_subprocess(const char *name, const char **args)
 		int wstatus = 0;
 		if (waitpid(cpid, &wstatus, 0) < 0)
 		{
-			eprintf("Could not wait on %s (pid %d): %s\n", name, cpid, strerror(errno));
-			return -1;
+			if (errno != EINTR) {
+				eprintf("Could not wait on %s (pid %d): %s\n", name, cpid, strerror(errno));
+				return -1;
+			}
+			continue;
 		}
 
 		if (WIFEXITED(wstatus)) return WEXITSTATUS(wstatus);


### PR DESCRIPTION
Prompted by https://github.com/c3lang/c3c/pull/1296#issuecomment-2267119406

Initially I thought this is because we are using fork/exec instead of posix_spawn, but apparently waitpid is expected to return EINTR and for example musl just ignores such situations and tries to wait again.

https://github.com/bminor/musl/blob/dd1e63c3638d5f9afb857fccf6ce1415ca5f1b8b/src/process/system.c#L39

@lerno could you please try this fix and see if it works on your machine.