### PR TITLE
Print Git Hash on `--version`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,19 @@ if(C3_USE_TB AND GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
     endif()
 endif()
 
+if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    # Get git hash
+    execute_process(COMMAND git rev-parse HEAD
+            OUTPUT_VARIABLE GIT_HASH
+            RESULT_VARIABLE GIT_REVPARSE_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(GIT_REVPARSE_RESULT EQUAL "0")
+        add_compile_definitions(GIT_HASH="${GIT_HASH}")
+    else()
+        message(WARNING "Cannot to get Git Hash: git rev-parse failed with ${GIT_REVPARSE_RESULT}")
+    endif()
+endif()
+
 if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     if (C3_LLVM_VERSION STREQUAL "auto")
         set(C3_LLVM_VERSION "18")

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -482,6 +482,9 @@ static void print_version(void)
 	PRINTF("C3 Compiler Version:       %s", COMPILER_VERSION);
 #endif
 	PRINTF("Installed directory:       %s", find_executable_path());
+#ifdef GIT_HASH
+	PRINTF("Git Hash:                  %s", GIT_HASH);
+#endif
 	PRINTF("LLVM version:              %s", llvm_version);
 	PRINTF("LLVM default target:       %s", llvm_target);
 }


### PR DESCRIPTION
Since I primarily use Pre-Release (the Release does not have the features that I need yet) I want to be aware on which commit I currently am. I think it could be generally useful for anybody to have this information in `--version`. I don't know if this needs any tests. Please let me know if there are any issues with this approach.