### PR TITLE
Move macro matrix_look_at to matrix module

### DIFF
--- a/lib/std/math/math_matrix.c3
+++ b/lib/std/math/math_matrix.c3
@@ -1,4 +1,5 @@
 module std::math::matrix(<Real>);
+import std::math::vector;
 
 struct Matrix2x2
 {
@@ -132,6 +133,7 @@ fn Matrix2x2 Matrix2x2.sub(&self, Matrix2x2 mat2) => matrix_sub(self, mat2);
 fn Matrix3x3 Matrix3x3.sub(&self, Matrix3x3 mat2) => matrix_sub(self, mat2);
 fn Matrix4x4 Matrix4x4.sub(&self, Matrix4x4 mat2) => matrix_sub(self, mat2);
 
+fn Matrix4x4 look_at(Real[<3>] eye, Real[<3>] target, Real[<3>] up) => matrix_look_at(Matrix4x4, eye, target, up);
 
 
 fn Matrix2x2 Matrix2x2.transpose(&self)
@@ -431,4 +433,18 @@ macro matrix_sub(mat, mat2) @private
 {
 	var $Type = Real[<$typeof(mat.m).len>];
 	return $typeof(*mat) { .m = ($Type)mat.m - ($Type)mat2.m };
+}
+
+macro matrix_look_at($Type, eye, target, up) @private
+{
+	var vz = (eye - target).normalize();
+	var vx = up.cross(vz).normalize();
+	var vy = vz.cross(vx);
+
+	return $Type {
+		vx[0], vx[1], vx[2], - (Real)vx.dot(eye),
+		vy[0], vy[1], vy[2], - (Real)vy.dot(eye),
+		vz[0], vz[1], vz[2], - (Real)vz.dot(eye),
+		0.0, 0.0, 0.0, 1
+	};
 }

--- a/lib/std/math/math_vector.c3
+++ b/lib/std/math/math_vector.c3
@@ -66,8 +66,8 @@ fn Vec3 Vec3.refract(self, Vec3 n, double r) => refract3(self, n, r);
 fn void ortho_normalize(Vec3f* v1, Vec3f* v2) => ortho_normalize3(v1, v2);
 fn void ortho_normalized(Vec3* v1, Vec3* v2) => ortho_normalize3(v1, v2);
 
-fn Matrix4f matrix4f_look_at(Vec3f eye, Vec3f target, Vec3f up) => matrix_look_at(Matrix4f, eye, target, up);
-fn Matrix4 matrix4_look_at(Vec3 eye, Vec3 target, Vec3 up) => matrix_look_at(Matrix4, eye, target, up);
+fn Matrix4f matrix4f_look_at(Vec3f eye, Vec3f target, Vec3f up) @deprecated => matrix::look_at(<float>)(eye, target, up);
+fn Matrix4 matrix4_look_at(Vec3 eye, Vec3 target, Vec3 up) @deprecated => matrix::look_at(<double>)(eye, target, up);
 
 fn Vec3f Vec3f.rotate_quat(self, Quaternionf q) => rotate_by_quat3(self, q);
 fn Vec3 Vec3.rotate_quat(self, Quaternion q) => rotate_by_quat3(self, q);
@@ -194,20 +194,6 @@ macro rotate_axis_angle(v, axis, angle) @private
 	wwv *= 2;
 
 	return v + wv + wwv;
-}
-
-macro matrix_look_at($Type, eye, target, up) @private
-{
-	var vz = (eye - target).normalize();
-	var vx = up.cross(vz).normalize();
-	var vy = vz.cross(vx);
-
-	return $Type {
-		vx[0], vx[1], vx[2], - vx.dot(eye),
-		vy[0], vy[1], vy[2], - vy.dot(eye),
-		vz[0], vz[1], vz[2], - vz.dot(eye),
-		0.0, 0.0, 0.0, 1
-	};
 }
 
 macro unproject3(v, m1, m2) @private


### PR DESCRIPTION
The macro named `matrix_look_at` is moved from math_vector.c3 file to math_matrix.c3 file.

syntax changed from:
`Matrix4f view = vector::matrix4f_look_at({1, 1, 1}, {0,0,0},{0,1,0});`
to:
`Matrix4f view = matrix::look_at(<float>)({1, 1, 1}, {0,0,0}, {0,1,0});`

old version marked as @deprecated and calls matrix::look_at from matrix module