### PR TITLE
fix(string): use heap allocator for ZString.copy

### DIFF
--- a/lib/std/core/string.c3
+++ b/lib/std/core/string.c3
@@ -466,7 +466,7 @@ fn void String.free(&s, Allocator allocator = allocator::heap())
 
 fn String String.tcopy(s) => s.copy(allocator::temp()) @inline;
 
-fn String ZString.copy(z, Allocator allocator = allocator::temp())
+fn String ZString.copy(z, Allocator allocator = allocator::heap())
 {
 	return z.str_view().copy(allocator) @inline;
 }


### PR DESCRIPTION
Use the heap allocator for ZString.copy() instead of the temp allocator to stay consistent across the code base.

The temp allocator is used for ZString.tcopy().