### PR TITLE
Vendor-fetch download to lib directory specified in project.json (#1422)

### DIFF
--- a/src/build/build.h
+++ b/src/build/build.h
@@ -13,6 +13,7 @@
 #define MAX_THREADS 0xFFFF
 #define DEFAULT_SYMTAB_SIZE (256 * 1024)
 #define DEFAULT_SWITCHRANGE_MAX_SIZE (256)
+#define DEFAULT_PATH "."
 
 typedef enum
 {
@@ -433,6 +434,7 @@ typedef struct BuildOptions_
 	const char *project_name;
 	const char *target_select;
 	const char *path;
+	const char *vendor_download_path;
 	const char *template;
 	LinkerType linker_type;
 	const char *custom_linker_path;

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -1223,7 +1223,8 @@ BuildOptions parse_arguments(int argc, const char *argv[])
 	}
 
 	BuildOptions build_options = {
-		.path = ".",
+		.path = DEFAULT_PATH,
+		.vendor_download_path = DEFAULT_PATH,
 		.emit_llvm = false,
 		.optsetting = OPT_SETTING_NOT_SET,
 		.debug_info_override = DEBUG_INFO_NOT_SET,

--- a/src/build/project.h
+++ b/src/build/project.h
@@ -1,0 +1,4 @@
+#pragma once 
+#include "../utils/json.h"
+
+const char** proj_lib_dirs_get();

--- a/src/build/project.h
+++ b/src/build/project.h
@@ -1,6 +1,6 @@
 #pragma once 
 #include "../utils/json.h"
 
-const char** proj_lib_dirs_get();
+const char** get_project_dependency_directories();
 
-void add_libraries_project(const char** libs, const char* target);
+void add_libraries_to_project_file(const char** libs, const char* target_name);

--- a/src/build/project.h
+++ b/src/build/project.h
@@ -2,3 +2,5 @@
 #include "../utils/json.h"
 
 const char** proj_lib_dirs_get();
+
+void add_libraries_project(const char** libs, const char* target);

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -23,13 +23,15 @@ static JSONObject *read_project(const char **file_used)
 	return json;
 }
 
-const char** proj_lib_dirs_get() {
+const char** get_project_dependency_directories()
+{
 	const char *filename;
-		JSONObject *json = read_project(&filename);
-		JSONObject *libdirs_json = json_obj_get(json, "dependency-search-paths");
-		char **libdirs = NULL;
-		get_list_append_strings(filename, NULL, json, &libdirs, "dependency-search-paths", "dependency-search-paths-override", "dependency-search-paths-add");
-		return libdirs;
+	JSONObject *json = read_project(&filename);
+
+	char **deps_dirs = NULL;
+	get_list_append_strings(filename, NULL, json, &deps_dirs, "dependency-search-paths", "dependency-search-paths-override", "dependency-search-paths-add");
+	
+	return deps_dirs;
 }
 
 static void print_vec(const char *header, const char **vec, bool opt)
@@ -249,19 +251,19 @@ static void view_target(const char *filename, const char *name, JSONObject *targ
 	TARGET_VIEW_BOOL("Return structs on the stack", "x86-stack-struct-return");
 }
 
-void add_libraries_project(const char** libs, const char* target) {
-	
+void add_libraries_to_project_file(const char** libs, const char* target_name) {
+	//TODO! Target name option not implemented
+
 	const char *filename;
 	JSONObject *project_json = read_project(&filename);
-	char **dependencies = NULL;
-	const char* target_name = NULL;
 	
-	// TODO! check if target is specified and exists
 
-	get_list_append_strings(filename, target_name, project_json, &dependencies, "dependencies", "dependencies-override", "dependencies-add");
-	char **libraries_to_add = NULL;
+	// TODO! check if target is specified and exists (NULL at the moment)
+	char **dependencies = NULL;
+	get_list_append_strings(filename, NULL, project_json, &dependencies, "dependencies", "dependencies-override", "dependencies-add");
 	
 	// check if libraries are already present 
+	char **libraries_to_add = NULL;
 	FOREACH(const char*, lib, libs)
 	{
 		if (str_findlist(lib, vec_size(dependencies), dependencies)!=-1) continue;
@@ -279,7 +281,8 @@ void add_libraries_project(const char** libs, const char* target) {
 		vec_add(elements, obj);
 	}
 	
-	// TODO! fancy functions for altering JSON file (quite cumbersome at the moment)
+	// TODO fancy functions for altering JSON file (quite cumbersome at the moment)
+
 	// TODO! check if "dependency" entry exists in the project.json file.
 	// Create one if needed
 	
@@ -293,7 +296,7 @@ void add_libraries_project(const char** libs, const char* target) {
 	FILE *file = fopen(filename, "w");
 	print_json_to_file(project_json, file);
 	fclose(file);
-	
+
 }
 
 void add_target_project(BuildOptions *build_options)

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -254,7 +254,7 @@ static void view_target(const char *filename, const char *name, JSONObject *targ
 
 void add_libraries_to_project_file(const char** libs, const char* target_name) {
 
-	if (!file_exists(PROJECT_JSON5) || !file_exists(PROJECT_JSON)) return;
+	if (!file_exists(PROJECT_JSON5) && !file_exists(PROJECT_JSON)) return;
 	//TODO! Target name option not implemented
 
 	const char *filename;

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -28,8 +28,9 @@ const char** get_project_dependency_directories()
 	const char *filename;
 	JSONObject *json = read_project(&filename);
 
-	char **deps_dirs = NULL;
-	get_list_append_strings(filename, NULL, json, &deps_dirs, "dependency-search-paths", "dependency-search-paths-override", "dependency-search-paths-add");
+	const char *target = NULL;
+	const char **deps_dirs = NULL;
+	get_list_append_strings(filename, target, json, &deps_dirs, "dependency-search-paths", "dependency-search-paths-override", "dependency-search-paths-add");
 	
 	return deps_dirs;
 }
@@ -259,11 +260,11 @@ void add_libraries_to_project_file(const char** libs, const char* target_name) {
 	
 
 	// TODO! check if target is specified and exists (NULL at the moment)
-	char **dependencies = NULL;
+	const char **dependencies = NULL;
 	get_list_append_strings(filename, NULL, project_json, &dependencies, "dependencies", "dependencies-override", "dependencies-add");
 	
 	// check if libraries are already present 
-	char **libraries_to_add = NULL;
+	const char **libraries_to_add = NULL;
 	FOREACH(const char*, lib, libs)
 	{
 		if (str_findlist(lib, vec_size(dependencies), dependencies)!=-1) continue;

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -1,4 +1,5 @@
 #include "build_internal.h"
+#include "project.h"
 #define PRINTFN(string, ...) fprintf(stdout, string "\n", ##__VA_ARGS__) // NOLINT
 #define PRINTF(string, ...) fprintf(stdout, string, ##__VA_ARGS__) // NOLINT
 
@@ -20,6 +21,15 @@ static JSONObject *read_project(const char **file_used)
 		error_exit("Expected a map of project information in '%s'.", project_filename);
 	}
 	return json;
+}
+
+const char** proj_lib_dirs_get() {
+	const char *filename;
+		JSONObject *json = read_project(&filename);
+		JSONObject *libdirs_json = json_obj_get(json, "dependency-search-paths");
+		char **libdirs = NULL;
+		get_list_append_strings(filename, NULL, json, &libdirs, "dependency-search-paths", "dependency-search-paths-override", "dependency-search-paths-add");
+		return libdirs;
 }
 
 static void print_vec(const char *header, const char **vec, bool opt)

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -867,9 +867,9 @@ void vendor_fetch(BuildOptions *options)
 		if (file_exists(PROJECT_JSON5) || file_exists(PROJECT_JSON))
 		{
 
-			const char** lib_dirs =  proj_lib_dirs_get();
-			int num_lib = vec_size(lib_dirs); 
-			if (num_lib > 0) options->vendor_download_path = lib_dirs[0];
+			const char** deps_dirs =  get_project_dependency_directories();
+			int num_lib = vec_size(deps_dirs); 
+			if (num_lib > 0) options->vendor_download_path = deps_dirs[0];
 
 		}
 
@@ -896,8 +896,9 @@ void vendor_fetch(BuildOptions *options)
 		}
 	}
 	
-	//TODO! add_library_to_project
-	add_libraries_project(fetched_libraries, options->project_options.target_name);
+	// add fetched library to the dependency list
+	add_libraries_to_project_file(fetched_libraries, options->project_options.target_name);
+
 	if (count == 0)	error_exit("Error: Failed to download any libraries.");
 	if (count < vec_size(options->libraries_to_fetch)) error_exit("Error: Only some libraries were downloaded.");
 }

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -861,7 +861,7 @@ const char * vendor_fetch_single(const char* lib, const char* path)
 void vendor_fetch(BuildOptions *options)
 {
 	unsigned count = 0;
-	if (strcmp(options->path, DEFAULT_PATH) == 0)
+	if (str_eq(options->path, DEFAULT_PATH))
 	{
 		// check if there is a project JSON file
 		if (file_exists(PROJECT_JSON5) || file_exists(PROJECT_JSON))

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -866,11 +866,14 @@ void vendor_fetch(BuildOptions *options)
 		// check if there is a project JSON file
 		if (file_exists(PROJECT_JSON5) || file_exists(PROJECT_JSON))
 		{
-
 			const char** deps_dirs =  get_project_dependency_directories();
 			int num_lib = vec_size(deps_dirs); 
 			if (num_lib > 0) options->vendor_download_path = deps_dirs[0];
 
+		}
+		else 
+		{
+			error_exit("No project file found, use --path to specify custom destination.\n");
 		}
 
 	}

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -863,9 +863,15 @@ void vendor_fetch(BuildOptions *options)
 	unsigned count = 0;
 	if (options->path == DEFAULT_PATH)
 	{
-		const char** lib_dirs =  proj_lib_dirs_get();
-		int num_lib = vec_size(lib_dirs); 
-		if (num_lib > 0) options->vendor_download_path = lib_dirs[0];
+		// check if there is a project JSON file
+		if (file_exists(PROJECT_JSON5) || file_exists(PROJECT_JSON))
+		{
+
+			const char** lib_dirs =  proj_lib_dirs_get();
+			int num_lib = vec_size(lib_dirs); 
+			if (num_lib > 0) options->vendor_download_path = lib_dirs[0];
+
+		}
 
 	}
 
@@ -891,7 +897,7 @@ void vendor_fetch(BuildOptions *options)
 	}
 	
 	//TODO! add_library_to_project
-	add_libraries_project(fetched_libraries, NULL);
+	add_libraries_project(fetched_libraries, options->project_options.target_name);
 	if (count == 0)	error_exit("Error: Failed to download any libraries.");
 	if (count < vec_size(options->libraries_to_fetch)) error_exit("Error: Only some libraries were downloaded.");
 }

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -868,6 +868,8 @@ void vendor_fetch(BuildOptions *options)
 		if (num_lib > 0) options->vendor_download_path = lib_dirs[0];
 
 	}
+
+	char** fetched_libraries = NULL;
 	FOREACH(const char *, lib, options->libraries_to_fetch)
 	{
 		//TODO : Implement progress bar in the download_file function.
@@ -879,8 +881,7 @@ void vendor_fetch(BuildOptions *options)
 		if (!error)
 		{
 			puts("finished.");
-			//TODO! add_library_to_project
-			// add option options->vendor-target for specific dependency
+			vec_add(fetched_libraries, lib);
 			count++;
 		}
 		else
@@ -888,6 +889,9 @@ void vendor_fetch(BuildOptions *options)
 			printf("Failed: '%s'\n", error);
 		}
 	}
