### PR TITLE
Fix the win32 native_clock() function in std::time::os

### DIFF
--- a/lib/std/time/os/time_win32.c3
+++ b/lib/std/time/os/time_win32.c3
@@ -17,7 +17,7 @@ fn Clock native_clock()
 	}
 	Win32_LARGE_INTEGER counter @noinit;
 	if (!win32_QueryPerformanceCounter(&counter)) return 0;
-	return (Clock)counter.quadPart;
+	return (Clock)((counter.quadPart * 1_000_000_000) / freq.quadPart);
 }
 
 fn Time native_timestamp()


### PR DESCRIPTION
The win32 `native_clock()` function had a bug where it was retrieving the performance frequency via `win32_QueryPerformanceFrequency` but never using it, leading to incorrect timestamps using `Clock.mark`, this resolves that bug by changing the `native_clock()` function to use the performance frequency in converting from the performance counter value to nanoseconds.