### PR TITLE
copy out keys also in HashMap.copy_keys

### DIFF
--- a/lib/std/collections/hashmap.c3
+++ b/lib/std/collections/hashmap.c3
@@ -313,7 +313,11 @@ fn Key[] HashMap.copy_keys(&map, Allocator allocator = allocator::heap())
 	{
 		while (entry)
 		{
-			list[index++] = entry.key;
+			$if COPY_KEYS:
+				list[index++] = entry.key.copy(allocator);
+			$else
+				list[index++] = entry.key;
+			$endif
 			entry = entry.next;
 		}
 	}

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -46,6 +46,7 @@
 - `&self` argument not implicitly null checked. #1556.
 - `(uptr)&((Foo*)null).a` incorrectly inserts a null check. #1544
 - Incorrect error message when `$eval` is provided an invalid string. #1570
+- `HashMap.copy_keys` did not properly copy keys which needed to be allocated #1569
 
 ### Stdlib changes
 - Remove unintended print of `char[]` as String

--- a/test/unit/stdlib/collections/copy_map.c3
+++ b/test/unit/stdlib/collections/copy_map.c3
@@ -29,3 +29,22 @@ fn void! copy_map() @test
 		assert(alloc.allocated() == 0);
 	};
 }
+
+/*
+	Some Keys (including Strings) are copied into the hashmap on insertion.
+	When copying keys out, the keys themselves must also be copied out.
+	Otherwise when the map is freed, the copied-in keys will also be freed,
+	resulting in use-after-free.
+*/
+fn void! copy_keys() @test
+{
+	String[] y;
+	@pool() {
+		IntMap x;
+		x.temp_init();
+		x.set("hello", 0); // keys copied into temp hashmap
+		y = x.copy_keys(); // keys copied out
+		// end of pool: hashmap and its copied-in keys dropped
+	};
+	assert(y == {"hello"});
+}

--- a/test/unit/stdlib/collections/copy_map.c3
+++ b/test/unit/stdlib/collections/copy_map.c3
@@ -43,7 +43,7 @@ fn void! copy_keys() @test
 		IntMap x;
 		x.temp_init();
 		x.set("hello", 0); // keys copied into temp hashmap
-		y = x.copy_keys(); // keys copied out
+		y = x.copy_keys(allocator::heap()); // keys copied out
 		// end of pool: hashmap and its copied-in keys dropped
 	};
 	assert(y == {"hello"});

--- a/test/unit/stdlib/collections/copy_map.c3
+++ b/test/unit/stdlib/collections/copy_map.c3
@@ -31,8 +31,8 @@ fn void! copy_map() @test
 }
 
 /*
-	Some Keys (including Strings) are copied into the hashmap on insertion.
-	When copying keys out, the keys themselves must also be copied out.
+	Some Keys (including Strings) are deep_copied into the hashmap on insertion.
+	When copying keys out, the keys themselves must also be deep-copied out.
 	Otherwise when the map is freed, the copied-in keys will also be freed,
 	resulting in use-after-free.
 */


### PR DESCRIPTION
Copyable keys are copied in when adding entries to HashMap, but not when copying out keys. Now copies keys out as well when `Key` is `COPY_KEYS`.