+	
+	//TODO! add_library_to_project
+	add_libraries_project(fetched_libraries, NULL);
 	if (count == 0)	error_exit("Error: Failed to download any libraries.");
 	if (count < vec_size(options->libraries_to_fetch)) error_exit("Error: Only some libraries were downloaded.");
 }

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -861,7 +861,7 @@ const char * vendor_fetch_single(const char* lib, const char* path)
 void vendor_fetch(BuildOptions *options)
 {
 	unsigned count = 0;
-	if (options->path == DEFAULT_PATH)
+	if (strcmp(options->path, DEFAULT_PATH) == 0)
 	{
 		// check if there is a project JSON file
 		if (file_exists(PROJECT_JSON5) || file_exists(PROJECT_JSON))
@@ -871,14 +871,10 @@ void vendor_fetch(BuildOptions *options)
 			if (num_lib > 0) options->vendor_download_path = deps_dirs[0];
 
 		}
-		else 
-		{
-			error_exit("No project file found, use --path to specify custom destination.\n");
-		}
 
 	}
 
-	char** fetched_libraries = NULL;
+	const char** fetched_libraries = NULL;
 	FOREACH(const char *, lib, options->libraries_to_fetch)
 	{
 		//TODO : Implement progress bar in the download_file function.

--- a/src/utils/json.c
+++ b/src/utils/json.c
@@ -8,7 +8,6 @@ JSONObject error = { .type = J_ERROR };
 JSONObject true_val = { .type = J_BOOL, .b = true };
 JSONObject false_val = { .type = J_BOOL, .b = false };
 JSONObject zero_val = { .type = J_NUMBER, .f = 0.0 };
-JSONObject empty_array_val = { .type = J_ARRAY, .array_len = 0 };
 JSONObject empty_obj_val = { .type = J_OBJECT, .member_len = 0 };
 
 #define CONSUME(token_) do { if (!consume(parser, token_)) { json_error(parser, "Unexpected character encountered."); return &error; } } while(0)
@@ -275,7 +274,12 @@ static inline bool consume(JsonParser *parser, JSONTokenType token)
 JSONObject *json_parse_array(JsonParser *parser)
 {
 	CONSUME(T_LBRACKET);
-	if (consume(parser, T_RBRACKET)) return &empty_array_val;
+	if (consume(parser, T_RBRACKET))
+	{
+		JSONObject *array = json_new_object(parser->allocator, J_ARRAY);
+		array->array_len = 0;
+		return array;
+	}
 
 	size_t capacity = 16;
 	JSONObject *array = json_new_object(parser->allocator, J_ARRAY);
@@ -440,7 +444,6 @@ bool is_freable(JSONObject *obj)
 	if (obj == &true_val) return false;
 	if (obj == &false_val) return false;
 	if (obj == &zero_val) return false;
-	if (obj == &empty_array_val) return false;
 	if (obj == &empty_obj_val) return false;
 	return true;
 }


### PR DESCRIPTION
This PR refers to the issue #1422 
* [x] vendor-fetch should download to `dependency-search-path` field set in `project.json` by default
* [x] vendor-fetch should add libraries in the target library list in `project.json` (~~with an option to specify a target~~)
    * [ ] Proper JSON file update (`dependencies` field of root or specified target) after fetching
    * [ ] Create `dependencies` field if it does not exist
* [ ] Fetch missing libraries that are specified in `project.json`