### PR TITLE
Fix WriteBuffer.write_bytes off-by-one

### DIFF
--- a/lib/std/io/stream/buffer.c3
+++ b/lib/std/io/stream/buffer.c3
@@ -120,7 +120,7 @@ fn usz! WriteBuffer.write(&self, char[] bytes) @dynamic
 
 fn void! WriteBuffer.write_byte(&self, char c) @dynamic
 {
-	usz n = self.bytes.len - self.index - 1;
+	usz n = self.bytes.len - self.index;
 	if (n == 0)
 	{
 		self.write_pending()!;

--- a/test/unit/stdlib/io/bufferstream.c3
+++ b/test/unit/stdlib/io/bufferstream.c3
@@ -67,3 +67,28 @@ fn void! writebuffer()
     String got = out.str_view();
     assert(got == DATA, "got %s; want %s", got, DATA);
 }
+
+fn void! writebuffer_write_byte()
+{
+    ByteWriter out;
+    out.temp_init();
+    char[2] buf;
+    WriteBuffer write_buf;
+    write_buf.init(&out, buf[..]);
+
+	write_buf.write_byte('a')!;
+	assert(write_buf.str_view() == "a");
+    assert(out.str_view() == "");
+
+	write_buf.write_byte('b')!;
+	assert(write_buf.str_view() == "ab");
+    assert(out.str_view() == "");
+
+	write_buf.write_byte('c')!;
+	assert(write_buf.str_view() == "c");
+    assert(out.str_view() == "ab");
+
+	write_buf.flush()!;
+	assert(write_buf.str_view() == "");
+    assert(out.str_view() == "abc");
+}


### PR DESCRIPTION
Was randomly thinking about my previous PR https://github.com/c3lang/c3c/pull/1616 which fixed WriteBuffer.write_bytes and realized I was off-by-one because I didn't think about the post-increment. Basically, the buffer was flushed one step too early.

With the bug, no data was lost, it's just that the WriteBuffer buffer would effectively be shortened by one. Now, the entire length of the buffer is used.