### PR TITLE
Feature/add-target (#1)

### DIFF
--- a/src/build/build.h
+++ b/src/build/build.h
@@ -100,7 +100,12 @@ typedef enum
 	LINKER_TYPE_CUSTOM = 2,
 } LinkerType;
 
-typedef enum { TRUST_NONE, TRUST_INCLUDE, TRUST_FULL } TrustLevel;
+typedef enum
+{
+	TRUST_NONE,
+	TRUST_INCLUDE,
+	TRUST_FULL
+} TrustLevel;
 
 typedef enum
 {
@@ -344,9 +349,7 @@ typedef enum
 	ARCH_OS_TARGET_LAST = WINDOWS_X64
 } ArchOsTarget;
 
-#define ANY_WINDOWS_ARCH_OS                                                    \
-  WINDOWS_AARCH64 : case WINDOWS_X64:                                          \
-  case MINGW_X64
+#define ANY_WINDOWS_ARCH_OS WINDOWS_AARCH64: case WINDOWS_X64: case MINGW_X64
 
 typedef enum
 {

--- a/src/build/build.h
+++ b/src/build/build.h
@@ -3,8 +3,8 @@
 // Use of this source code is governed by the GNU LGPLv3.0 license
 // a copy of which can be found in the LICENSE file.
 
-#include "../version.h"
 #include "../utils/lib.h"
+#include "../version.h"
 #include <stdint.h>
 
 #define MAX_BUILD_LIB_DIRS 1024
@@ -48,16 +48,16 @@ typedef enum
 	COMMAND_PROJECT,
 } CompilerCommand;
 
-
 typedef enum
 {
 	SUBCOMMAND_MISSING = 0,
-	SUBCOMMAND_VIEW
+	SUBCOMMAND_VIEW,
+	SUBCOMMAND_ADD
 } ProjectSubcommand;
 
 typedef enum
 {
-	DIAG_NONE = 0, // Don't use!
+	DIAG_NONE = 0,     // Don't use!
 	DIAG_WARNING_TYPE, // Don't use!
 	DIAG_UNUSED,
 	DIAG_UNUSED_PARAMETER,
@@ -100,12 +100,7 @@ typedef enum
 	LINKER_TYPE_CUSTOM = 2,
 } LinkerType;
 
-typedef enum
-{
-	TRUST_NONE,
-	TRUST_INCLUDE,
-	TRUST_FULL
-} TrustLevel;
+typedef enum { TRUST_NONE, TRUST_INCLUDE, TRUST_FULL } TrustLevel;
 
 typedef enum
 {
@@ -133,10 +128,10 @@ typedef enum
 typedef enum
 {
 	OPTIMIZATION_NOT_SET = -1,
-	OPTIMIZATION_NONE = 0,          // -O0
-	OPTIMIZATION_LESS = 1,          // -O1
-	OPTIMIZATION_MORE = 2,          // -O2
-	OPTIMIZATION_AGGRESSIVE = 3,    // -O3
+	OPTIMIZATION_NONE = 0,       // -O0
+	OPTIMIZATION_LESS = 1,       // -O1
+	OPTIMIZATION_MORE = 2,       // -O2
+	OPTIMIZATION_AGGRESSIVE = 3, // -O3
 } OptimizationLevel;
 
 typedef enum
@@ -149,7 +144,7 @@ typedef enum
 typedef enum
 {
 	SINGLE_MODULE_NOT_SET = -1,
-	SINGLE_MODULE_OFF = 0,          // NOLINT
+	SINGLE_MODULE_OFF = 0, // NOLINT
 	SINGLE_MODULE_ON = 1
 } SingleModule;
 
@@ -211,9 +206,9 @@ typedef enum
 typedef enum
 {
 	SIZE_OPTIMIZATION_NOT_SET = -1,
-	SIZE_OPTIMIZATION_NONE = 0,     // None
-	SIZE_OPTIMIZATION_SMALL = 1,    // -Os
-	SIZE_OPTIMIZATION_TINY = 2,     // -Oz
+	SIZE_OPTIMIZATION_NONE = 0,  // None
+	SIZE_OPTIMIZATION_SMALL = 1, // -Os
+	SIZE_OPTIMIZATION_TINY = 2,  // -Oz
 } SizeOptimizationLevel;
 
 typedef enum
@@ -233,7 +228,7 @@ typedef enum
 typedef enum
 {
 	STRUCT_RETURN_DEFAULT = -1,
-	STRUCT_RETURN_STACK = 0,        // NOLINT
+	STRUCT_RETURN_STACK = 0, // NOLINT
 	STRUCT_RETURN_REG = 1
 } StructReturn;
 
@@ -349,7 +344,37 @@ typedef enum
 	ARCH_OS_TARGET_LAST = WINDOWS_X64
 } ArchOsTarget;
 
