### PR TITLE
Escape arguments to platform linker/compiler.

### DIFF
--- a/resources/testproject/lib/clib.c3l/manifest.json
+++ b/resources/testproject/lib/clib.c3l/manifest.json
@@ -1,6 +1,6 @@
 { 
   "provides" : "clib",
-  "c-sources" : ["hello2.c"],
+  "c-sources" : ["hello2.c", "whitespace test.c"],
   "targets" : {
     "macos-x64" : {
     },

--- a/resources/testproject/lib/clib.c3l/whitespace test.c
+++ b/resources/testproject/lib/clib.c3l/whitespace test.c
@@ -1,0 +1,1 @@
+#include <stdio.h>

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -665,6 +665,7 @@ const char *concat_string_parts(const char **args)
 	scratch_buffer_clear();
 	FOREACH(const char *, arg, args)
 	{
+		assert(arg != &scratch_buffer.str && "Incorrectly passed a scratch buffer string as an argument.");
 		if (PLATFORM_WINDOWS && arg == *args)
 		{
 			scratch_buffer_append(arg);

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -665,21 +665,16 @@ const char *concat_string_parts(const char **args)
 	scratch_buffer_clear();
 	FOREACH(const char *, arg, args)
 	{
-#if !PLATFORM_WINDOWS
-		scratch_buffer_append_shell_escaped(arg);
-#else
-		if (arg != *args)
-		{
-			scratch_buffer_append_double_quoted(arg);
-		}
-		else 
+		if (PLATFORM_WINDOWS && arg == *args)
 		{
 			scratch_buffer_append(arg);
 		}
-#endif
-		scratch_buffer_append_char(' ');
+		else 
+		{
+			scratch_buffer_append_argument(arg);
+		}
 	}
-	return strdup(scratch_buffer_to_string());
+	return scratch_buffer_copy();
 }
 
 

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -766,7 +766,7 @@ const char *cc_compiler(const char *cc, const char *file, const char *flags, con
 
 	FOREACH(const char *, include_dir, include_dirs)
 	{
-		vec_add(parts, str_printf(is_cl_exe ? "/I\"%s\"" : "-I\"%s\"", include_dir));
+		vec_add(parts, str_printf(is_cl_exe ? "/I%s" : "-I%s", include_dir));
 	}
 
 	const bool pie_set =
@@ -785,7 +785,7 @@ const char *cc_compiler(const char *cc, const char *file, const char *flags, con
 	vec_add(parts, file);
 	if (is_cl_exe)
 	{
-		vec_add(parts, str_printf("/Fo:\"%s\"", out_name));
+		vec_add(parts, str_printf("/Fo:%s", out_name));
 	}
 	else
 	{

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -665,7 +665,7 @@ const char *concat_string_parts(const char **args)
 	scratch_buffer_clear();
 	FOREACH(const char *, arg, args)
 	{
-		assert(arg != &scratch_buffer.str && "Incorrectly passed a scratch buffer string as an argument.");
+		assert(arg != scratch_buffer.str && "Incorrectly passed a scratch buffer string as an argument.");
 		if (PLATFORM_WINDOWS && arg == *args)
 		{
 			scratch_buffer_append(arg);

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -153,8 +153,8 @@ void slice_trim(StringSlice *slice);
 
 void scratch_buffer_clear(void);
 void scratch_buffer_append(const char *string);
-UNUSED char *scratch_buffer_get_quoted(const char *string);
-UNUSED void scratch_buffer_append_quoted(const char *string);
+void scratch_buffer_append_double_quoted(const char *string);
+void scratch_buffer_append_shell_escaped(const char *string);
 void scratch_buffer_append_len(const char *string, size_t len);
 void scratch_buffer_append_char(char c);
 void scratch_buffer_append_signed_int(int64_t i);

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -153,10 +153,12 @@ void slice_trim(StringSlice *slice);
 
 void scratch_buffer_clear(void);
 void scratch_buffer_append(const char *string);
+void scratch_buffer_append_argument(const char *string);
 void scratch_buffer_append_double_quoted(const char *string);
 void scratch_buffer_append_shell_escaped(const char *string);
 void scratch_buffer_append_len(const char *string, size_t len);
 void scratch_buffer_append_char(char c);
+void scratch_buffer_append_char_repeat(char c, size_t count);
 void scratch_buffer_append_signed_int(int64_t i);
 void scratch_buffer_append_double(double d);
 UNUSED void scratch_buffer_append_unsigned_int(uint64_t i);

--- a/src/utils/stringutils.c
+++ b/src/utils/stringutils.c
@@ -320,15 +320,9 @@ void scratch_buffer_append_len(const char *string, size_t len)
 	scratch_buffer.len += (uint32_t)len;
 }
 
-char *scratch_buffer_get_quoted(const char *string)
+void scratch_buffer_append_double_quoted(const char *string)
 {
-	scratch_buffer_clear();
-	scratch_buffer_append_quoted(string);
-	return scratch_buffer_to_string();
-}
-
-void scratch_buffer_append_quoted(const char *string)
-{
+	scratch_buffer_append_char('"');
 	char c;
 	while ((c = string++[0]) != '\0')
 	{
@@ -343,14 +337,39 @@ void scratch_buffer_append_quoted(const char *string)
 			case '\n':
 				scratch_buffer_append("\\n");
 				continue;
-			case '\'':
-				scratch_buffer_append("\\'");
-				continue;
 			default:
 				scratch_buffer_append_char(c);
 				continue;
 
 		}
+	}
+	scratch_buffer_append_char('"');
+}
+
+void scratch_buffer_append_shell_escaped(const char *string)
+{
+	char c;
+	while ((c = string++[0]) != '\0')
+	{
+		if ((unsigned)c < 0x80)
+		{
+			switch (c)
+			{
+				case LOWER_CHAR_CASE:
+				case UPPER_CHAR_CASE:
+				case NUMBER_CHAR_CASE:
+				case '_':
+				case '/':
+				case '.':
+				case ',':
+				case '-':
+					break;
+				default:
+					scratch_buffer_append_char('\\');
+					break;
+			}
+		}
+		scratch_buffer_append_char(c);
 	}
 }
 void scratch_buffer_append(const char *string)


### PR DESCRIPTION
For the most part fixes problems when a file path passed to platform linker or compiler has whitespace in it.

I assume `linker.c` is going to be cleaned up/refactored in the future and argument handling may be handled a bit differently, so this is a quick fix until then.

Tested on Linux, macOS and Windows with a variety of inputs.