### PR TITLE
Rename `inner_kind` and `inner_type`.

### DIFF
--- a/lib/std/core/mem.c3
+++ b/lib/std/core/mem.c3
@@ -373,10 +373,10 @@ macro void set_inline(void* dst, char val, usz $len, usz $dst_align = 0, bool $i
 	$$memset_inline(dst, val, $len, $is_volatile, $dst_align);
 }
 /**
- * @require values::@inner_kind(a) == TypeKind.SLICE || values::@inner_kind(a) == TypeKind.POINTER
- * @require values::@inner_kind(b) == TypeKind.SLICE || values::@inner_kind(b) == TypeKind.POINTER
- * @require values::@inner_kind(a) != TypeKind.SLICE || len == -1
- * @require values::@inner_kind(a) != TypeKind.POINTER || len > -1
+ * @require values::@remove_distinct_kind(a) == TypeKind.SLICE || values::@remove_distinct_kind(a) == TypeKind.POINTER
+ * @require values::@remove_distinct_kind(b) == TypeKind.SLICE || values::@remove_distinct_kind(b) == TypeKind.POINTER
+ * @require values::@remove_distinct_kind(a) != TypeKind.SLICE || len == -1
+ * @require values::@remove_distinct_kind(a) != TypeKind.POINTER || len > -1
  * @require values::@assign_to(a, b) && values::@assign_to(b, a)
  **/
 macro bool equals(a, b, isz len = -1, usz $align = 0)
@@ -386,7 +386,7 @@ macro bool equals(a, b, isz len = -1, usz $align = 0)
 	$endif
 	void* x @noinit;
 	void* y @noinit;
-	$if values::@inner_kind(a) == TypeKind.SLICE:
+	$if values::@remove_distinct_kind(a) == TypeKind.SLICE:
 		len = a.len;
 		if (len != b.len) return false;
 		x = a.ptr;

--- a/lib/std/core/types.c3
+++ b/lib/std/core/types.c3
@@ -128,7 +128,7 @@ macro bool is_int($Type) @const  => $Type.kindof == TypeKind.SIGNED_INT || $Type
  **/
 macro bool is_signed($Type) @const
 {
-	$switch (inner_kind($Type))
+	$switch (remove_distinct_kind($Type))
 		$case SIGNED_INT:
 		$case FLOAT:
 			return true;
@@ -144,7 +144,7 @@ macro bool is_signed($Type) @const
  **/
 macro bool is_unsigned($Type) @const
 {
-	$switch (inner_kind($Type))
+	$switch (remove_distinct_kind($Type))
 		$case UNSIGNED_INT:
 			return true;
 		$case VECTOR:
@@ -209,19 +209,28 @@ macro bool is_vector($Type) @const
 	return $Type.kindof == TypeKind.VECTOR;
 }
 
-macro typeid inner_type($Type) @const
+/**
+ * Recursively remove distinct to get the innermost type.
+ **/
+macro typeid remove_distinct($Type) @const
 {
 	$if $Type.kindof == TypeKind.DISTINCT:
-		return inner_type($typefrom($Type.inner));
+		return remove_distinct($typefrom($Type.inner));
 	$else
 		return $Type.typeid;
 	$endif
 }
 
-macro TypeKind inner_kind($Type) @const
+/**
+ * Recursively remove distinct to get the innermost TypeKind.
+ **/
+macro TypeKind remove_distinct_kind($Type) @const
 {
-	return inner_type($Type).kindof;
+	return remove_distinct($Type).kindof;
 }
+
+macro typeid inner_type($Type) @const @deprecated("Use remove_distinct") => remove_distinct($Type);
+macro TypeKind inner_kind($Type) @const @deprecated("Use remove_distinct_kind") => remove_distinct_kind($Type);
 
 macro bool is_same($TypeA, $TypeB) @const
 {

--- a/lib/std/core/values.c3
+++ b/lib/std/core/values.c3
@@ -42,5 +42,6 @@ macro promote_int_same(x, y)
 	$endif
 }
 
-macro TypeKind @inner_kind(#value) @const => types::inner_kind($typeof(#value));
-
+macro typeid @remove_distinct(#value) @const => types::remove_distinct($typeof(#value));
+macro TypeKind @remove_distinct_kind(#value) @const => types::remove_distinct_kind($typeof(#value));
+macro TypeKind @inner_kind(#value) @const @deprecated("Use @remove_distinct_kind") => @remove_distinct_kind(#value);

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -9,7 +9,8 @@
 *None yet*
 
 ### Stdlib changes
-*None yet*
+- Added `types::remove_distinct`, `types::remove_distinct_kind`, `values::@remove_distinct`, `values::@remove_distinct_kind`.
+- Deprecated `types::inner_kind`, `types::inner_type`, `values::@inner_kind`.
 
 ## 0.6.2 Change list
 


### PR DESCRIPTION
Rename to `remove_distinct_kind` and `remove_distinct`.

Are these names good? It might not be obvious they remove distinct *recursively*.
The alternative contenders would be `flatten_kind` and `flatten`, but then it's not entirely obvious what it does either.