### PR TITLE
Add support for nix flakes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ TAGS
 /.cache/
 /compile_commands.json
 
+# 'nix build' resulting symlink
+result
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1730958623,
+        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,12 +16,16 @@
         c3c-debug = pkgs.callPackage ./nix/default.nix { debug = true; };
         c3c-nochecks = pkgs.callPackage ./nix/default.nix { debug = true; checks = false; };
       };
-      # devShells.default = pkgs.mkShell {
-      #   packages = [ 
-      #     self.packages.${system}.c3c-nochecks
-      #     pkgs.clang-tools 
-      #   ];
-      # };
+
+      devShells.default = let 
+        c3c = self.packages.${system}.c3c-nochecks; 
+      in pkgs.mkShell {
+          packages = [ 
+            pkgs.clang-tools 
+            c3c
+          ];
+          shellHook = ''ln -sf ${c3c}/compile_commands.json compile_commands.json'';
+        };
     }
   );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,20 +12,24 @@
     {
       packages = {
         default = self.packages.${system}.c3c;
+
         c3c = pkgs.callPackage ./nix/default.nix {};
-        c3c-debug = pkgs.callPackage ./nix/default.nix { debug = true; };
-        c3c-nochecks = pkgs.callPackage ./nix/default.nix { debug = true; checks = false; };
+
+        c3c-debug = pkgs.callPackage ./nix/default.nix { 
+          debug = true; 
+        };
+
+        c3c-nochecks = pkgs.callPackage ./nix/default.nix { 
+          debug = true; 
+          checks = false; 
+        };
       };
 
-      devShells.default = let 
-        c3c = self.packages.${system}.c3c-nochecks; 
-      in pkgs.mkShell {
-          packages = [ 
-            pkgs.clang-tools 
-            c3c
-          ];
-          shellHook = ''ln -sf ${c3c}/compile_commands.json compile_commands.json'';
+      devShells = {
+        default = pkgs.callPackage ./nix/shell.nix {
+          c3c = self.packages.${system}.c3c-nochecks; 
         };
+      };
     }
   );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -8,17 +8,20 @@
 
   outputs = { self, ... } @ inputs: inputs.flake-utils.lib.eachDefaultSystem 
   (system: 
-    let pkgs = import inputs.nixpkgs { inherit system; };
-        c3c  = pkgs.callPackage ./nix/default.nix {}; 
-    in {
+    let pkgs = import inputs.nixpkgs { inherit system; }; in 
+    {
       packages = {
         default = self.packages.${system}.c3c;
-        inherit c3c;
+        c3c = pkgs.callPackage ./nix/default.nix {};
+        c3c-debug = pkgs.callPackage ./nix/default.nix { debug = true; };
+        c3c-nochecks = pkgs.callPackage ./nix/default.nix { debug = true; checks = false; };
       };
-
-      devShells.default = pkgs.mkShell {
-        buildInputs = [ c3c ];
-      };
+      # devShells.default = pkgs.mkShell {
+      #   packages = [ 
+      #     self.packages.${system}.c3c-nochecks
+      #     pkgs.clang-tools 
+      #   ];
+      # };
     }
   );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "C3 compiler flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, ... } @ inputs: inputs.flake-utils.lib.eachDefaultSystem 
+  (system: 
+    let pkgs = import inputs.nixpkgs { inherit system; };
+        c3c  = pkgs.callPackage ./nix/default.nix {}; 
+    in {
+      packages = {
+        default = self.packages.${system}.c3c;
+        inherit c3c;
+      };
+
+      devShells.default = pkgs.mkShell {
+        buildInputs = [ c3c ];
+      };
+    }
+  );
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -36,8 +36,9 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
       --replace-fail "\''${LLVM_LIBRARY_DIRS}" "${llvmPackages.lld.lib}/lib ${llvmPackages.llvm.lib}/lib"
   '';
 
+  cmakeBuildType = if debug then "Debug" else "Release";
+
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=${if debug then "Debug" else "Release"}"
     "-DC3_ENABLE_CLANGD_LSP=${if debug then "ON" else "OFF"}"
   ];
 
