### PR TITLE
fix: Guard against uninitialized hashmap in key removal

### DIFF
--- a/lib/std/collections/map.c3
+++ b/lib/std/collections/map.c3
@@ -369,6 +369,7 @@ fn void HashMap.free_internal(&map, void* ptr) @inline @private
 
 fn bool HashMap.remove_entry_for_key(&map, Key key) @private
 {
+	if (!map.count) return false;
 	uint hash = rehash(key.hash());
 	uint i = index_for(hash, map.table.len);
 	Entry* prev = map.table[i];


### PR DESCRIPTION
Removing non-present keys is a supported operation on HashMaps, and most other operations are defined on uninitialized HashMaps.

Currently, removing any key on an uninitialized HashMap will result in an 'Array index out of bounds' error.

This change guards against such a case.