### PR TITLE
Introduce os::native_fputc() abstraction layer for File.write_byte()

### DIFF
--- a/lib/std/io/file.c3
+++ b/lib/std/io/file.c3
@@ -76,7 +76,7 @@ fn void! File.memopen(File* file, char[] data, String mode)
  */
 fn void! File.write_byte(&self, char c) @dynamic
 {
-	if (!libc::fputc(c, self.file)) return IoError.EOF?;
+	return os::native_fputc(c, self.file);
 }
 
 /**

--- a/lib/std/io/os/file_libc.c3
+++ b/lib/std/io/os/file_libc.c3
@@ -77,7 +77,7 @@ fn usz! native_fwrite(CFile file, char[] buffer) @inline
 
 fn void! native_fputc(CInt c, CFile stream) @inline
 {
-	if (!libc::fputc(c, self.file)) return IoError.EOF?;
+	if (!libc::fputc(c, stream)) return IoError.EOF?;
 }
 
 fn usz! native_fread(CFile file, char[] buffer) @inline

--- a/lib/std/io/os/file_libc.c3
+++ b/lib/std/io/os/file_libc.c3
@@ -75,6 +75,11 @@ fn usz! native_fwrite(CFile file, char[] buffer) @inline
 	return libc::fwrite(buffer.ptr, 1, buffer.len, file);
 }
 
+fn void! native_fputc(CInt c, CFile stream) @inline
+{
+	if (!libc::fputc(c, self.file)) return IoError.EOF?;
+}
+
 fn usz! native_fread(CFile file, char[] buffer) @inline
 {
 	return libc::fread(buffer.ptr, 1, buffer.len, file);

--- a/lib/std/io/os/file_nolibc.c3
+++ b/lib/std/io/os/file_nolibc.c3
@@ -9,6 +9,7 @@ def FtellFn = fn usz!(void*);
 def FwriteFn = fn usz!(void*, char[] buffer);
 def FreadFn = fn usz!(void*, char[] buffer);
 def RemoveFn = fn void!(String);
+def FputcFn = fn void!(int, void*);
 
 FopenFn native_fopen_fn @weak @if(!$defined(native_fopen_fn));
 FcloseFn native_fclose_fn @weak @if(!$defined(native_fclose_fn));
@@ -18,6 +19,7 @@ FtellFn native_ftell_fn @weak @if(!$defined(native_ftell_fn));
 FwriteFn native_fwrite_fn @weak @if(!$defined(native_fwrite_fn));
 FreadFn native_fread_fn @weak @if(!$defined(native_fread_fn));
 RemoveFn native_remove_fn @weak @if(!$defined(native_remove_fn));
+FputcFn native_fputc_fn @weak @if(!$defined(native_fputc_fn));
 
 /**
  * @require mode.len > 0
@@ -71,5 +73,11 @@ fn usz! native_fwrite(CFile file, char[] buffer) @inline
 fn usz! native_fread(CFile file, char[] buffer) @inline
 {
 	if (native_fread_fn) return native_fread_fn(file, buffer);
+	return IoError.UNSUPPORTED_OPERATION?;
+}
+
+fn void! native_fputc(CInt c, CFile stream) @inline
+{
+	if (native_fputc_fn) return native_fputc_fn(c, stream);
 	return IoError.UNSUPPORTED_OPERATION?;
 }


### PR DESCRIPTION
# Problem

Without it, using `io::printn()` in WASM is pretty much impossible, because it tries to call to `libc::fputc` specifically to just put `\n` at the end.

# Steps to Reproduce

I'm using [Node.js](https://nodejs.org/) to simplify the setup. We will need 2 files:

```rust
// main.c3
import std::io;
import std::io::os;

extern fn void js_write(void *buffer, usz buffer_len);

fn void main() @extern("main") @wasm {
    os::native_fwrite_fn = fn usz!(void* f, char[] buffer) {
        js_write(&buffer[0], buffer.len);
        return buffer.len;
    };
    io::printn("Hello, World");
}
```

```js
// main.js
const fs = require('fs');

let wasm = undefined;

function js_write(buffer, len) {
    console.log(new TextDecoder().decode(new Uint8ClampedArray(wasm.instance.exports.memory.buffer, buffer, len)));
}

(async () => {
    wasm = await WebAssembly.instantiate(fs.readFileSync('main.wasm'), {
        env: {js_write}
    });
    wasm.instance.exports._initialize();
    wasm.instance.exports.main();
})();
```

Steps to reproduce:

```console
$ c3c --version
C3 Compiler Version:       0.6.3 (Pre-release, Sep 13 2024 16:59:02)
Installed directory:       /home/rexim/opt/c3-linux/bin/
Git Hash:                  6ff5ac5592b178350162d8bcb58cf00b8fd98f2a
Backends:                  LLVM
LLVM version:              18.1.8
LLVM default target:       x86_64-unknown-linux-gnu
$ node --version
v20.9.0
$ c3c compile -o main --target wasm32 --link-libc=no --no-entry -O5 -z --export-table -z --allow-undefined main.c3
] Assuming non-Posix environment
$ node main.js
Hello, World
wasm://wasm/main.wasm-0005b392:1


RuntimeError: unreachable
    at main.wasm.fputc (wasm://wasm/main.wasm-0005b392:wasm-function[4]:0x17c)
    at main.wasm.main (wasm://wasm/main.wasm-0005b392:wasm-function[2]:0x141)
    at /home/rexim/Programming/thirdparty/c3lang/c3c-issues/c3-wasm-io/main.js:15:27

Node.js v20.9.0
$
```
