### PR TITLE
Update .editorconfig to reflect current style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,12 +11,10 @@ indent_style = space
 indent_size = 4
 
 [*.{c,cc,h}]
-indent_style = space
-indent_size = 4
+indent_style = tab
 
 [*.{c3}]
-indent_style = space
-indent_size = 4
+indent_style = tab
 
 [*.{json,toml,yml,gyp}]
 indent_style = space


### PR DESCRIPTION
For `C3` and `C` files, change from spaces to tabs (and remove hardcoded `indent_size` to allow readers to view tabs at preferred width).