### PR TITLE
Properly persist git hash on each build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,19 +101,6 @@ if(C3_USE_TB AND GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
     endif()
 endif()
 
-if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
-    # Get git hash
-    execute_process(COMMAND git rev-parse HEAD
-            OUTPUT_VARIABLE GIT_HASH
-            RESULT_VARIABLE GIT_REVPARSE_RESULT
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(GIT_REVPARSE_RESULT EQUAL "0")
-        add_compile_definitions(GIT_HASH="${GIT_HASH}")
-    else()
-        message(WARNING "Cannot to get Git Hash: git rev-parse failed with ${GIT_REVPARSE_RESULT}")
-    endif()
-endif()
-
 if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     if (C3_LLVM_VERSION STREQUAL "auto")
         set(C3_LLVM_VERSION "18")
@@ -349,8 +336,14 @@ add_executable(c3c
         src/utils/time.c
         src/utils/http.c
         src/compiler/sema_liveness.c
-        src/build/common_build.c)
+        src/build/common_build.c
+        ${CMAKE_BINARY_DIR}/git_hash.h)
 
+add_custom_target(
+        generate_git_hash
+        ALL
+        COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_LIST_DIR}/git_hash.cmake"
+        BYPRODUCTS ${CMAKE_BINARY_DIR}/git_hash.h)
 
 if (C3_USE_TB)
     file(GLOB tilde-sources
@@ -391,7 +384,8 @@ endif()
 
 target_include_directories(c3c PRIVATE
         "${CMAKE_SOURCE_DIR}/src/"
-        "${CMAKE_SOURCE_DIR}/wrapper/include/")
+        "${CMAKE_SOURCE_DIR}/wrapper/include/"
+        "${CMAKE_BINARY_DIR}")
 
 
 target_include_directories(c3c_wrappers PRIVATE

--- a/git_hash.cmake
+++ b/git_hash.cmake
@@ -1,0 +1,14 @@
+find_package(Git QUIET)
+
+set(GIT_HASH "unknown")
+
+if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git")
+    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+                    OUTPUT_VARIABLE GIT_HASH
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    COMMAND_ERROR_IS_FATAL ANY)
+endif()
+
+message("Git Hash: ${GIT_HASH}")
+
+file(WRITE ${CMAKE_BINARY_DIR}/git_hash.h "#pragma once\n#define GIT_HASH \"${GIT_HASH}\"\n")

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -5,6 +5,7 @@
 #include "../utils/whereami.h"
 #include "build.h"
 #include "build_internal.h"
+#include "git_hash.h"
 
 extern int llvm_version_major;
 bool silence_deprecation;
@@ -482,9 +483,7 @@ static void print_version(void)
 	PRINTF("C3 Compiler Version:       %s", COMPILER_VERSION);
 #endif
 	PRINTF("Installed directory:       %s", find_executable_path());
-#ifdef GIT_HASH
 	PRINTF("Git Hash:                  %s", GIT_HASH);
-#endif
 	PRINTF("LLVM version:              %s", llvm_version);
 	PRINTF("LLVM default target:       %s", llvm_target);
 }


### PR DESCRIPTION
From https://github.com/c3lang/c3c/pull/1387#issuecomment-2315386781

The approach for embedding the git hash into the executable I introduced is flawed. It only works at the configuration step. So if you fetch your changes and simply rebuild the compiler, you end up with the previous hash still being displayed on `--version`. This is a very important issue as it makes the application display misleading information. I extremely apologize for wasting time and not testing my PRs properly.

Here is the new approach:
- Instead of passing git hash via a macro definition we save it into a separate `./build/git_hash.h` file that is then included into the source code. 
- The `./build/git_hash.h` file is generated by a standalone script `./git_hash.cmake`. 
- This script is not part of `CMakeLists.txt` and it is meant to be run via `cmake -P ./git_hash.cmake` from `CMakeLists.txt`. 
- We introduce a custom target `generate_git_hash` that runs `./git_hash.cmake` and produces `./build/git_hash.h` as a byproduct. 
- We then make `c3c` executable depend on `./build/git_hash.h` which triggers `generate_git_hash` on every build.

Tested locally on Linux and everything seems to be file. Let's see how it performs on CI. Please let me know if you see any flaws. Sorry again for wasting time.