### PR TITLE
fix int formatting in std::collections::object

### DIFF
--- a/lib/std/collections/object.c3
+++ b/lib/std/collections/object.c3
@@ -63,7 +63,7 @@ fn usz! Object.to_format(&self, Formatter* formatter) @dynamic
 			switch (self.type.kindof)
 			{
 				case SIGNED_INT:
-					return formatter.printf("%d", self.i)!;
+					return formatter.printf("%d", (int128)self.i)!;
 				case UNSIGNED_INT:
 					return formatter.printf("%d", (uint128)self.i)!;
 				case FLOAT:

--- a/test/unit/stdlib/collections/object.c3
+++ b/test/unit/stdlib/collections/object.c3
@@ -21,3 +21,21 @@ fn void test_general()
 	root.set("yyy", true);
 	assert(root.get_bool("yyy") ?? false);
 }
+
+fn void test_to_format_int()
+{
+	{
+		Object* int_object = object::new_int(16, allocator::heap());
+		defer int_object.free();
+		String s = string::new_format("%s", int_object);
+		defer free(s);
+		assert(s == "16");
+	}
+	{
+		Object* int_object = object::new_int(-16, allocator::heap());
+		defer int_object.free();
+		String s = string::new_format("%s", int_object);
+		defer free(s);
+		assert(s == "-16");
+	}
+}


### PR DESCRIPTION
Reported at https://discord.com/channels/650345951868747808/650347464498610189/1291898838772088832

> When the value is a signed integer, it's still formatted as unsigned integer:
> ```
> io::printn(b_value.type.kindof);
> io::printn(b_value);
> io::printn((int128)b_value.i);
> ```

> ```
> SIGNED_INT
> 340282366920938463463374607431768211414
> -42
> ```