### PR TITLE
Fix WriteBuffer.write_byte

### DIFF
--- a/lib/std/io/stream/buffer.c3
+++ b/lib/std/io/stream/buffer.c3
@@ -120,10 +120,13 @@ fn usz! WriteBuffer.write(&self, char[] bytes) @dynamic
 
 fn void! WriteBuffer.write_byte(&self, char c) @dynamic
 {
-	usz n = self.bytes.len - self.index;
-	if (n == 0) self.write_pending()!;
-	self.bytes[0] = c;
-	self.index = 1;
+	usz n = self.bytes.len - self.index - 1;
+	if (n == 0)
+	{
+		self.write_pending()!;
+	}
+	self.bytes[self.index] = c;
+	self.index += 1;
 }
 
 fn void! WriteBuffer.write_pending(&self) @local

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -9,6 +9,7 @@
 ### Fixes
 - Fix bug where `a > 0 ? f() : g()` could cause a compiler crash if both returned `void!`.
 - `@builtin` was not respected for generic modules #1617.
+- Fix issue writing a single byte in the WriteBuffer
 
 ### Stdlib changes
 


### PR DESCRIPTION
Fixes implementation of `WriteBuffer.write_byte`.