### PR TITLE
Adding hashmap and map initialization functions with data

### DIFF
--- a/lib/std/collections/hashmap.c3
+++ b/lib/std/collections/hashmap.c3
@@ -53,6 +53,76 @@ fn HashMap* HashMap.temp_init(&self, uint capacity = DEFAULT_INITIAL_CAPACITY, f
 	return self.init(allocator::temp(), capacity, load_factor) @inline;
 }
 
+/**
+ * @param [&inout] allocator "The allocator to use"
+ * @require capacity > 0 "The capacity must be 1 or higher"
+ * @require load_factor > 0.0 "The load factor must be higher than 0"
+ * @require !self.allocator "Map was already initialized"
+ * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
+ **/
+macro HashMap* HashMap.new_init_with_keyvalues(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+{
+	self.new_init(.capacity = capacity, .load_factor = load_factor, .allocator = allocator);
+	$for (var $i = 0; $i < $vacount; $i += 2)
+		self.set($vaarg[$i], $vaarg[$i+1]);
+	$endfor
+	return self;
+}
+
+/**
+ * @param [in] keys "The keys for the HashMap entries"
+ * @param [in] values "The values for the HashMap entries"
+ * @param [&inout] allocator "The allocator to use"
+ * @require capacity > 0 "The capacity must be 1 or higher"
+ * @require load_factor > 0.0 "The load factor must be higher than 0"
+ * @require !self.allocator "Map was already initialized"
+ * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
+ **/
+fn HashMap* HashMap.new_init_with_arrays(&self, Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+{
+	assert(keys.len == values.len);
+	self.new_init(.capacity = capacity, .load_factor = load_factor, .allocator = allocator);
+	for (usz i = 0; i < keys.len; i++)
+	{
+		self.set(keys[i], values[i]);
+	}
+	return self;
+}
+
+/**
+ * @require capacity > 0 "The capacity must be 1 or higher"
+ * @require load_factor > 0.0 "The load factor must be higher than 0"
+ * @require !self.allocator "Map was already initialized"
+ * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
+ **/
+macro HashMap* HashMap.temp_init_with_keyvalues(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
+{
+	self.temp_init(.capacity = capacity, .load_factor = load_factor);
+	$for (var $i = 0; $i < $vacount; $i += 2)
+		self.set($vaarg[$i], $vaarg[$i+1]);
+	$endfor
+	return self;
+}
+
+/**
+ * @param [in] keys "The keys for the HashMap entries"
+ * @param [in] values "The values for the HashMap entries"
+ * @param [&inout] allocator "The allocator to use"
+ * @require capacity > 0 "The capacity must be 1 or higher"
+ * @require load_factor > 0.0 "The load factor must be higher than 0"
+ * @require !self.allocator "Map was already initialized"
+ * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
+ **/
+fn HashMap* HashMap.temp_init_with_arrays(&self, Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+{
+	assert(keys.len == values.len);
+	self.temp_init(.capacity = capacity, .load_factor = load_factor);
+	for (usz i = 0; i < keys.len; i++)
+	{
+		self.set(keys[i], values[i]);
+	}
+	return self;
+}
 
 /**
  * Has this hash map been initialized yet?

--- a/lib/std/collections/hashmap.c3
+++ b/lib/std/collections/hashmap.c3
@@ -55,12 +55,13 @@ fn HashMap* HashMap.temp_init(&self, uint capacity = DEFAULT_INITIAL_CAPACITY, f
 
 /**
  * @param [&inout] allocator "The allocator to use"
+ * @require $vacount % 2 == 0 "There must be an even number of arguments provided for keys and values"
  * @require capacity > 0 "The capacity must be 1 or higher"
  * @require load_factor > 0.0 "The load factor must be higher than 0"
  * @require !self.allocator "Map was already initialized"
  * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
  **/
-macro HashMap* HashMap.new_init_with_keyvalues(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+macro HashMap* HashMap.new_init_with_key_values(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
 {
 	self.new_init(.capacity = capacity, .load_factor = load_factor, .allocator = allocator);
 	$for (var $i = 0; $i < $vacount; $i += 2)
@@ -73,12 +74,13 @@ macro HashMap* HashMap.new_init_with_keyvalues(&self, ..., uint capacity = DEFAU
  * @param [in] keys "The keys for the HashMap entries"
  * @param [in] values "The values for the HashMap entries"
  * @param [&inout] allocator "The allocator to use"
+ * @require keys.len == values.len "Both keys and values arrays must be the same length"
  * @require capacity > 0 "The capacity must be 1 or higher"
  * @require load_factor > 0.0 "The load factor must be higher than 0"
  * @require !self.allocator "Map was already initialized"
  * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
  **/
-fn HashMap* HashMap.new_init_with_arrays(&self, Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+fn HashMap* HashMap.new_init_from_keys_and_values(&self, Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
 {
 	assert(keys.len == values.len);
 	self.new_init(.capacity = capacity, .load_factor = load_factor, .allocator = allocator);
@@ -90,12 +92,13 @@ fn HashMap* HashMap.new_init_with_arrays(&self, Key[] keys, Value[] values, uint
 }
 
 /**
+ * @require $vacount % 2 == 0 "There must be an even number of arguments provided for keys and values"
  * @require capacity > 0 "The capacity must be 1 or higher"
  * @require load_factor > 0.0 "The load factor must be higher than 0"
  * @require !self.allocator "Map was already initialized"
  * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
  **/
-macro HashMap* HashMap.temp_init_with_keyvalues(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
+macro HashMap* HashMap.temp_init_with_key_values(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
 {
 	self.temp_init(.capacity = capacity, .load_factor = load_factor);
 	$for (var $i = 0; $i < $vacount; $i += 2)
@@ -108,12 +111,13 @@ macro HashMap* HashMap.temp_init_with_keyvalues(&self, ..., uint capacity = DEFA
  * @param [in] keys "The keys for the HashMap entries"
  * @param [in] values "The values for the HashMap entries"
  * @param [&inout] allocator "The allocator to use"
+ * @require keys.len == values.len "Both keys and values arrays must be the same length"
  * @require capacity > 0 "The capacity must be 1 or higher"
  * @require load_factor > 0.0 "The load factor must be higher than 0"
  * @require !self.allocator "Map was already initialized"
  * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
  **/
-fn HashMap* HashMap.temp_init_with_arrays(&self, Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+fn HashMap* HashMap.temp_init_from_keys_and_values(&self, Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
 {
 	assert(keys.len == values.len);
 	self.temp_init(.capacity = capacity, .load_factor = load_factor);

--- a/lib/std/collections/map.c3
+++ b/lib/std/collections/map.c3
@@ -46,6 +46,73 @@ fn Map temp(uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAUL
 }
 
 /**
+ * @param [&inout] allocator "The allocator to use"
+ * @require capacity > 0 "The capacity must be 1 or higher"
+ * @require load_factor > 0.0 "The load factor must be higher than 0"
+ * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
+ **/
+macro Map new_with_keyvalues(..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+{
+	Map map = new(.capacity = capacity, .load_factor = load_factor, .allocator = allocator);
+	$for (var $i = 0; $i < $vacount; $i += 2)
+		map.set($vaarg[$i], $vaarg[$i+1]);
+	$endfor
+	return map;
+}
+
+/**
+ * @param [in] keys "Array of keys for the Map entries"
+ * @param [in] values "Array of values for the Map entries"
+ * @param [&inout] allocator "The allocator to use"
+ * @require capacity > 0 "The capacity must be 1 or higher"
+ * @require load_factor > 0.0 "The load factor must be higher than 0"
+ * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
+ **/
+fn Map new_with_arrays(Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+{
+	assert(keys.len == values.len);
+	Map map = new(.capacity = capacity, .load_factor = load_factor, .allocator = allocator);
+	for (usz i = 0; i < keys.len; i++)
+	{
+		map.set(keys[i], values[i]);
+	}
+	return map;
+}
+
+/**
+ * @require capacity > 0 "The capacity must be 1 or higher"
+ * @require load_factor > 0.0 "The load factor must be higher than 0"
+ * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
+ **/
+macro Map temp_with_keyvalues(..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
+{
+	Map map = temp(capacity, load_factor);
+	$for (var $i = 0; $i < $vacount; $i += 2)
+		map.set($vaarg[$i], $vaarg[$i+1]);
+	$endfor
+	return map;
+}
+
+/**
+ * @param [in] keys "The keys for the HashMap entries"
+ * @param [in] values "The values for the HashMap entries"
+ * @param [&inout] allocator "The allocator to use"
+ * @require capacity > 0 "The capacity must be 1 or higher"
+ * @require load_factor > 0.0 "The load factor must be higher than 0"
+ * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
+ **/
+fn Map temp_with_arrays(Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+{
+	assert(keys.len == values.len);
+	Map map = temp(capacity, load_factor);
+	for (usz i = 0; i < keys.len; i++)
+	{
+		map.set(keys[i], values[i]);
+	}
+	return map;
+}
+
+/**
  * @param [&in] other_map "The map to copy from."
  **/
 fn Map new_from_map(Map other_map, Allocator allocator = null)

--- a/lib/std/collections/map.c3
+++ b/lib/std/collections/map.c3
@@ -47,11 +47,12 @@ fn Map temp(uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAUL
 
 /**
  * @param [&inout] allocator "The allocator to use"
+ * @require $vacount % 2 == 0 "There must be an even number of arguments provided for keys and values"
  * @require capacity > 0 "The capacity must be 1 or higher"
  * @require load_factor > 0.0 "The load factor must be higher than 0"
  * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
  **/
-macro Map new_with_keyvalues(..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+macro Map new_init_with_key_values(..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
 {
 	Map map = new(.capacity = capacity, .load_factor = load_factor, .allocator = allocator);
 	$for (var $i = 0; $i < $vacount; $i += 2)
@@ -64,11 +65,12 @@ macro Map new_with_keyvalues(..., uint capacity = DEFAULT_INITIAL_CAPACITY, floa
  * @param [in] keys "Array of keys for the Map entries"
  * @param [in] values "Array of values for the Map entries"
  * @param [&inout] allocator "The allocator to use"
+ * @require keys.len == values.len "Both keys and values arrays must be the same length"
  * @require capacity > 0 "The capacity must be 1 or higher"
  * @require load_factor > 0.0 "The load factor must be higher than 0"
  * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
  **/
-fn Map new_with_arrays(Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+fn Map new_init_from_keys_and_values(Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
 {
 	assert(keys.len == values.len);
 	Map map = new(.capacity = capacity, .load_factor = load_factor, .allocator = allocator);
@@ -80,11 +82,12 @@ fn Map new_with_arrays(Key[] keys, Value[] values, uint capacity = DEFAULT_INITI
 }
 
 /**
+ * @require $vacount % 2 == 0 "There must be an even number of arguments provided for keys and values"
  * @require capacity > 0 "The capacity must be 1 or higher"
  * @require load_factor > 0.0 "The load factor must be higher than 0"
  * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
  **/
-macro Map temp_with_keyvalues(..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
+macro Map temp_new_with_key_values(..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
 {
 	Map map = temp(capacity, load_factor);
 	$for (var $i = 0; $i < $vacount; $i += 2)
@@ -97,11 +100,12 @@ macro Map temp_with_keyvalues(..., uint capacity = DEFAULT_INITIAL_CAPACITY, flo
  * @param [in] keys "The keys for the HashMap entries"
  * @param [in] values "The values for the HashMap entries"
  * @param [&inout] allocator "The allocator to use"
+ * @require keys.len == values.len "Both keys and values arrays must be the same length"
  * @require capacity > 0 "The capacity must be 1 or higher"
  * @require load_factor > 0.0 "The load factor must be higher than 0"
  * @require capacity < MAXIMUM_CAPACITY "Capacity cannot exceed maximum"
  **/
-fn Map temp_with_arrays(Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
+fn Map temp_init_from_keys_and_values(Key[] keys, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR, Allocator allocator = allocator::heap())
 {
 	assert(keys.len == values.len);
 	Map map = temp(capacity, load_factor);


### PR DESCRIPTION
Adding some functions to initialize HashMap and Map structures with data.
```
def StringHashMap = HashMap(<String, int>);
def IntHashMap = HashMap(<int, String>);
def StringMap = Map(<String, int>);
def IntMap = Map(<int, String>);

int[] keys = {1, 2, 3};
String[] values = {"one", "two", "three"};

fn void main(String[] args)
{
    StringHashMap m1;
    IntHashMap m2;

    m1.new_init_with_keyvalues("abc", 123, "def", 456, "ghi", 789);
    defer m1.free();
    m1.@each(; String k, int v) { io::printf("%s -> %s\n", k, v); };

    m2.new_init_with_arrays(keys, values);
    defer m2.free();
    m2.@each(; int k, String v) { io::printf("%s -> %s\n", k, v); };

    StringMap m3;
    IntMap m4;

    m3 = map::new_with_keyvalues(<String, int>)("abc", 123, "def", 456, "ghi", 789);
    defer m3.free();
    m3.@each(; String k, int v) { io::printf("%s -> %s\n", k, v); };

    m4 = map::new_with_arrays(<int, String>)(keys, values);
    defer m4.free();
    m4.@each(; int k, String v) { io::printf("%s -> %s\n", k, v); };
}
```
