### PR TITLE
Implemented arg passing to `clean-run` and `run` commands

### DIFF
--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -66,11 +66,11 @@ static void usage(void)
 	PRINTF("  benchmark                                           Run the benchmarks in the current project.");
 	PRINTF("  test                                                Run the unit tests in the current project.");
 	PRINTF("  clean                                               Clean all build files.");
-	PRINTF("  run [<target>]                                      Run (and build if needed) the target in the current project.");
+	PRINTF("  run [<target>] [-- [<arg1> ...]]                    Run (and build if needed) the target in the current project.");
 	PRINTF("  dist [<target>]                                     Clean and build a target for distribution.");
 	PRINTF("  directives [<target>]                               Generate documentation for the target.");
 	PRINTF("  bench [<target>]                                    Benchmark a target.");
-	PRINTF("  clean-run [<target>]                                Clean, then run the target.");
+	PRINTF("  clean-run [<target>] [-- [<arg1> ...]]              Clean, then run the target.");
 	PRINTF("  compile-run <file1> [<file2> ...] [-- [<arg1> ...]] Compile files then immediately run the result.");
 	PRINTF("  compile-only <file1> [<file2> ...]                  Compile files but do not perform linking.");
 	PRINTF("  compile-benchmark <file1> [<file2> ...]             Compile files into an executable and run benchmarks.");

--- a/src/build/builder.c
+++ b/src/build/builder.c
@@ -97,7 +97,9 @@ bool command_passes_args(CompilerCommand command)
 {
 	switch (command)
 	{
+		case COMMAND_CLEAN_RUN:
 		case COMMAND_COMPILE_RUN:
+		case COMMAND_RUN:
 			return true;
 		case COMMAND_COMPILE:
 		case COMMAND_COMPILE_ONLY:
@@ -111,8 +113,6 @@ bool command_passes_args(CompilerCommand command)
 		case COMMAND_INIT:
 		case COMMAND_INIT_LIB:
 		case COMMAND_BUILD:
-		case COMMAND_RUN:
-		case COMMAND_CLEAN_RUN:
 		case COMMAND_CLEAN:
 		case COMMAND_DIST:
 		case COMMAND_DOCS:


### PR DESCRIPTION
This change is in response to #1318.

Changed `COMMAND_CLEAN_RUN` and `COMMAND_RUN` to return true when passed to function `command_passes_args()`.
Also, updated the compiler usage message to reflect that `clean-run` and `run` commands can be passed args.

Did some local testing and everything seems to work fine on my end (this was on windows-x64).

Let me know if anything needs to be changed.