@@ -45,6 +46,8 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   postBuild = optionalString debug ''
     mkdir $out
+    substituteInPlace compile_commands.json \
+      --replace "/build/source/" "$src/"
     cp compile_commands.json $out/compile_commands.json
   '';
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  llvmPackages,
+  cmake,
+  python3,
+  curl,
+  libxml2,
+  libffi,
+  xar,
+  versionCheckHook,
+}: let 
+  inherit (builtins) baseNameOf toString readFile split elemAt;
+  inherit (lib.sources) cleanSourceWith cleanSource; 
+  inherit (lib.lists) findSingle findFirst;
+  inherit (lib.asserts) assertMsg;
+  inherit (lib.strings) hasInfix hasSuffix splitString removeSuffix removePrefix concatMapStringsSep;
+in 
+llvmPackages.stdenv.mkDerivation (finalAttrs: {
+  pname = "c3c";
+  version = let
+    versionFile = readFile ../src/version.h;
+    splitted = splitString "\n" versionFile;
+    findLine = findFirst (x: hasInfix "COMPILER_VERSION" x) "none";
+    foundLine = findLine splitted;
+    foundLineSplitted = splitString " " foundLine;
+    unformattedVersion = elemAt foundLineSplitted 2;
+    version = removeSuffix "\"" ( removePrefix "\"" unformattedVersion );
+    dumpStrList = concatMapStringsSep " " (x: "\""+x+"\"");
+  in 
+    assert assertMsg (foundLine != "none") "No COMPILER_VERSION substring was found in version.h. Lines: [${dumpStrList splitted}]";
+    version;
+
+  src = cleanSourceWith {
+    filter = _path: _type: !(hasSuffix ".nix" (baseNameOf(toString _path)));
+    src = cleanSource ../.;
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${LLVM_LIBRARY_DIRS}" "${llvmPackages.lld.lib}/lib ${llvmPackages.llvm.lib}/lib"
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    llvmPackages.llvm
+    llvmPackages.lld
+    curl
+    libxml2
+    libffi
+  ] ++ lib.optionals llvmPackages.stdenv.hostPlatform.isDarwin [ xar ];
+
+  nativeCheckInputs = [ python3 ];
+
+  doCheck = llvmPackages.stdenv.system == "x86_64-linux";
+
+  checkPhase = ''
+    runHook preCheck
+    ( cd ../resources/testproject; ../../build/c3c build )
+    ( cd ../test; python src/tester.py ../build/c3c test_suite )
+    runHook postCheck
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = with lib; {
+    description = "Compiler for the C3 language";
+    homepage = "https://github.com/c3lang/c3c";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [
+      luc65r
+      anas
+    ];
+    platforms = platforms.all;
+    mainProgram = "c3c";
+  };
+})
+

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -37,10 +37,16 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   '';
 
   cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=${if debug then "Debug" else "Release"}" 
+    "-DCMAKE_BUILD_TYPE=${if debug then "Debug" else "Release"}"
+    "-DC3_ENABLE_CLANGD_LSP=${if debug then "ON" else "OFF"}"
   ];
 
   nativeBuildInputs = [ cmake ];
+
+  postBuild = optionalString debug ''
+    mkdir $out
+    cp compile_commands.json $out/compile_commands.json
+  '';
 
   buildInputs = [
     llvmPackages.llvm

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,20 @@
+{
+  mkShell,
+  clang-tools,
+  c3c,
+}:
+
+mkShell {
+  inputsFrom = [
+    c3c
+  ];
+
+  packages = [ 
+    clang-tools 
+    c3c
+  ];
+
+  shellHook = ''
+    ln -sf ${c3c}/compile_commands.json compile_commands.json
+  '';
+}


### PR DESCRIPTION
Added support for nix flakes. 

Flake provides the following outputs:
- `packages.${system}.default` - refers to `c3c`
- `packages.${system}.c3c` - c3c derivation
- `packages.${system}.c3c-debug` - debug version (also includes compile_commands.json in derivation path)
- `packages.${system}.c3c-nochecks` - same as `c3c-debug` but with omitted checks
- `devShells.${system}.default` - dev shell for lsp