### PR TITLE
Fixed gencontext_begin_module using wrong reloc_model.

### DIFF
--- a/src/compiler/llvm_codegen_module.c
+++ b/src/compiler/llvm_codegen_module.c
@@ -73,7 +73,7 @@ void gencontext_begin_module(GenContext *c)
 
 	static const char *pic_level = "PIC Level";
 	static const char *pie_level = "PIE Level";
-	switch (compiler.build.reloc_model)
+	switch (compiler.platform.reloc_model)
 	{
 		case RELOC_BIG_PIE:
 			llvm_set_module_flag(c, LLVMModuleFlagBehaviorOverride, pie_level, (unsigned)2 /* PIE */, type_uint);


### PR DESCRIPTION
It was using compiler.build.reloc_model, which is just a flag value, so it defaults to none(0) if --reloc isn't passed.
I changed it to compiler.platform.reloc_model, because linker_setup_* functions were using that.