-#define ANY_WINDOWS_ARCH_OS WINDOWS_AARCH64: case WINDOWS_X64: case MINGW_X64
+#define ANY_WINDOWS_ARCH_OS                                                    \
+  WINDOWS_AARCH64 : case WINDOWS_X64:                                          \
+  case MINGW_X64
+
+typedef enum
+{
+	TARGET_TYPE_EXECUTABLE,
+	TARGET_TYPE_STATIC_LIB,
+	TARGET_TYPE_DYNAMIC_LIB,
+	TARGET_TYPE_OBJECT_FILES,
+	TARGET_TYPE_BENCHMARK,
+	TARGET_TYPE_TEST,
+} TargetType;
+
+static const char *targets[6] = {
+		[TARGET_TYPE_EXECUTABLE] = "executable",
+		[TARGET_TYPE_STATIC_LIB] = "static-lib",
+		[TARGET_TYPE_DYNAMIC_LIB] = "dynamic-lib",
+		[TARGET_TYPE_BENCHMARK] = "benchmark",
+		[TARGET_TYPE_TEST] = "test",
+		[TARGET_TYPE_OBJECT_FILES] = "object-files"
+};
+static const char *target_desc[6] = {
+		[TARGET_TYPE_EXECUTABLE] = "Executable",
+		[TARGET_TYPE_STATIC_LIB] = "Static library",
+		[TARGET_TYPE_DYNAMIC_LIB] = "Dynamic library",
+		[TARGET_TYPE_BENCHMARK] = "benchmark suite",
+		[TARGET_TYPE_TEST] = "test suite",
+		[TARGET_TYPE_OBJECT_FILES] = "object files"
+};
+
 
 typedef struct BuildOptions_
 {
@@ -365,17 +390,20 @@ typedef struct BuildOptions_
 	size_t linker_lib_count;
 	const char* std_lib_dir;
 	VectorConv vector_conv;
-	struct {
+	struct
+	{
 		const char *sdk;
 		const char *def;
 		WinCrtLinking crt_linking;
 	} win;
-	struct {
+	struct
+	{
 		const char *sysroot;
 		const char *min_version;
 		const char *sdk_version;
 	} macos;
-	struct {
+	struct
+	{
 		const char *crt;
 		const char *crtbegin;
 	} linuxpaths;
@@ -397,7 +425,12 @@ typedef struct BuildOptions_
 	bool silence_deprecation;
 	CompilerBackend backend;
 	CompilerCommand command;
-	ProjectSubcommand subcommand;
+	struct
+	{
+		ProjectSubcommand command;
+		const char *target_name;
+		TargetType target_type;
+	} project_options;
 	CompileOption compile_option;
 	TrustLevel trust_level;
 	DiagnosticsSeverity severity[DIAG_END_SENTINEL];
@@ -459,16 +492,6 @@ typedef struct BuildOptions_
 	bool testing;
 } BuildOptions;
 
-typedef enum
-{
-	TARGET_TYPE_EXECUTABLE,
-	TARGET_TYPE_STATIC_LIB,
-	TARGET_TYPE_DYNAMIC_LIB,
-	TARGET_TYPE_OBJECT_FILES,
-	TARGET_TYPE_BENCHMARK,
-	TARGET_TYPE_TEST,
-} TargetType;
-
 typedef struct
 {
 	struct Library__ *parent;
@@ -499,7 +522,6 @@ typedef struct Library__
 	LibraryTarget *target_used;
 	LibraryTarget **targets;
 } Library;
-
 
 typedef struct
 {
@@ -681,8 +703,10 @@ BuildOptions parse_arguments(int argc, const char *argv[]);
 ArchOsTarget arch_os_target_from_string(const char *target);
 bool command_accepts_files(CompilerCommand command);
 bool command_passes_args(CompilerCommand command);
-void update_build_target_with_opt_level(BuildTarget *target, OptimizationSetting level);
+void update_build_target_with_opt_level(BuildTarget *target,
+	OptimizationSetting level);
 void create_project(BuildOptions *build_options);
 void create_library(BuildOptions *build_options);
 void resolve_libraries(BuildTarget *build_target);
 void view_project(BuildOptions *build_options);
+void add_target_project(BuildOptions *build_options);

--- a/src/build/build_internal.h
+++ b/src/build/build_internal.h
@@ -104,7 +104,7 @@ BuildTarget *project_select_target(Project *project, const char *optional_target
 void update_feature_flags(const char ***flags, const char ***removed_flag, const char *arg, bool add);
 
 const char *get_string(const char *file, const char *category, JSONObject *table, const char *key,
-                       const char *default_value);
+	const char *default_value);
 int get_valid_bool(const char *file, const char *target, JSONObject *json, const char *key, int default_val);
 const char *get_optional_string(const char *file, const char *category, JSONObject *table, const char *key);
 const char *get_mandatory_string(const char *file, const char *category, JSONObject *object, const char *key);
@@ -112,7 +112,8 @@ const char **get_string_array(const char *file, const char *category, JSONObject
 const char **get_optional_string_array(const char *file, const char *target, JSONObject *table, const char *key);
 const char *get_cflags(const char *file, const char *target, JSONObject *json, const char *original_flags);
 void get_list_append_strings(const char *file, const char *target, JSONObject *json, const char ***list_ptr,
-                             const char *base, const char *override, const char *add);
-int get_valid_string_setting(const char *file, const char *target, JSONObject *json, const char *key, const char** values, int first_result, int count, const char *expected);
-void check_json_keys(const char* valid_keys[][2], size_t key_count, const char* deprecated_keys[], size_t deprecated_key_count, JSONObject *json, const char *target_name, const char *option);
+	const char *base, const char *override, const char *add);
+int get_valid_string_setting(const char *file, const char *target, JSONObject *json, const char *key, const char **values, int first_result, int count, const char *expected);
+int get_valid_enum_from_string(const char *str, const char *target, const char **values, int count, const char *expected);
+void check_json_keys(const char *valid_keys[][2], size_t key_count, const char *deprecated_keys[], size_t deprecated_key_count, JSONObject *json, const char *target_name, const char *option);
 long get_valid_integer(JSONObject *table, const char *key, const char *category, bool mandatory);

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -205,7 +205,10 @@ static const char *check_dir(const char *path)
 	return path;
 }
 
-static inline bool at_end() { return arg_index == arg_count - 1; }
+static inline bool at_end()
+{
+	return arg_index == arg_count - 1;
+}
 
 static inline const char *next_arg()
 {
@@ -214,7 +217,10 @@ static inline const char *next_arg()
 	return current_arg;
 }
 
-static inline bool next_is_opt() { return args[arg_index + 1][0] == '-'; }
+static inline bool next_is_opt()
+{
+	return args[arg_index + 1][0] == '-';
+}
 
 INLINE bool match_longopt(const char *name)
 {
@@ -283,7 +289,6 @@ static void project_usage()
 
 static void parse_project_subcommand(BuildOptions *options)
 {
-
 	if (arg_match("view"))
 	{
 		options->project_options.command = SUBCOMMAND_VIEW;
@@ -293,14 +298,10 @@ static void parse_project_subcommand(BuildOptions *options)
 	{
 		options->project_options.command = SUBCOMMAND_ADD;
 
-		if (at_end() || next_is_opt())
-			error_exit("Expected a target name");
-
+		if (at_end() || next_is_opt()) error_exit("Expected a target name");
 		options->project_options.target_name = next_arg();
 
-		if (at_end() || next_is_opt())
-			error_exit("Expected a target type like 'executable' or 'static-lib'");
-
+		if (at_end() || next_is_opt()) error_exit("Expected a target type like 'executable' or 'static-lib'");
 		options->project_options.target_type = (TargetType)get_valid_enum_from_string(next_arg(), "type", targets, ELEMENTLEN(targets), "a target type like 'executable' or 'static-lib'");
 
 		return;
@@ -328,16 +329,14 @@ static void parse_command(BuildOptions *options)
 	if (arg_match("init"))
 	{
 		options->command = COMMAND_INIT;
-		if (at_end() || next_is_opt())
-			error_exit("Expected a project name after init");
+		if (at_end() || next_is_opt()) error_exit("Expected a project name after init");
 		options->project_name = next_arg();
 		return;
 	}
 	if (arg_match("init-lib"))
 	{
 		options->command = COMMAND_INIT_LIB;
-		if (at_end() || next_is_opt())
-			error_exit("Expected a library name after init");
+		if (at_end() || next_is_opt()) error_exit("Expected a library name after init");
 		options->project_name = next_arg();
 		return;
 	}

--- a/src/build/common_build.c
+++ b/src/build/common_build.c
@@ -94,6 +94,7 @@ const char **get_string_array(const char *file, const char *category, JSONObject
 	for (unsigned i = 0; i < value->array_len; i++)
 	{
 		JSONObject *val = value->elements[i];
+		if (val->type == J_COMMENT_LINE) continue;
 		if (val->type != J_STRING) goto NOT_ARRAY;
 		vec_add(values, val->str);
 	}
@@ -178,6 +179,17 @@ int get_valid_string_setting(const char *file, const char *target, JSONObject *j
 		error_exit("In file '%s': '%s' had an invalid value for '%s', expected %s", file, target, key, expected);
 	}
 	error_exit("In file '%s': Invalid value for '%s', expected %s", file, key, expected);
+}
+
+int get_valid_enum_from_string(const char *str, const char *target, const char **values, int count, const char *expected)
+{
+	int res = str_findlist(str, count, values);
+	if (res >= 0) return res;
+	if (target)
+	{
+		error_exit("'%s' had an invalid value, expected %s", target, expected);
+	}
+	error_exit("Invalid value, expected %s", expected);
 }
 
 long get_valid_integer(JSONObject *table, const char *key, const char *category, bool mandatory)

--- a/src/build/common_build.c
+++ b/src/build/common_build.c
@@ -94,7 +94,6 @@ const char **get_string_array(const char *file, const char *category, JSONObject
 	for (unsigned i = 0; i < value->array_len; i++)
 	{
 		JSONObject *val = value->elements[i];
-		if (val->type == J_COMMENT_LINE) continue;
 		if (val->type != J_STRING) goto NOT_ARRAY;
 		vec_add(values, val->str);
 	}

--- a/src/build/project.c
+++ b/src/build/project.c
@@ -419,22 +419,6 @@ static void project_add_target(Project *project, BuildTarget *default_target,  J
 static void project_add_targets(Project *project, JSONObject *project_data)
 {
 	assert(project_data->type == J_OBJECT);
-	static const char* targets[6] = {
-			[TARGET_TYPE_EXECUTABLE] = "executable",
-			[TARGET_TYPE_STATIC_LIB] = "static-lib",
-			[TARGET_TYPE_DYNAMIC_LIB] = "dynamic-lib",
-			[TARGET_TYPE_BENCHMARK] = "benchmark",
-			[TARGET_TYPE_TEST] = "test",
-			[TARGET_TYPE_OBJECT_FILES] = "object-files"
-	};
-	static const char *target_desc[6] = {
-			[TARGET_TYPE_EXECUTABLE] = "Executable",
-			[TARGET_TYPE_STATIC_LIB] = "Static library",
-			[TARGET_TYPE_DYNAMIC_LIB] = "Dynamic library",
-			[TARGET_TYPE_BENCHMARK] = "benchmark suite",
-			[TARGET_TYPE_TEST] = "test suite",
-			[TARGET_TYPE_OBJECT_FILES] = "object files"
-	};
 
 	BuildTarget default_target = default_build_target;
 	load_into_build_target(project_data, NULL, &default_target);

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -246,12 +246,7 @@ void add_target_project(BuildOptions *build_options)
 		JSONObject *object = targets_json->members[i];
 		const char *key = targets_json->keys[i];
 
-		if (key == NULL)
-		{
-			continue;
-		}
-
-		if (strcmp(key, build_options->project_options.target_name) == 0)
+		if (str_eq(key, build_options->project_options.target_name))
 		{
 			error_exit("Target with name '%s' already exists", key);
 		}

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -257,14 +257,11 @@ void add_target_project(BuildOptions *build_options)
 		}
 	}
 
-	JSONObject *target_type_obj = MALLOCS(JSONObject);
-	target_type_obj->type = J_STRING;
+	JSONObject *target_type_obj = json_new_object(&malloc_arena, J_STRING);
 	target_type_obj->str = targets[build_options->project_options.target_type];
 
 
-	JSONObject *new_target = MALLOCS(JSONObject);
-	new_target->type = J_OBJECT;
-
+	JSONObject *new_target = json_new_object(&malloc_arena, J_OBJECT);
 	new_target->members = malloc_arena(sizeof(JSONObject) * 16);
 	new_target->keys = malloc_arena(sizeof(JSONObject) * 16);
 
@@ -354,11 +351,6 @@ void view_project(BuildOptions *build_options)
 	{
 		JSONObject *object = targets_json->members[i];
 		const char *key = targets_json->keys[i];
-
-		if (object->type == J_COMMENT_LINE)
-		{
-			continue;
-		}
 
 		if (object->type != J_OBJECT)
 		{

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -1,7 +1,7 @@
 #include "build_internal.h"
 #define PRINTFN(string, ...) fprintf(stdout, string "\n", ##__VA_ARGS__) // NOLINT
 #define PRINTF(string, ...) fprintf(stdout, string, ##__VA_ARGS__) // NOLINT
-static JSONObject* read_project() 
+static JSONObject *read_project()
 {
 	size_t size;
 	char *read = file_read_all(PROJECT_JSON, &size);
@@ -19,52 +19,52 @@ static JSONObject* read_project()
 	return json;
 }
 
-static void print_vec(const char* header, const char** vec, bool opt) 
+static void print_vec(const char *header, const char **vec, bool opt)
 {
 	if (opt && !vec) return;
 	PRINTF("%s: ", header);
-	if (!vec_size(vec)) 
+	if (!vec_size(vec))
 	{
 		PRINTFN("*none*");
 		return;
-	}	
-	FOREACH_IDX(i, const char *, item, vec) 
+	}
+	FOREACH_IDX(i, const char *, item, vec)
 	{
 		if (i > 0) PRINTF(", ");
-		PRINTF("%s",item);
+		PRINTF("%s", item);
 	}
 	PRINTFN("");
 }
 
-static void print_opt_str(const char* header, const char* str) 
+static void print_opt_str(const char *header, const char *str)
 {
 	if (!str) return;
 	PRINTFN("%s: %s", header, str);
 }
 
-static void print_opt_setting(const char* header, int setting, const char** values) 
+static void print_opt_setting(const char *header, int setting, const char **values)
 {
 	if (setting < 0) return;
 	PRINTFN("%s: %s", header, values[setting]);
 }
 
-static void print_opt_bool(const char* header, int b) 
+static void print_opt_bool(const char *header, int b)
 {
 	if (b == -1) return;
 	PRINTF("%s: ", header);
 	PRINTFN(b ? "true" : "false");
 }
 
-static void print_opt_int(const char* header, long v) 
+static void print_opt_int(const char *header, long v)
 {
 	if (v < 0) return;
 	PRINTFN("%s: %ld", header, v);
 }
 
-static const char* generate_expected(const char** options, size_t n) 
+static const char *generate_expected(const char **options, size_t n)
 {
 	scratch_buffer_clear();
-	for (size_t i = 0; i < n; i++) 
+	for (size_t i = 0; i < n; i++)
 	{
 		if (i > 0) scratch_buffer_append(", ");
 		if (i == n - 1) scratch_buffer_append(" or ");
@@ -74,7 +74,7 @@ static const char* generate_expected(const char** options, size_t n)
 }
 
 
-const char* optimization_levels[] = {
+const char *optimization_levels[] = {
 	[OPT_SETTING_O0] = "O0",
 	[OPT_SETTING_O1] = "O1",
 	[OPT_SETTING_O2] = "O2",
@@ -82,10 +82,10 @@ const char* optimization_levels[] = {
 	[OPT_SETTING_O4] = "O4",
 	[OPT_SETTING_O5] = "O5",
 	[OPT_SETTING_OSMALL] = "Os",
-	[OPT_SETTING_OTINY] = "Oz" 
+	[OPT_SETTING_OTINY] = "Oz"
 };
 
-const char* debug_levels[] = {
+const char *debug_levels[] = {
 	[DEBUG_INFO_NONE] = "none",
 	[DEBUG_INFO_LINE_TABLES] = "line-tables",
 	[DEBUG_INFO_FULL] = "full"
@@ -171,12 +171,12 @@ do {\
     print_opt_int("\t" header, v);\
 } while(0);
 
-static void view_target(const char* name, JSONObject* target) 
+static void view_target(const char *name, JSONObject *target)
 {
 	/* General target information */
-	PRINTFN("- %s",name);
+	PRINTFN("- %s", name);
 	print_opt_str("\tName", name);
-	TARGET_VIEW_MANDATORY_STRING("Type","type");
+	TARGET_VIEW_MANDATORY_STRING("Type", "type");
 	TARGET_VIEW_STRING("Target language target", "langrev");
 	TARGET_VIEW_STRING_ARRAY("Warnings used", "warnings");
 	TARGET_VIEW_STRING_ARRAY("Additional c3l library search paths", "dependency-search-paths");
@@ -204,7 +204,7 @@ static void view_target(const char* name, JSONObject* target)
 	TARGET_VIEW_SETTING("Floating point behaviour", "fp-math", fp_math);
 	TARGET_VIEW_STRING_ARRAY("Additional linked libraries", "linked-libraries");
 	TARGET_VIEW_STRING_ARRAY("Linked libraries (override)", "linked-libraries-override");
-	TARGET_VIEW_STRING("Linker","linker");
+	TARGET_VIEW_STRING("Linker", "linker");
 	TARGET_VIEW_STRING_ARRAY("Additional linker search paths", "linker-search-paths");
 	TARGET_VIEW_STRING_ARRAY("Linker search paths (override)", "linker-search-paths-override");
 	TARGET_VIEW_STRING_ARRAY("Additional linker arguments", "link-args");
@@ -236,13 +236,60 @@ static void view_target(const char* name, JSONObject* target)
 	TARGET_VIEW_BOOL("Return structs on the stack", "x86-stack-struct-return");
 }
 
-void view_project(BuildOptions *build_options) 
+void add_target_project(BuildOptions *build_options)
 {
-	JSONObject* project_json = read_project();
+	JSONObject *project_json = read_project();
+	JSONObject *targets_json = json_obj_get(project_json, "targets");
+
+	for (unsigned i = 0; i < targets_json->member_len; i++)
+	{
+		JSONObject *object = targets_json->members[i];
+		const char *key = targets_json->keys[i];
+
+		if (key == NULL)
+		{
+			continue;
+		}
+
+		if (strcmp(key, build_options->project_options.target_name) == 0)
+		{
+			error_exit("Target with name '%s' already exists", key);
+		}
+	}
+
+	JSONObject *target_type_obj = MALLOCS(JSONObject);
+	target_type_obj->type = J_STRING;
+	target_type_obj->str = targets[build_options->project_options.target_type];
+
+
+	JSONObject *new_target = MALLOCS(JSONObject);
+	new_target->type = J_OBJECT;
+
+	new_target->members = malloc_arena(sizeof(JSONObject) * 16);
+	new_target->keys = malloc_arena(sizeof(JSONObject) * 16);
+
+	new_target->keys[0] = "type";
+	new_target->members[0] = target_type_obj;
+	new_target->member_len = 1;
+
+
+	size_t index = targets_json->member_len;
+	targets_json->members[index] = new_target;
+	targets_json->keys[index] = build_options->project_options.target_name;
+	targets_json->member_len++;
+
+	FILE *file = fopen(PROJECT_JSON, "w");
+	print_json_to_file(project_json, file);
+	fclose(file);
+}
+
+void view_project(BuildOptions *build_options)
+{
+	JSONObject *project_json = read_project();
 
 	/* General information */
-	VIEW_MANDATORY_STRING_ARRAY("Authors","authors");
-	VIEW_MANDATORY_STRING("Version","version");
+	VIEW_MANDATORY_STRING_ARRAY("Authors", "authors");
+	VIEW_MANDATORY_STRING("Version", "version");
 	VIEW_MANDATORY_STRING("Project language target", "langrev");
 	VIEW_MANDATORY_STRING_ARRAY("Warnings used", "warnings");
 	VIEW_MANDATORY_STRING_ARRAY("c3l library search paths", "dependency-search-paths");
@@ -262,7 +309,7 @@ void view_project(BuildOptions *build_options)
 	VIEW_STRING_ARRAY("Enabled features", "features");
 	VIEW_SETTING("Floating point behaviour", "fp-math", fp_math);
 	VIEW_STRING_ARRAY("Linked libraries", "linked-libraries");
-	VIEW_STRING("Linker","linker");
+	VIEW_STRING("Linker", "linker");
 	VIEW_STRING_ARRAY("Linker search paths", "linker-search-paths");
 	VIEW_STRING_ARRAY("Linker arguments", "link-args");
 	VIEW_BOOL("Link libc", "link-libc");
@@ -303,14 +350,20 @@ void view_project(BuildOptions *build_options)
 		error_exit("'targets' did not contain map of targets.");
 	}
 
-	for (unsigned i = 0; i < targets_json->member_len; i++) 
+	for (unsigned i = 0; i < targets_json->member_len; i++)
 	{
 		JSONObject *object = targets_json->members[i];
 		const char *key = targets_json->keys[i];
+
+		if (object->type == J_COMMENT_LINE)
+		{
+			continue;
+		}
+
 		if (object->type != J_OBJECT)
 		{
 			error_exit("Invalid data in target '%s'", key);
 		}
-		view_target(key,object);
+		view_target(key, object);
 	}
 }

--- a/src/main.c
+++ b/src/main.c
@@ -35,8 +35,7 @@ int main_real(int argc, const char *argv[])
 	if (result)
 	{
 		cleanup();
-		if (result == COMPILER_SUCCESS_EXIT)
-			result = EXIT_SUCCESS;
+		if (result == COMPILER_SUCCESS_EXIT) result = EXIT_SUCCESS;
 		return result;
 	}
 
@@ -47,8 +46,7 @@ int main_real(int argc, const char *argv[])
 		if (str_eq(argv[i], "--max-mem") && i < argc - 1)
 		{
 			max_mem = atoll(argv[i + 1]);
-			if (max_mem)
-				max_mem = next_highest_power_of_2(max_mem);
+			if (max_mem) max_mem = next_highest_power_of_2(max_mem);
 			break;
 		}
 	}
@@ -63,59 +61,59 @@ int main_real(int argc, const char *argv[])
 
 	switch (build_options.command)
 	{
-	case COMMAND_PRINT_SYNTAX:
-		print_syntax(&build_options);
-		break;
-	case COMMAND_INIT:
-		create_project(&build_options);
-		break;
-	case COMMAND_INIT_LIB:
-		create_library(&build_options);
-		break;
-	case COMMAND_UNIT_TEST:
-		compiler_tests();
-		break;
-	case COMMAND_GENERATE_HEADERS:
-	case COMMAND_COMPILE:
-	case COMMAND_COMPILE_ONLY:
-	case COMMAND_COMPILE_RUN:
-	case COMMAND_DYNAMIC_LIB:
-	case COMMAND_STATIC_LIB:
-	case COMMAND_COMPILE_BENCHMARK:
-	case COMMAND_COMPILE_TEST:
-		compile_target(&build_options);
-		break;
-	case COMMAND_CLEAN:
-		compile_clean(&build_options);
-		break;
-	case COMMAND_VENDOR_FETCH:
-		vendor_fetch(&build_options);
-		break;
-	case COMMAND_CLEAN_RUN:
-	case COMMAND_BUILD:
-	case COMMAND_RUN:
-	case COMMAND_DIST:
-	case COMMAND_DOCS:
-	case COMMAND_BENCH:
-	case COMMAND_BENCHMARK:
-	case COMMAND_TEST:
-		compile_file_list(&build_options);
-		break;
-	case COMMAND_PROJECT:
-		switch (build_options.project_options.command)
-		{
-		case SUBCOMMAND_VIEW:
-			view_project(&build_options);
+		case COMMAND_PRINT_SYNTAX:
+			print_syntax(&build_options);
 			break;
-		case SUBCOMMAND_ADD:
-			add_target_project(&build_options);
+		case COMMAND_INIT:
+			create_project(&build_options);
 			break;
-		case SUBCOMMAND_MISSING:
+		case COMMAND_INIT_LIB:
+			create_library(&build_options);
 			break;
-		}
-		break;
-	case COMMAND_MISSING:
-		UNREACHABLE
+		case COMMAND_UNIT_TEST:
+			compiler_tests();
+			break;
+		case COMMAND_GENERATE_HEADERS:
+		case COMMAND_COMPILE:
+		case COMMAND_COMPILE_ONLY:
+		case COMMAND_COMPILE_RUN:
+		case COMMAND_DYNAMIC_LIB:
+		case COMMAND_STATIC_LIB:
+		case COMMAND_COMPILE_BENCHMARK:
+		case COMMAND_COMPILE_TEST:
+			compile_target(&build_options);
+			break;
+		case COMMAND_CLEAN:
+			compile_clean(&build_options);
+			break;
+		case COMMAND_VENDOR_FETCH:
+			vendor_fetch(&build_options);
+			break;
+		case COMMAND_CLEAN_RUN:
+		case COMMAND_BUILD:
+		case COMMAND_RUN:
+		case COMMAND_DIST:
+		case COMMAND_DOCS:
+		case COMMAND_BENCH:
+		case COMMAND_BENCHMARK:
+		case COMMAND_TEST:
+			compile_file_list(&build_options);
+			break;
+		case COMMAND_PROJECT:
+			switch (build_options.project_options.command)
+			{
+				case SUBCOMMAND_VIEW:
+					view_project(&build_options);
+					break;
+				case SUBCOMMAND_ADD:
+					add_target_project(&build_options);
+					break;
+				case SUBCOMMAND_MISSING:
+					break;
+			}
+			break;
+		case COMMAND_MISSING:
+			UNREACHABLE
 	}
 
 	symtab_destroy();

--- a/src/main.c
+++ b/src/main.c
@@ -1,8 +1,9 @@
-#include <compiler_tests/benchmark.h>
-#include "compiler/compiler.h"
 #include "build/build.h"
+#include "compiler/compiler.h"
 #include "compiler_tests/tests.h"
 #include "utils/lib.h"
+#include <compiler_tests/benchmark.h>
+
 
 bool debug_log = false;
 bool debug_stats = false;
@@ -34,7 +35,8 @@ int main_real(int argc, const char *argv[])
 	if (result)
 	{
 		cleanup();
-		if (result == COMPILER_SUCCESS_EXIT) result = EXIT_SUCCESS;
+		if (result == COMPILER_SUCCESS_EXIT)
+			result = EXIT_SUCCESS;
 		return result;
 	}
 
@@ -45,7 +47,8 @@ int main_real(int argc, const char *argv[])
 		if (str_eq(argv[i], "--max-mem") && i < argc - 1)
 		{
 			max_mem = atoll(argv[i + 1]);
-			if (max_mem) max_mem = next_highest_power_of_2(max_mem);
+			if (max_mem)
+				max_mem = next_highest_power_of_2(max_mem);
 			break;
 		}
 	}
@@ -60,56 +63,59 @@ int main_real(int argc, const char *argv[])
 
 	switch (build_options.command)
 	{
-		case COMMAND_PRINT_SYNTAX:
-			print_syntax(&build_options);
+	case COMMAND_PRINT_SYNTAX:
+		print_syntax(&build_options);
+		break;
+	case COMMAND_INIT:
+		create_project(&build_options);
+		break;
+	case COMMAND_INIT_LIB:
+		create_library(&build_options);
+		break;
+	case COMMAND_UNIT_TEST:
+		compiler_tests();
+		break;
+	case COMMAND_GENERATE_HEADERS:
+	case COMMAND_COMPILE:
+	case COMMAND_COMPILE_ONLY:
+	case COMMAND_COMPILE_RUN:
+	case COMMAND_DYNAMIC_LIB:
+	case COMMAND_STATIC_LIB:
+	case COMMAND_COMPILE_BENCHMARK:
+	case COMMAND_COMPILE_TEST:
+		compile_target(&build_options);
+		break;
+	case COMMAND_CLEAN:
+		compile_clean(&build_options);
+		break;
+	case COMMAND_VENDOR_FETCH:
+		vendor_fetch(&build_options);
+		break;
+	case COMMAND_CLEAN_RUN:
+	case COMMAND_BUILD:
+	case COMMAND_RUN:
+	case COMMAND_DIST:
+	case COMMAND_DOCS:
+	case COMMAND_BENCH:
+	case COMMAND_BENCHMARK:
+	case COMMAND_TEST:
+		compile_file_list(&build_options);
+		break;
+	case COMMAND_PROJECT:
+		switch (build_options.project_options.command)
+		{
+		case SUBCOMMAND_VIEW:
+			view_project(&build_options);
 			break;
-		case COMMAND_INIT:
-			create_project(&build_options);
+		case SUBCOMMAND_ADD:
+			add_target_project(&build_options);
 			break;
-		case COMMAND_INIT_LIB:
-			create_library(&build_options);
+		case SUBCOMMAND_MISSING:
 			break;
-		case COMMAND_UNIT_TEST:
-			compiler_tests();
-			break;
-		case COMMAND_GENERATE_HEADERS:
-		case COMMAND_COMPILE:
-		case COMMAND_COMPILE_ONLY:
-		case COMMAND_COMPILE_RUN:
-		case COMMAND_DYNAMIC_LIB:
-		case COMMAND_STATIC_LIB:
-		case COMMAND_COMPILE_BENCHMARK:
-		case COMMAND_COMPILE_TEST:
-			compile_target(&build_options);
-			break;
-		case COMMAND_CLEAN:
-			compile_clean(&build_options);
-			break;
-		case COMMAND_VENDOR_FETCH:
-			vendor_fetch(&build_options);
-			break;
-		case COMMAND_CLEAN_RUN:
-		case COMMAND_BUILD:
-		case COMMAND_RUN:
-		case COMMAND_DIST:
-		case COMMAND_DOCS:
-		case COMMAND_BENCH:
-		case COMMAND_BENCHMARK:
-		case COMMAND_TEST:
-			compile_file_list(&build_options);
-			break;
-		case COMMAND_PROJECT:
-			switch (build_options.subcommand) 
-			{
-				case SUBCOMMAND_VIEW:
-					view_project(&build_options);
-					break;
-				case SUBCOMMAND_MISSING:
-					UNREACHABLE
-			}
-			break;
-		case COMMAND_MISSING:
-			UNREACHABLE
+		}
+		break;
+	case COMMAND_MISSING:
+		UNREACHABLE
 	}
 
 	symtab_destroy();
@@ -121,7 +127,7 @@ int main_real(int argc, const char *argv[])
 
 int wmain(int argc, const uint16_t *argv[])
 {
-	char** args = malloc(sizeof(void*) * (unsigned)argc);
+	char **args = malloc(sizeof(void *) * (unsigned)argc);
 	for (unsigned i = 0; i < (unsigned)argc; i++)
 	{
 		args[i] = win_utf16to8(argv[i]);
@@ -131,9 +137,6 @@ int wmain(int argc, const uint16_t *argv[])
 
 #else
 
-int main(int argc, const char *argv[])
-{
-	return main_real(argc, argv);
-}
+int main(int argc, const char *argv[]) { return main_real(argc, argv); }
 
 #endif

--- a/src/utils/json.c
+++ b/src/utils/json.c
@@ -453,27 +453,27 @@ void json_free(JsonDeallocator *deallocator, JSONObject **ptr)
 
 	switch (obj->type)
 	{
-	case J_OBJECT:
-		for (size_t i = 0; i < obj->member_len; i++)
-		{
-			json_free(deallocator, &obj->members[i]);
-			deallocator((char *)obj->keys[i]);
-		}
-		deallocator(obj->keys);
-		deallocator(obj->members);
-		break;
-	case J_ARRAY:
-		for (size_t i = 0; i < obj->array_len; i++)
-		{
-			json_free(deallocator, &obj->elements[i]);
-		}
-		deallocator(obj->elements);
-		break;
-	case J_STRING:
-		deallocator((char *)obj->str);
-		break;
-	default:
-		break;
+		case J_OBJECT:
+			for (size_t i = 0; i < obj->member_len; i++)
+			{
+				json_free(deallocator, &obj->members[i]);
+				deallocator((char *)obj->keys[i]);
+			}
+			deallocator(obj->keys);
+			deallocator(obj->members);
+			break;
+		case J_ARRAY:
+			for (size_t i = 0; i < obj->array_len; i++)
+			{
+				json_free(deallocator, &obj->elements[i]);
+			}
+			deallocator(obj->elements);
+			break;
+		case J_STRING:
+			deallocator((char *)obj->str);
+			break;
+		default:
+			break;
 	}
 	deallocator(*ptr);
 	*ptr = NULL;

--- a/src/utils/json.c
+++ b/src/utils/json.c
@@ -2,6 +2,8 @@
 #include "json.h"
 
 
+#define PRINTF(file, string, ...) fprintf(file, string, ##__VA_ARGS__) /* NOLINT */
+
 JSONObject error = { .type = J_ERROR };
 JSONObject true_val = { .type = J_BOOL, .b = true };
 JSONObject false_val = { .type = J_BOOL, .b = false };
@@ -16,41 +18,35 @@ static inline void json_skip_whitespace(JsonParser *parser)
 	char c;
 	while (1)
 	{
-		RETRY:
+	RETRY:
 		switch (parser->current[0])
 		{
-			case '/':
-				c = parser->current[1];
-				if (c == '/')
-				{
-					parser->current++;
-					while ((c = (++parser->current)[0]) && c != '\n') {}
-					goto RETRY;
-				}
-				if (c == '*')
-				{
-					parser->current++;
-					while ((c = (++parser->current)[0]))
-					{
-						if (c == '*' && parser->current[1] == '/')
-						{
-							parser->current += 2;
-							goto RETRY;
-						}
-					}
-					goto RETRY;
-				}
-				return;
-			case '\n':
-				parser->line++;
-			case '\r':
-			case ' ':
-			case '\v':
-			case '\t':
+		case '/':
+			c = parser->current[1];
+			if (c == '*')
+			{
 				parser->current++;
-				continue;
-			default:
-				return;
+				while ((c = (++parser->current)[0]))
+				{
+					if (c == '*' && parser->current[1] == '/')
+					{
+						parser->current += 2;
+						goto RETRY;
+					}
+				}
+				goto RETRY;
+			}
+			return;
+		case '\n':
+			parser->line++;
+		case '\r':
+		case ' ':
+		case '\v':
+		case '\t':
+			parser->current++;
+			continue;
+		default:
+			return;
 		}
 	}
 }
@@ -100,6 +96,43 @@ static void json_parse_number(JsonParser *parser)
 	parser->last_number = value;
 }
 
+static void json_parse_comment_line(JsonParser *parser)
+{
+	parser->current_token_type = T_COMMENT;
+
+	const char *current = ++parser->current;
+	char c;
+	while (c = current++[0], c != '\0' && c != '\n') { current++; }
+
+	size_t max_size = current - parser->current;
+	char *str = parser->allocator(max_size + 1);
+	char *str_current = str;
+	parser->last_string = str;
+	str_current[0] = '\0';
+
+	while (1)
+	{
+		c = parser->current++[0];
+		if (c == '\0')
+		{
+			str_current[0] = '\0';
+			return;
+		}
+		if (c == '\n')
+		{
+			parser->last_string = str;
+			str_current[0] = '\0';
+
+			return;
+		}
+
+		str_current++[0] = c;
+	}
+
+	UNREACHABLE
+
+}
+
 static void json_parse_string(JsonParser *parser)
 {
 	parser->current_token_type = T_STRING;
@@ -134,42 +167,42 @@ static void json_parse_string(JsonParser *parser)
 		c = parser->current++[0];
 		switch (c)
 		{
-			case '\\':
-			case '"':
-			case '/':
-				break;
-			case 'b':
-				c = '\b';
-				break;
-			case 'n':
-				c = '\n';
-				break;
-			case 'f':
-				c = '\f';
-				break;
-			case 'r':
-				c = '\r';
-				break;
-			case 't':
-				c = '\t';
-				break;
-			case 'u':
+		case '\\':
+		case '"':
+		case '/':
+			break;
+		case 'b':
+			c = '\b';
+			break;
+		case 'n':
+			c = '\n';
+			break;
+		case 'f':
+			c = '\f';
+			break;
+		case 'r':
+			c = '\r';
+			break;
+		case 't':
+			c = '\t';
+			break;
+		case 'u':
+		{
+			char u1 = parser->current++[0];
+			char u2 = parser->current++[0];
+			char u3 = parser->current++[0];
+			char u4 = parser->current++[0];
+			if (!char_is_hex(u1) || !char_is_hex(u2) || !char_is_hex(u3) || !char_is_hex(u4))
 			{
-				char u1 = parser->current++[0];
-				char u2 = parser->current++[0];
-				char u3 = parser->current++[0];
-				char u4 = parser->current++[0];
-				if (!char_is_hex(u1) || !char_is_hex(u2) || !char_is_hex(u3) || !char_is_hex(u4))
-				{
-					json_error(parser, "Invalid hex in \\u escape sequence.");
-					return;
-				}
-				c = (char_hex_to_nibble(u1) << 12) + (char_hex_to_nibble(u2) << 8) + (char_hex_to_nibble(u3) << 4) + char_hex_to_nibble(u4);
-				break;
-			}
-			default:
-				json_error(parser, "Invalid escape sequence.");
+				json_error(parser, "Invalid hex in \\u escape sequence.");
 				return;
+			}
+			c = (char_hex_to_nibble(u1) << 12) + (char_hex_to_nibble(u2) << 8) + (char_hex_to_nibble(u3) << 4) + char_hex_to_nibble(u4);
+			break;
+		}
+		default:
+			json_error(parser, "Invalid escape sequence.");
+			return;
 		}
 		str_current++[0] = c;
 	}
@@ -183,79 +216,87 @@ static inline void json_lexer_advance(JsonParser *parser)
 	json_skip_whitespace(parser);
 	switch (parser->current[0])
 	{
-		case '\0':
-			parser->current_token_type = T_EOF;
+	case '\0':
+		parser->current_token_type = T_EOF;
+		return;
+	case '{':
+		parser->current_token_type = T_LBRACE;
+		parser->current++;
+		return;
+	case '}':
+		parser->current_token_type = T_RBRACE;
+		parser->current++;
+		return;
+	case '[':
+		parser->current_token_type = T_LBRACKET;
+		parser->current++;
+		return;
+	case ']':
+		parser->current_token_type = T_RBRACKET;
+		parser->current++;
+		return;
+	case ':':
+		parser->current_token_type = T_COLON;
+		parser->current++;
+		return;
+	case ',':
+		parser->current_token_type = T_COMMA;
+		parser->current++;
+		return;
+	case '"':
+		json_parse_string(parser);
+		return;
+	case '-':
+	case '0':
+	case '1':
+	case '2':
+	case '3':
+	case '4':
+	case '5':
+	case '6':
+	case '7':
+	case '8':
+	case '9':
+		json_parse_number(parser);
+		return;
+	case 't':
+		if (!json_match(parser, "true"))
+		{
+			json_error(parser, "Unexpected symbol, I expected maybe 'true' here.");
 			return;
-		case '{':
-			parser->current_token_type = T_LBRACE;
+		}
+		parser->current += 4;
+		parser->current_token_type = T_TRUE;
+		return;
+	case 'f':
+		if (!json_match(parser, "false"))
+		{
+			json_error(parser, "Unexpected symbol, I expected maybe 'false' here.");
+			return;
+		}
+		parser->current += 5;
+		parser->current_token_type = T_FALSE;
+		return;
+	case 'n':
+		if (!json_match(parser, "null"))
+		{
+			json_error(parser, "Unexpected symbol, I expected maybe 'null' here.");
+			return;
+		}
+		parser->current += 4;
+		parser->current_token_type = T_NULL;
+		return;
+	case '/':
+		char c = parser->current[1];
+		if (c == '/')
+		{
 			parser->current++;
-			return;
-		case '}':
-			parser->current_token_type = T_RBRACE;
-			parser->current++;
-			return;
-		case '[':
-			parser->current_token_type = T_LBRACKET;
-			parser->current++;
-			return;
-		case ']':
-			parser->current_token_type = T_RBRACKET;
-			parser->current++;
-			return;
-		case ':':
-			parser->current_token_type = T_COLON;
-			parser->current++;
-			return;
-		case ',':
-			parser->current_token_type = T_COMMA;
-			parser->current++;
-			return;
-		case '"':
-			json_parse_string(parser);
-			return;
-		case '-':
-		case '0':
-		case '1':
-		case '2':
-		case '3':
-		case '4':
-		case '5':
-		case '6':
-		case '7':
-		case '8':
-		case '9':
-			json_parse_number(parser);
-			return;
-		case 't':
-			if (!json_match(parser, "true"))
-			{
-				json_error(parser, "Unexpected symbol, I expected maybe 'true' here.");
-				return;
-			}
-			parser->current += 4;
-			parser->current_token_type = T_TRUE;
-			return;
-		case 'f':
-			if (!json_match(parser, "false"))
-			{
-				json_error(parser, "Unexpected symbol, I expected maybe 'false' here.");
-				return;
-			}
-			parser->current += 5;
-			parser->current_token_type = T_FALSE;
-			return;
-		case 'n':
-			if (!json_match(parser, "null"))
-			{
-				json_error(parser, "Unexpected symbol, I expected maybe 'null' here.");
-				return;
-			}
-			parser->current += 4;
-			parser->current_token_type = T_NULL;
-			return;
-		default:
-			json_error(parser, "Unexpected symbol found.");
-			return;
+			json_parse_comment_line(parser);
+		}
+		return;
+	default:
+		json_error(parser, "Unexpected symbol found.");
+		return;
 	}
 	UNREACHABLE
 }
@@ -278,21 +319,29 @@ JSONObject *json_parse_array(JsonParser *parser)
 	}
 	size_t capacity = 16;
 	JSONObject *array = json_new_object(parser->allocator, J_ARRAY);
-	JSONObject** elements = parser->allocator(sizeof(JSONObject*) * capacity);
+	JSONObject **elements = parser->allocator(sizeof(JSONObject *) * capacity);
 	size_t index = 0;
 	while (1)
 	{
 		JSONObject *parsed = json_parse(parser);
+
 		if (parser->error_message) return &error;
 		if (index >= capacity)
 		{
 			JSONObject **elements_old = elements;
-			size_t copy_size = capacity * sizeof(JSONObject*);
+			size_t copy_size = capacity * sizeof(JSONObject *);
 			capacity *= 2;
-			elements = parser->allocator(sizeof(JSONObject*) * capacity);
+			elements = parser->allocator(sizeof(JSONObject *) * capacity);
 			memcpy(elements, elements_old, copy_size);
 		}
 		elements[index++] = parsed;
+
+		if (parsed->type == J_COMMENT_LINE)
+		{
+			if (consume(parser, T_RBRACKET)) break;
+			continue;
+		}
+
 		if (consume(parser, T_RBRACKET)) break;
 		CONSUME(T_COMMA);
 		// Allow trailing comma
@@ -306,35 +355,75 @@ JSONObject *json_parse_array(JsonParser *parser)
 JSONObject *json_parse_object(JsonParser *parser)
 {
 	CONSUME(T_LBRACE);
+
 	if (consume(parser, T_RBRACE))
 	{
 		return &empty_obj_val;
 	}
+
 	size_t capacity = 16;
 	JSONObject *obj = json_new_object(parser->allocator, J_OBJECT);
-	JSONObject** elements = parser->allocator(sizeof(JSONObject*) * capacity);
-	const char** keys = parser->allocator(sizeof(JSONObject*) * capacity);
+	JSONObject **elements = parser->allocator(sizeof(JSONObject *) * capacity);
+	const char **keys = parser->allocator(sizeof(JSONObject *) * capacity);
 	size_t index = 0;
 	while (1)
 	{
+		if (consume(parser, T_RBRACE))
+		{
+			break;
+		}
+
+		// Parse COMMENT LINE
+		if (parser->current_token_type == T_COMMENT)
+		{
+			JSONObject *value = json_parse(parser);
+
+
+			if (parser->error_message) return NULL;
+			if (index >= capacity)
+			{
+				JSONObject **elements_old = elements;
+				const char **keys_old = keys;
+				size_t copy_size = capacity * sizeof(void *);
+				capacity *= 2;
+				elements = parser->allocator(sizeof(JSONObject *) * capacity);
+				keys = parser->allocator(sizeof(JSONObject *) * capacity);
+				memcpy(elements, elements_old, copy_size);
+				memcpy(keys, keys_old, copy_size);
+			}
+
+			keys[index] = NULL;
+			elements[index++] = value;
+
+			continue;
+		}
+
 		const char *key = parser->last_string;
+
 		CONSUME(T_STRING);
 		CONSUME(T_COLON);
+
 		JSONObject *value = json_parse(parser);
+
+
 		if (parser->error_message) return NULL;
 		if (index >= capacity)
 		{
 			JSONObject **elements_old = elements;
 			const char **keys_old = keys;
-			size_t copy_size = capacity * sizeof(void*);
+			size_t copy_size = capacity * sizeof(void *);
 			capacity *= 2;
-			elements = parser->allocator(sizeof(JSONObject*) * capacity);
-			keys = parser->allocator(sizeof(JSONObject*) * capacity);
+			elements = parser->allocator(sizeof(JSONObject *) * capacity);
+			keys = parser->allocator(sizeof(JSONObject *) * capacity);
 			memcpy(elements, elements_old, copy_size);
 			memcpy(keys, keys_old, copy_size);
 		}
+
 		keys[index] = key;
 		elements[index++] = value;
+
+		if (consume(parser, T_COMMA)) continue;
+
 		if (consume(parser, T_RBRACE)) break;
 		if (!consume(parser, T_COMMA))
 		{
@@ -356,7 +445,7 @@ JSONObject *json_obj_get(JSONObject *obj, const char *key)
 	assert(obj->type == J_OBJECT);
 	for (unsigned i = 0; i < obj->member_len; i++)
 	{
-		if (strcmp(obj->keys[i], key) == 0) return obj->elements[i];
+		if (obj->keys[i] != 0 && strcmp(obj->keys[i], key) == 0) return obj->elements[i];
 	}
 	return NULL;
 }
@@ -366,51 +455,57 @@ JSONObject *json_parse(JsonParser *parser)
 	if (parser->error_message) return &error;
 	switch (parser->current_token_type)
 	{
-		case T_EOF:
-			return NULL;
-		case T_ERROR:
-			UNREACHABLE
-		case T_LBRACE:
-			return json_parse_object(parser);
-		case T_LBRACKET:
-			return json_parse_array(parser);
-		case T_COMMA:
-		case T_RBRACE:
-		case T_RBRACKET:
-		case T_COLON:
-			json_error(parser, "Unexpected character.");
-			return NULL;
-		case T_STRING:
+	case T_EOF:
+		return NULL;
+	case T_ERROR:
+		UNREACHABLE
+	case T_LBRACE:
+		return json_parse_object(parser);
+	case T_LBRACKET:
+		return json_parse_array(parser);
+	case T_COMMA:
+	case T_RBRACE:
+	case T_RBRACKET:
+	case T_COLON:
+		json_error(parser, "Unexpected character.");
+		return NULL;
+	case T_STRING:
+	{
+		JSONObject *obj = json_new_object(parser->allocator, J_STRING);
+		obj->type = J_STRING;
+		obj->str = parser->last_string;
+		json_lexer_advance(parser);
+		return obj;
+	}
+	case T_NUMBER:
+	{
+		JSONObject *obj = NULL;
+		if (parser->last_number == 0)
 		{
-			JSONObject *obj = json_new_object(parser->allocator, J_STRING);
-			obj->type = J_STRING;
-			obj->str = parser->last_string;
 			json_lexer_advance(parser);
-			return obj;
+			return &zero_val;
 		}
-		case T_NUMBER:
-		{
-			JSONObject *obj = NULL;
-			if (parser->last_number == 0) 
-			{
-				json_lexer_advance(parser);
-				return &zero_val;
-			}
-			obj = json_new_object(parser->allocator, J_NUMBER);
-			obj->type = J_NUMBER;
-			obj->f = parser->last_number;
-			json_lexer_advance(parser);
-			return obj;
-		}
-		case T_TRUE:
-			json_lexer_advance(parser);
-			return &true_val;
-		case T_FALSE:
-			json_lexer_advance(parser);
-			return &false_val;
-		case T_NULL:
-			json_lexer_advance(parser);
-			return NULL;
+		obj = json_new_object(parser->allocator, J_NUMBER);
+		obj->type = J_NUMBER;
+		obj->f = parser->last_number;
+		json_lexer_advance(parser);
+		return obj;
+	}
+	case T_TRUE:
+		json_lexer_advance(parser);
+		return &true_val;
+	case T_FALSE:
+		json_lexer_advance(parser);
+		return &false_val;
+	case T_NULL:
+		json_lexer_advance(parser);
+		return NULL;
+	case T_COMMENT:
+		JSONObject *obj = json_new_object(parser->allocator, J_COMMENT_LINE);
+		obj->type = J_COMMENT_LINE;
+		obj->str = parser->last_string;
+		json_lexer_advance(parser);
+		return obj;
 	}
 	UNREACHABLE
 }
@@ -441,30 +536,143 @@ void json_free(JsonDeallocator *deallocator, JSONObject **ptr)
 
 	if (!is_freable(obj)) return;
 
-	switch(obj->type)
+	switch (obj->type)
 	{
-		case J_OBJECT:
-			for (size_t i = 0; i < obj->member_len; i++)
-			{
-				json_free(deallocator, &obj->members[i]);
-				deallocator((char*)obj->keys[i]);
-			}
-			deallocator(obj->keys);
-			deallocator(obj->members);
-			break;
-		case J_ARRAY:
-			for (size_t i = 0; i < obj->array_len; i++)
-			{
-				json_free(deallocator, &obj->elements[i]);
-			}
-			deallocator(obj->elements);
-			break;
-		case J_STRING:
-			deallocator((char*)obj->str);
-			break;
-		default:
-			break;
+	case J_OBJECT:
+		for (size_t i = 0; i < obj->member_len; i++)
+		{
+			json_free(deallocator, &obj->members[i]);
+			deallocator((char *)obj->keys[i]);
+		}
+		deallocator(obj->keys);
+		deallocator(obj->members);
+		break;
+	case J_ARRAY:
+		for (size_t i = 0; i < obj->array_len; i++)
+		{
+			json_free(deallocator, &obj->elements[i]);
+		}
+		deallocator(obj->elements);
+		break;
+	case J_STRING:
+		deallocator((char *)obj->str);
+		break;
+	default:
+		break;
 	}
 	deallocator(*ptr);
 	*ptr = NULL;
 }
+
+static inline void print_indent(int indent_level, FILE *file)
+{
+	for (int i = 0; i < indent_level; i++)
+	{
+		fputs("  ", file);
+	}
+}
+
+static inline void print_json(JSONObject *obj, int indent_level, FILE *file)
+{
+	if (obj == NULL)
+	{
+		return;
+	}
+
+	switch (obj->type)
+	{
+	case J_BOOL:
+		PRINTF(file, "%s", obj->b ? "true" : "false");
+		break;
+	case J_STRING:
+		PRINTF(file, "\"%s\"", obj->str);
+		break;
+	case J_NUMBER:
+		PRINTF(file, "%f", obj->f);
+		break;
+	case J_ARRAY:
+
+		fputs(" [ ", file);
+
+		if (obj->array_len == 0)
+		{
+			fputs(" ]", file);
+			break;
+		}
+
+		bool should_print_item_per_line = false;
+
+		for (size_t i = 0; i < obj->array_len; i++)
+		{
+			if (obj->elements[i]->type == J_OBJECT)
+			{
+				should_print_item_per_line = true;
+				break;
+			}
+
+			if (obj->elements[i]->type == J_COMMENT_LINE)
+			{
+				should_print_item_per_line = true;
+				break;
+			}
+		}
+
+		if (!should_print_item_per_line && obj->array_len < 5)
+		{
+			for (size_t i = 0; i < obj->array_len; i++)
+			{
+				if (i != 0) fputs(", ", file);
+				print_json(obj->elements[i], indent_level, file);
+			}
+			fputs(" ]", file);
+			break;
+		}
+
+		fputs("\n", file);
+		for (size_t i = 0; i < obj->array_len; i++)
+		{
+			if (obj->elements[i]->type == J_COMMENT_LINE)
+			{
+				print_json(obj->elements[i], indent_level, file);
+				continue;
+			}
+
+			print_indent(indent_level + 1, file);
+			print_json(obj->elements[i], indent_level + 1, file);
+			fputs(",\n", file);
+		}
+
+		fputs(" ]", file);
+		break;
+	case J_OBJECT:
+		fputs("{\n", file);
+		for (size_t i = 0; i < obj->member_len; i++)
+		{
+			if (obj->members[i]->type == J_COMMENT_LINE)
+			{
+				print_json(obj->members[i], indent_level, file);
+				continue;
+			}
+
+			print_indent(indent_level + 1, file);
+			PRINTF(file, "\"%s\": ", obj->keys[i]);
+			print_json(obj->members[i], indent_level + 1, file);
+			fputs(",\n", file);
+		}
+		print_indent(indent_level, file);
+		fputs("}", file);
+		break;
+	case J_COMMENT_LINE:
+		print_indent(indent_level + 1, file);
+		PRINTF(file, "//%s\n", obj->str);
+		break;
+	default:
+		break;
+	}
+}
+
+void print_json_to_file(JSONObject *obj, FILE *file)
+{
+	print_json(obj, 0, file);
+}
+

--- a/src/utils/json.h
+++ b/src/utils/json.h
@@ -6,8 +6,7 @@ typedef enum
 	J_ARRAY,
 	J_NUMBER,
 	J_BOOL,
-	J_ERROR,
-	J_COMMENT_LINE
+	J_ERROR
 } JSONType;
 
 
@@ -47,8 +46,7 @@ typedef enum JSONTokenType_
 	T_TRUE,
 	T_FALSE,
 	T_NULL,
-	T_EOF,
-	T_COMMENT
+	T_EOF
 } JSONTokenType;
 
 typedef void *(JsonAllocator)(size_t);

--- a/src/utils/json.h
+++ b/src/utils/json.h
@@ -7,6 +7,7 @@ typedef enum
 	J_NUMBER,
 	J_BOOL,
 	J_ERROR,
+	J_COMMENT_LINE
 } JSONType;
 
 
@@ -47,10 +48,11 @@ typedef enum JSONTokenType_
 	T_FALSE,
 	T_NULL,
 	T_EOF,
+	T_COMMENT
 } JSONTokenType;
 
-typedef void*(JsonAllocator)(size_t);
-typedef void*(JsonDeallocator)(void*);
+typedef void *(JsonAllocator)(size_t);
+typedef void *(JsonDeallocator)(void *);
 
 typedef struct
 {
@@ -68,6 +70,7 @@ JSONObject *json_parse(JsonParser *parser);
 JSONObject *json_obj_get(JSONObject *obj, const char *key);
 INLINE JSONObject *json_new_object(JsonAllocator *allocator, JSONType type);
 void json_free(JsonDeallocator *deallocator, JSONObject **ptr);
+void print_json_to_file(JSONObject *obj, FILE *file);
 
 
 INLINE JSONObject *json_new_object(JsonAllocator *allocator, JSONType type)


### PR DESCRIPTION
Contribution to #1311 issue

* json.c functionality to print JSONObject into a FILE.
* ~~ json.c to parse line comments (//line comment) as JSONObject node. ~~
* add-target project subcommand: read project.json into JSONObject, add JSONObject target, print into file.
* ~~line comments are preserved after project.json manipulation~~

![image](https://github.com/user-attachments/assets/20babcaf-c087-4a0a-aa13-dff9b56107aa)

~~Because line comments can appear at any point, it slightly messes CONSUME elegancy of json parser.~~


project.json
```
{
  // Language version of C3.
  "langrev": "1",
  // Warnings used for all targets.
  "warnings":  [ "no-unused" ],
  // Directories where C3 library files may be found.
  "dependency-search-paths":  [ "lib" ],
  // Libraries to use for all targets.
  "dependencies":  [  ],
  // Authors, optionally with email.
  "authors":  [ "John Doe <john.doe@example.com>" ],
  // Version using semantic versioning.
  "version": "0.1.0",
  // Sources compiled for all targets.
  "sources":  [ "src/**" ],
  // C sources if the project also compiles C sources
  // relative to the project file.
  // "c-sources": [ "csource/**" ],
  // Output location, relative to project file.
  "output": "build",
  // Architecture and OS target.
  // You can use 'c3c --list-targets' to list all valid targets.
  // "target": "windows-x64",
  // Targets.
  "targets": {
    "target_1": {
      // Executable or library.
      "type": "executable",
      // Additional libraries, sources
      // and overrides of global settings here.
    },
    "target_2": {
      "type": "static-lib",
    },
  },
  // Global settings.
  // CPU name, used for optimizations in the LLVM backend.
  "cpu": "generic",
  // Optimization: "O0", "O1", "O2", "O3", "O4", "O5", "Os", "Oz".
  "opt": "O0",
  // See resources/examples/project_all_settings.json and 'c3c --list-project-properties' to see more properties.
}
```