### PR TITLE
fix: segfault in panic when statically compiled

### DIFF
--- a/lib/std/libc/os/posix.c3
+++ b/lib/std/libc/os/posix.c3
@@ -11,6 +11,7 @@ const int RTLD_LAZY = 0x1;
 const int RTLD_NOW = 0x2;
 const int RTLD_LOCAL = 0x4;
 const int RTLD_GLOBAL = 0x8;
+const int RTLD_NODELETE = 0x1000;
 
 def Pid_t = int;
 def Uid_t = uint;

--- a/lib/std/os/posix/process.c3
+++ b/lib/std/os/posix/process.c3
@@ -61,7 +61,7 @@ def BacktraceFn = fn CInt(void** buffer, CInt size);
 fn CInt backtrace(void** buffer, CInt size)
 {
 	if (size < 1) return 0;
-	void* handle = libc::dlopen("libc.so.6", libc::RTLD_LAZY);
+	void* handle = libc::dlopen("libc.so.6", libc::RTLD_LAZY|libc::RTLD_NODELETE);
 	if (handle)
 	{
 		BacktraceFn backtrace_fn = libc::dlsym(handle, "backtrace");


### PR DESCRIPTION
In the current state of c3c panic in statically compiled binary leads to segfault.

Test code:
```c
module test;

fn int main(String[] args)
{
    std::core::builtin::panic("test1", "test2", "test3", 31337);
    return 0;
}
```

Compiled with:
```bash
c3c build -z "-static"
```

Reason: segfault happens because dlclose unloads libc.so.6 in static binaries and funcptr given by dlsym is not valid anymore.
https://github.com/c3lang/c3c/blob/e6c9cfed42294849bcfd808ff6cd13348dc33c25/lib/std/os/posix/process.c3#L64-L73

Solution: add RTLD_NODELETE to dlopen which does not allow unloading libc.so.6 in dlclose
```c
void* handle = libc::dlopen("libc.so.6", libc::RTLD_LAZY|libc::RTLD_NODELETE);
```