### PR TITLE
Add CMake option C3_ENABLE_CLANGD_LSP

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 4
+
+[*.{c,cc,h}]
+indent_style = space
+indent_size = 4
+
+[*.{c3}]
+indent_style = space
+indent_size = 4
+
+[*.{json,toml,yml,gyp}]
+indent_style = space
+indent_size = 2
+
+[*.{py,pyi}]
+indent_style = space
+indent_size = 2
+

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,8 @@ out/
 
 # Emacs files
 TAGS
+
+# Clangd LSP files
+/.cache/
+/compile_commands.json
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,17 @@ if(C3_USE_TB AND GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
     endif()
 endif()
 
+# Clangd LSP support
+option(C3_ENABLE_CLANGD_LSP "Enable/Disable output of compile commands during generation." OFF)
+if(C3_ENABLE_CLANGD_LSP)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E create_symlink
+            ${CMAKE_BINARY_DIR}/compile_commands.json
+            ${CMAKE_SOURCE_DIR}/compile_commands.json
+    )
+endif(C3_ENABLE_CLANGD_LSP)
+
 if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
     if (C3_LLVM_VERSION STREQUAL "auto")
         set(C3_LLVM_VERSION "18")


### PR DESCRIPTION
Added a CMake option to be able to use Clangd LSP with neovim and vscode.