### PR TITLE
Made shebangs be ignored

### DIFF
--- a/src/compiler/lexer.c
+++ b/src/compiler/lexer.c
@@ -250,6 +250,14 @@ static void skip_whitespace(Lexer *lexer)
 	{
 		switch (peek(lexer))
 		{
+            //Case for shebang line #!
+            case '#':
+                if(peek_next(lexer) == '!')
+                {
+                    skip(lexer, 2);
+                    parse_line_comment(lexer);
+                    continue;
+                }
 			case '/':
 				if (lexer->mode == LEX_DOCS) return;
 				// The '//' case

--- a/test/test_suite/comments/simple_comments.c3
+++ b/test/test_suite/comments/simple_comments.c3
@@ -1,4 +1,5 @@
 module comments;
+#!/bin/c3
 /* Span *//* style */
 
 /* Nested /* Errors // Inside */ */


### PR DESCRIPTION
shebangs are now treated as comments. This allows single file scripts to be made using the `compile-run` command.
Example:
```c3
#!/bin/c3c compile-run
import std::io;
fn int main(String args)
{
    io::printn("Hello, World!");
    return 0;
}
```
It does **not** make `#` into comments only `#!`