### PR TITLE
Relative DESTINATION path when installing man page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,14 +526,8 @@ install(TARGETS c3c DESTINATION bin)
 install(DIRECTORY lib/ DESTINATION lib/c3)
 
 # Man page install (OSX/Linux only)
-set(MAN_PAGE_DIR "/usr/local/share/man/man1")
-message(STATUS "installing man page to ${MAN_PAGE_DIR}")
-
-if (NOT WIN32 AND EXISTS "${MAN_PAGE_DIR}")
-    install(FILES c3c.1 DESTINATION ${MAN_PAGE_DIR})
-elseif (NOT WIN32)
-    # won't create MAN_PAGE_DIR if it doesn't already exist
-    message(WARNING "Man page directory ${MAN_PAGE_DIR} does not exist, skipping man page installation")
+if (NOT WIN32)
+    install(FILES c3c.1 DESTINATION "share/man/man1")
 endif()
 
 if (C3_WITH_LLVM AND DEFINED sanitizer_runtime_libraries)


### PR DESCRIPTION
This makes the `install()` function install the file with respect to `CMAKE_INSTALL_PREFIX` which may not always be `/usr/local/` especially when some people install the compiler locally in their `$HOME` folder.

https://cmake.org/cmake/help/latest/command/install.html

I personally like to set my `CMAKE_INSTALL_PREFIX` to `$HOME/opt/c3`, so for me this results in this

![2024-11-01-183528_1022x309_scrot](https://github.com/user-attachments/assets/22894a4d-3a4a-4e4b-ad84-5ce0d2d1a11f)

This PR makes it respect the installation prefix

![2024-11-01-184954_820x259_scrot](https://github.com/user-attachments/assets/3ece2b5a-93e3-4b89-9fea-9876123efc44)

cc: @goneal26 