### PR TITLE
Remove requirements for pop_first, cause it already returns fault.

### DIFF
--- a/lib/std/collections/list.c3
+++ b/lib/std/collections/list.c3
@@ -128,9 +128,6 @@ fn void List.clear(&self)
 	self.set_size(0);
 }
 
-<*
- @require self.size > 0
-*>
 fn Type! List.pop_first(&self)
 {
 	if (!self.size) return IteratorResult.NO_MORE_ELEMENT?;


### PR DESCRIPTION
```pop``` hasn't this requirements and works fine. But ```pop_first``` break in loops like this:

```c3
while (try current = queue.pop_first())
{
    // do smth.
}
```
So, I just remove this lines and everything works fine.