### PR TITLE
Project view command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ add_executable(c3c
         src/build/builder.c
         src/build/build_options.c
         src/build/project_creation.c
+        src/build/project_manipulation.c
         src/build/libraries.c
         src/compiler/ast.c
         src/compiler/bigint.c

--- a/src/build/build.h
+++ b/src/build/build.h
@@ -669,3 +669,4 @@ void update_build_target_with_opt_level(BuildTarget *target, OptimizationSetting
 void create_project(BuildOptions *build_options);
 void create_library(BuildOptions *build_options);
 void resolve_libraries(BuildTarget *build_target);
+void view_project(BuildOptions *build_options);

--- a/src/build/build.h
+++ b/src/build/build.h
@@ -45,7 +45,15 @@ typedef enum
 	COMMAND_TEST,
 	COMMAND_UNIT_TEST,
 	COMMAND_PRINT_SYNTAX,
+	COMMAND_PROJECT,
 } CompilerCommand;
+
+
+typedef enum
+{
+	SUBCOMMAND_MISSING = 0,
+	SUBCOMMAND_VIEW
+} ProjectSubcommand;
 
 typedef enum
 {
@@ -388,6 +396,7 @@ typedef struct BuildOptions_
 	unsigned version;
 	CompilerBackend backend;
 	CompilerCommand command;
+	ProjectSubcommand subcommand;
 	CompileOption compile_option;
 	TrustLevel trust_level;
 	DiagnosticsSeverity severity[DIAG_END_SENTINEL];

--- a/src/build/build_internal.h
+++ b/src/build/build_internal.h
@@ -110,3 +110,4 @@ void get_list_append_strings(const char *file, const char *target, JSONObject *j
                              const char *base, const char *override, const char *add);
 int get_valid_string_setting(const char *file, const char *target, JSONObject *json, const char *key, const char** values, int first_result, int count, const char *expected);
 void check_json_keys(const char* valid_keys[][2], size_t key_count, const char* deprecated_keys[], size_t deprecated_key_count, JSONObject *json, const char *target_name, const char *option);
+long get_valid_integer(JSONObject *table, const char *key, const char *category, bool mandatory);

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -79,6 +79,7 @@ static void usage(void)
 	PRINTF("  dynamic-lib <file1> [<file2> ...]                   Compile files without a project into a dynamic library.");
 	PRINTF("  headers <file1> [<file2> ...]                       Analyse files and generate C headers for public methods.");
 	PRINTF("  vendor-fetch <library> ...                          Fetches one or more libraries from the vendor collection.");
+	PRINTF("  project <subcommand> ...                            Manipulate or view project files.");
 	PRINTF("");
 	PRINTF("Options:");
 	PRINTF("  --tb                       - Use Tilde Backend for compilation.");
@@ -282,7 +283,7 @@ static void project_usage() {
 	PRINTF("Usage: %s [<options>] project <subcommand> [<args>]", args[0]);
 	PRINTF("");
 	PRINTF("Project Subcommands:");
-	PRINTF("    view            view the current projects structure");
+	PRINTF("  view              view the current projects structure");
 }
 
 static void parse_project_subcommand(BuildOptions *options) {

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -279,15 +279,18 @@ static void parse_optional_target(BuildOptions *options)
 	}
 }
 
-static void project_usage() {
+static void project_usage() 
+{
 	PRINTF("Usage: %s [<options>] project <subcommand> [<args>]", args[0]);
 	PRINTF("");
 	PRINTF("Project Subcommands:");
 	PRINTF("  view              view the current projects structure");
 }
 
-static void parse_project_subcommand(BuildOptions *options) {
-	if (arg_match("view")) {
+static void parse_project_subcommand(BuildOptions *options) 
+{
+	if (arg_match("view")) 
+	{
 		options->subcommand = SUBCOMMAND_VIEW;
 		return;
 	}
@@ -296,7 +299,8 @@ static void parse_project_subcommand(BuildOptions *options) {
 
 static void parse_project_options(BuildOptions *options)
 {
-	if (at_end()) {
+	if (at_end()) 
+	{
 		project_usage();
 		return;
 	}

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -299,7 +299,7 @@ static void parse_project_options(BuildOptions *options)
 		project_usage();
 		return;
 	}
-	++arg_index;
+	next_arg();
 	parse_project_subcommand(options);
 }
 

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -295,7 +295,7 @@ static void parse_project_subcommand(BuildOptions *options) {
 
 static void parse_project_options(BuildOptions *options)
 {
-	if (!at_end()) {
+	if (at_end()) {
 		project_usage();
 		return;
 	}

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -51,6 +51,7 @@ const char *trust_level[3] = {
 #define EOUTPUT(string, ...) fprintf(stderr, string "\n", ##__VA_ARGS__) // NOLINT
 #define PRINTF(string, ...) fprintf(stdout, string "\n", ##__VA_ARGS__) // NOLINT
 #define FAIL_WITH_ERR(string, ...) do { fprintf(stderr, "Error: " string "\n\n", ##__VA_ARGS__); usage(); exit_compiler(EXIT_FAILURE); } while (0) /* NOLINT */
+#define PROJECT_FAIL_WITH_ERR(string, ...) do { fprintf(stderr, "Error: " string "\n\n", ##__VA_ARGS__); project_usage(); exit_compiler(EXIT_FAILURE); } while (0) /* NOLINT */
 
 static void usage(void)
 {
@@ -277,6 +278,31 @@ static void parse_optional_target(BuildOptions *options)
 	}
 }
 
+static void project_usage() {
+	PRINTF("Usage: %s [<options>] project <subcommand> [<args>]", args[0]);
+	PRINTF("");
+	PRINTF("Project Subcommands:");
+	PRINTF("    view            view the current projects structure");
+}
+
+static void parse_project_subcommand(BuildOptions *options) {
+	if (arg_match("view")) {
+		options->subcommand = SUBCOMMAND_VIEW;
+		return;
+	}
+	PROJECT_FAIL_WITH_ERR("Cannot process the unknown subcommand \"%s\".", current_arg);
+}
+
+static void parse_project_options(BuildOptions *options)
+{
+	if (!at_end()) {
+		project_usage();
+		return;
+	}
+	++arg_index;
+	parse_project_subcommand(options);
+}
+
 static void parse_command(BuildOptions *options)
 {
 	if (arg_match("init"))
@@ -402,6 +428,13 @@ static void parse_command(BuildOptions *options)
 	{
 		options->command = COMMAND_BENCH;
 		parse_optional_target(options);
+		return;
+	}
+	if (arg_match("project"))
+	{
+		options->command = COMMAND_PROJECT;
+		options->subcommand = SUBCOMMAND_MISSING;
+		parse_project_options(options);
 		return;
 	}
 	FAIL_WITH_ERR("Cannot process the unknown command \"%s\".", current_arg);

--- a/src/build/builder.c
+++ b/src/build/builder.c
@@ -87,6 +87,7 @@ bool command_accepts_files(CompilerCommand command)
 		case COMMAND_BENCHMARK:
 		case COMMAND_TEST:
 		case COMMAND_VENDOR_FETCH:
+		case COMMAND_PROJECT:
 			return false;
 	}
 	UNREACHABLE
@@ -120,6 +121,7 @@ bool command_passes_args(CompilerCommand command)
 		case COMMAND_BENCHMARK:
 		case COMMAND_TEST:
 		case COMMAND_VENDOR_FETCH:
+		case COMMAND_PROJECT:
 			return false;
 	}
 	UNREACHABLE

--- a/src/build/common_build.c
+++ b/src/build/common_build.c
@@ -1,5 +1,6 @@
 #include "build_internal.h"
 #include "utils/common.h"
+#include <math.h>
 
 void check_json_keys(const char* valid_keys[][2], size_t key_count, const char* deprecated_keys[], size_t deprecated_key_count, JSONObject *json, const char *target_name, const char *option)
 {

--- a/src/build/common_build.c
+++ b/src/build/common_build.c
@@ -176,3 +176,21 @@ int get_valid_string_setting(const char *file, const char *target, JSONObject *j
 	}
 	error_exit("In file '%s': Invalid value for '%s', expected %s", file, key, expected);
 }
+
+long get_valid_integer(JSONObject *table, const char *key, const char *category, bool mandatory)
+{
+	JSONObject *value = json_obj_get(table, key);
+	if (!value)
+	{
+		if (mandatory)
+		{
+			error_exit("%s was missing a mandatory '%s' field, please add it.", category, key);
+		}
+		return -1;
+	}
+	if (value->type != J_NUMBER || trunc(value->f) != value->f)
+	{
+		error_exit("%s had an invalid mandatory '%s' field that was not an integer, please correct it.", category, key);
+	}
+	return (long)trunc(value->f);
+}

--- a/src/build/common_build.c
+++ b/src/build/common_build.c
@@ -50,7 +50,7 @@ const char *get_mandatory_string(const char *file, const char *category, JSONObj
 	if (!value)
 	{
 		if (category) error_exit("In file '%s': The mandatory field '%s' was missing in '%s'.", file, key, category);
-		error_exit("In file '%s': The mandatory field '%s' was missing.", file);
+		error_exit("In file '%s': The mandatory field '%s' was missing.", file, key);
 	}
 	return value;
 }

--- a/src/build/project.c
+++ b/src/build/project.c
@@ -133,24 +133,6 @@ const int project_target_keys_count = ELEMENTLEN(project_target_keys);
 
 const int project_deprecated_target_keys_count = ELEMENTLEN(project_deprecated_target_keys);
 
-long get_valid_integer(JSONObject *table, const char *key, const char *category, bool mandatory)
-{
-	JSONObject *value = json_obj_get(table, key);
-	if (!value)
-	{
-		if (mandatory)
-		{
-			error_exit("%s was missing a mandatory '%s' field, please add it.", category, key);
-		}
-		return -1;
-	}
-	if (value->type != J_NUMBER || trunc(value->f) != value->f)
-	{
-		error_exit("%s had an invalid mandatory '%s' field that was not an integer, please correct it.", category, key);
-	}
-	return (long)trunc(value->f);
-}
-
 
 static void load_into_build_target(JSONObject *json, const char *target_name, BuildTarget *target)
 {

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -33,6 +33,7 @@ static void print_vec(const char* header, const char** vec, bool opt)
 		if (i > 0) PRINTF(", ");
 		PRINTF("%s",item);
 	}
+	PRINTFN("");
 }
 
 static void print_opt_str(const char* header, const char* str) 

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -3,7 +3,7 @@
 #define PRINTF(string, ...) fprintf(stdout, string, ##__VA_ARGS__) // NOLINT
 static JSONObject* read_project() 
 {
-    size_t size;
+	size_t size;
 	char *read = file_read_all(PROJECT_JSON, &size);
 	JsonParser parser;
 	json_init_string(&parser, read, &malloc_arena);
@@ -16,24 +16,22 @@ static JSONObject* read_project()
 	{
 		error_exit("Expected a map of project information in '%s'.", PROJECT_JSON);
 	}
-    return json;
+	return json;
 }
 
 static void print_vec(const char* header, const char** vec, bool opt) 
 {
 	if (opt && !vec) return;
 	PRINTF("%s: ", header);
-	if (vec_size(vec) > 0) {
-		FOREACH_IDX(i, char *, item, vec) 
-		{
-			if (i > 0) 
-			{
-				PRINTF(", ");
-			}
-			PRINTF("%s",item);
-		}
-	} else {
+	if (!vec_size(vec)) 
+	{
 		PRINTFN("*none*");
+		return;
+	}	
+	FOREACH_IDX(i, char *, item, vec) 
+	{
+		if (i > 0) PRINTF(", ");
+		PRINTF("%s",item);
 	}
 }
 
@@ -53,12 +51,7 @@ static void print_opt_bool(const char* header, int b)
 {
 	if (b == -1) return;
 	PRINTF("%s: ", header);
-	if (b) 
-	{
-		PRINTFN("true");
-	} else {
-		PRINTFN("false");
-	}
+	PRINTFN(b ? "true" : "false");
 }
 
 static void print_opt_int(const char* header, long v) 
@@ -70,13 +63,10 @@ static void print_opt_int(const char* header, long v)
 static const char* generate_expected(const char** options, size_t n) 
 {
 	scratch_buffer_clear();
-	for (size_t i = 0; i < n; i++) {
-		if (i > 0) {
-			scratch_buffer_append(", ");
-		}
-		if (i == n - 1) {
-			scratch_buffer_append(" or ");
-		}
+	for (size_t i = 0; i < n; i++) 
+	{
+		if (i > 0) scratch_buffer_append(", ");
+		if (i == n - 1) scratch_buffer_append(" or ");
 		scratch_buffer_printf("\"%s\"", options[i]);
 	}
 	return scratch_buffer_to_string();
@@ -203,7 +193,7 @@ static void view_target(const char* name, JSONObject* target)
 	TARGET_VIEW_STRING("C compiler", "cc");
 	TARGET_VIEW_STRING("Additional C compiler flags", "cflags");
 	TARGET_VIEW_STRING("C compiler flags (override)", "cflags-override");
-    TARGET_VIEW_STRING("CPU name", "cpu");
+	TARGET_VIEW_STRING("CPU name", "cpu");
 	TARGET_VIEW_SETTING("Debug level", "debug-info", debug_levels);
 	TARGET_VIEW_STRING_ARRAY("Additional scripts to run", "exec");
 	TARGET_VIEW_STRING_ARRAY("Scripts to run (override)", "exec");

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -182,10 +182,10 @@ static void view_target(const char* name, JSONObject* target) {
 	TARGET_VIEW_STRING_ARRAY("c3l library search paths (override)", "dependency-search-paths-override");
 	TARGET_VIEW_STRING_ARRAY("Additional c3l library dependencies", "dependencies");
 	TARGET_VIEW_STRING_ARRAY("c3l library dependencies (override)", "dependencies-override");
-	TARGET_VIEW_STRING_ARRAY("Additional source folders", "sources");
-	TARGET_VIEW_STRING_ARRAY("Source folders (override)", "sources-override");
-	TARGET_VIEW_STRING_ARRAY("Additional C source folders", "c-sources");
-	TARGET_VIEW_STRING_ARRAY("C source folders (override)", "c-sources-override");
+	TARGET_VIEW_STRING_ARRAY("Additional source paths", "sources");
+	TARGET_VIEW_STRING_ARRAY("Source paths (override)", "sources-override");
+	TARGET_VIEW_STRING_ARRAY("Additional C source paths", "c-sources");
+	TARGET_VIEW_STRING_ARRAY("C source paths (override)", "c-sources-override");
 	TARGET_VIEW_SETTING("Optimization level", "opt", optimization_levels);
 
 	/* Extended target information */
@@ -243,8 +243,8 @@ void view_project(BuildOptions *build_options) {
 	VIEW_MANDATORY_STRING_ARRAY("Warnings used", "warnings");
 	VIEW_MANDATORY_STRING_ARRAY("c3l library search paths", "dependency-search-paths");
 	VIEW_MANDATORY_STRING_ARRAY("c3l library dependencies", "dependencies");
-	VIEW_MANDATORY_STRING_ARRAY("Source folders", "sources");
-	VIEW_STRING_ARRAY("C source folders", "c-sources");
+	VIEW_MANDATORY_STRING_ARRAY("Source paths", "sources");
+	VIEW_STRING_ARRAY("C source paths", "c-sources");
 	VIEW_STRING("Output location", "output");
 	VIEW_SETTING("Default optimization level", "opt", optimization_levels);
 

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -30,7 +30,7 @@ static void print_vec(const char* header, const char** vec, bool opt)
 			{
 				PRINTF(", ");
 			}
-			PRINTF("%s",vec[i]);
+			PRINTF("%s",item);
 		}
 	} else {
 		PRINTFN("*none*");

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -28,7 +28,7 @@ static void print_vec(const char* header, const char** vec, bool opt)
 		PRINTFN("*none*");
 		return;
 	}	
-	FOREACH_IDX(i, char *, item, vec) 
+	FOREACH_IDX(i, const char *, item, vec) 
 	{
 		if (i > 0) PRINTF(", ");
 		PRINTF("%s",item);

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -1,7 +1,8 @@
 #include "build_internal.h"
 #define PRINTFN(string, ...) fprintf(stdout, string "\n", ##__VA_ARGS__) // NOLINT
 #define PRINTF(string, ...) fprintf(stdout, string, ##__VA_ARGS__) // NOLINT
-static JSONObject* read_project() {
+static JSONObject* read_project() 
+{
     size_t size;
 	char *read = file_read_all(PROJECT_JSON, &size);
 	JsonParser parser;
@@ -18,48 +19,56 @@ static JSONObject* read_project() {
     return json;
 }
 
-static void print_vec(const char* header, const char** vec, bool opt) {
+static void print_vec(const char* header, const char** vec, bool opt) 
+{
 	if (opt && !vec) return;
 	PRINTF("%s: ", header);
 	if (vec_size(vec) > 0) {
-		for (int i = 0; i < vec_size(vec); ++i) {
-			if (i > 0) {
+		FOREACH_IDX(i, char *, item, vec) 
+		{
+			if (i > 0) 
+			{
 				PRINTF(", ");
 			}
 			PRINTF("%s",vec[i]);
 		}
-		PRINTFN("");
 	} else {
 		PRINTFN("*none*");
 	}
 }
 
-static void print_opt_str(const char* header, const char* str) {
+static void print_opt_str(const char* header, const char* str) 
+{
 	if (!str) return;
 	PRINTFN("%s: %s", header, str);
 }
 
-static void print_opt_setting(const char* header, int setting, const char** values) {
+static void print_opt_setting(const char* header, int setting, const char** values) 
+{
 	if (setting < 0) return;
 	PRINTFN("%s: %s", header, values[setting]);
 }
 
-static void print_opt_bool(const char* header, int b) {
+static void print_opt_bool(const char* header, int b) 
+{
 	if (b == -1) return;
 	PRINTF("%s: ", header);
-	if (b) {
+	if (b) 
+	{
 		PRINTFN("true");
 	} else {
 		PRINTFN("false");
 	}
 }
 
-static void print_opt_int(const char* header, long v) {
+static void print_opt_int(const char* header, long v) 
+{
 	if (v < 0) return;
 	PRINTFN("%s: %ld", header, v);
 }
 
-static const char* generate_expected(const char** options, size_t n) {
+static const char* generate_expected(const char** options, size_t n) 
+{
 	scratch_buffer_clear();
 	for (size_t i = 0; i < n; i++) {
 		if (i > 0) {
@@ -171,7 +180,8 @@ do {\
     print_opt_int("\t" header, v);\
 } while(0);
 
-static void view_target(const char* name, JSONObject* target) {
+static void view_target(const char* name, JSONObject* target) 
+{
 	/* General target information */
 	PRINTFN("- %s",name);
 	print_opt_str("\tName", name);
@@ -233,7 +243,8 @@ static void view_target(const char* name, JSONObject* target) {
 	TARGET_VIEW_BOOL("Return structs on the stack", "x86-stack-struct-return");
 }
 
-void view_project(BuildOptions *build_options) {
+void view_project(BuildOptions *build_options) 
+{
 	JSONObject* project_json = read_project();
 
 	/* General information */
@@ -299,7 +310,8 @@ void view_project(BuildOptions *build_options) {
 		error_exit("'targets' did not contain map of targets.");
 	}
 
-	for (unsigned i = 0; i < targets_json->member_len; i++) {
+	for (unsigned i = 0; i < targets_json->member_len; i++) 
+	{
 		JSONObject *object = targets_json->members[i];
 		const char *key = targets_json->keys[i];
 		if (object->type != J_OBJECT)

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -1,0 +1,113 @@
+#include "build_internal.h"
+#define PRINTFN(string, ...) fprintf(stdout, string "\n", ##__VA_ARGS__) // NOLINT
+#define PRINTF(string, ...) fprintf(stdout, string, ##__VA_ARGS__) // NOLINT
+static JSONObject* read_project() {
+    size_t size;
+	char *read = file_read_all(PROJECT_JSON, &size);
+	JsonParser parser;
+	json_init_string(&parser, read, &malloc_arena);
+	JSONObject *json = json_parse(&parser);
+	if (parser.error_message)
+	{
+		error_exit("Error on line %d reading '%s':'%s'", parser.line, PROJECT_JSON, parser.error_message);
+	}
+	if (!json || json->type != J_OBJECT)
+	{
+		error_exit("Expected a map of project information in '%s'.", PROJECT_JSON);
+	}
+    return json;
+}
+
+static void print_vec(const char* header, const char** vec, bool opt) {
+	if (opt && !vec) return;
+	PRINTF("%s: ", header);
+	if (vec_size(vec) > 0) {
+		for (int i = 0; i < vec_size(vec); ++i) {
+			if (i > 0) {
+				PRINTF(", ");
+			}
+			PRINTF("%s",vec[i]);
+		}
+		PRINTFN("");
+	} else {
+		PRINTFN("*none*");
+	}
+}
+
+static void print_opt_str(const char* header, const char* str) {
+	if (!str) return;
+	PRINTFN("%s: %s", header, str);
+}
+
+static void print_opt_setting(const char* header, int setting, const char** values) {
+	if (setting < 0) return;
+	PRINTFN("%s: %s", header, values[setting]);
+}
+
+const char* optimization_levels[] = {
+	[OPT_SETTING_O0] = "O0",
+	[OPT_SETTING_O1] = "O1",
+	[OPT_SETTING_O2] = "O2",
+	[OPT_SETTING_O3] = "O3",
+	[OPT_SETTING_O4] = "O4",
+	[OPT_SETTING_O5] = "O5",
+	[OPT_SETTING_OSMALL] = "Small",
+	[OPT_SETTING_OTINY] = "Tiny" 
+};
+
+const char* optimization_level_expected = "one of \"O0\", \"O1\", \"O2\", \"O3\", \"O4\", \"O5\", \"Os\", or \"Oz\"";
+
+static void view_target(const char* name, JSONObject* target) {
+	PRINTFN("- %s",name);
+	print_opt_str("\tName", name);
+	const char* type = get_mandatory_string(PROJECT_JSON,name,target,"type");
+	print_opt_str("\tType",type);
+}
+
+void view_project(BuildOptions *build_options) {
+	JSONObject* project_json = read_project();
+
+	/* General information */
+	const char** authors = get_string_array(PROJECT_JSON, NULL, project_json, "authors", true);
+	print_vec("Authors", authors, false);
+	const char* version = get_mandatory_string(PROJECT_JSON, NULL, project_json, "version");
+	print_opt_str("version", version);
+	const char* langrev = get_mandatory_string(PROJECT_JSON, NULL, project_json, "langrev");
+	PRINTFN("Project language target: %s", langrev);
+	const char** warnings = get_string_array(PROJECT_JSON, NULL, project_json, "warnings", true);
+	print_vec("Warnings used", warnings, false);
+	const char** search_paths = get_string_array(PROJECT_JSON, NULL, project_json, "dependency-search-paths", true);
+	print_vec("Search paths, .c3l files", search_paths, false);
+	const char** dependencies = get_string_array(PROJECT_JSON, NULL, project_json, "dependencies", true);
+	print_vec("Dependencies, .c3l", dependencies, false);
+	const char** sources = get_string_array(PROJECT_JSON, NULL, project_json, "sources", true);
+	print_vec("Source folders", sources, false);
+	const char** c_sources = get_string_array(PROJECT_JSON, NULL, project_json, "c-sources", false);
+	print_vec("Source folders, c files", c_sources, true);
+	const char* output = get_mandatory_string(PROJECT_JSON, NULL, project_json, "output");
+	print_opt_str("Output location", output);
+	int optimization_level = get_valid_string_setting(PROJECT_JSON, NULL, project_json, "opt", optimization_levels, 0, ELEMENTLEN(optimization_levels), optimization_level_expected);
+	print_opt_setting("Default optimization level", optimization_level, optimization_levels);
+
+	/* Target information */
+	PRINTFN("Targets: ");
+	JSONObject *targets_json = json_obj_get(project_json, "targets");
+	if (!targets_json)
+	{
+		error_exit("No targets found in project.");
+	}
+	if (targets_json->type != J_OBJECT)
+	{
+		error_exit("'targets' did not contain map of targets.");
+	}
+
+	for (unsigned i = 0; i < targets_json->member_len; i++) {
+		JSONObject *object = targets_json->members[i];
+		const char *key = targets_json->keys[i];
+		if (object->type != J_OBJECT)
+		{
+			error_exit("Invalid data in target '%s'", key);
+		}
+		view_target(key,object);
+	}
+}

--- a/src/main.c
+++ b/src/main.c
@@ -98,6 +98,15 @@ int main_real(int argc, const char *argv[])
 		case COMMAND_TEST:
 			compile_file_list(&build_options);
 			break;
+		case COMMAND_PROJECT:
+			switch (build_options.subcommand) {
+				case SUBCOMMAND_VIEW:
+					view_project(&build_options);
+					break;
+				case SUBCOMMAND_MISSING:
+					UNREACHABLE
+			}
+			break;
 		case COMMAND_MISSING:
 			UNREACHABLE
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -99,7 +99,8 @@ int main_real(int argc, const char *argv[])
 			compile_file_list(&build_options);
 			break;
 		case COMMAND_PROJECT:
-			switch (build_options.subcommand) {
+			switch (build_options.subcommand) 
+			{
 				case SUBCOMMAND_VIEW:
 					view_project(&build_options);
 					break;


### PR DESCRIPTION
Implements the first part of #1311, that being a command to display information contained in the current project's `project.json` file.

It displays general information about the project, then target specific information in a list afterwards.

An example output is shown in this image.
![an example output of c3c project view](https://github.com/user-attachments/assets/079f1c76-ae87-40fa-b2ed-e4018a07b419)

The project.json for that example is as follows
```json
{
	"langrev": "1",
	"warnings": ["no-unused"],
	"linked-libraries": ["glfw"],
	"authors": [],
	"version": "0.1.0",
	"dependencies": ["opengl", "stb"],
	"dependency-search-paths": ["dependencies"],
	"sources": ["./dependencies/helpers.c3", "./dependencies/glfw.c3", "./dependencies/camera.c3"],
	"c-sources": ["./dependencies/stb.c3l/native/*"],
	"cflags": "-fPIE",
	"targets": {
		"cube": {
			"type": "executable",
			"sources": ["./examples/cube.c3"]
		},
		"triangle": {
			"type": "executable",
			"sources": ["./examples/triangle.c3"]
		},
		"texture": {
			"type": "executable",
			"sources": ["./examples/texture.c3"]
		},
		"gltf": {
			"type": "executable",
			"sources": ["./examples/gltf.c3", "./dependencies/gltf.c3"]
		}
	},
	"output": "./build",
	"symtab": 52,
	"no-entry": false
}
```
