### PR TITLE
Add "sources" option support for library.

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -7,6 +7,7 @@
 - Init command will now add `test-sources` to `project.json` #1520
 - `a++` may be discarded if `a` is optional and ++/-- works for overloaded operators.
 - Improve support for Windows cross compilation on targets with case sensitive file systems.
+- Add "sources" support to library `manifest.json`, defaults to root folder if unspecified.
 
 ### Fixes
 - Fix bug where `a > 0 ? f() : g()` could cause a compiler crash if both returned `void!`.

--- a/src/build/build.h
+++ b/src/build/build.h
@@ -523,6 +523,7 @@ typedef struct
 	const char *cc;
 	const char *cflags;
 	WinCrtLinking win_crt;
+	const char **source_dirs;
 	const char **csource_dirs;
 	const char **csources;
 	const char **cinclude_dirs;
@@ -540,6 +541,7 @@ typedef struct Library__
 	const char **execs;
 	const char *cc;
 	const char *cflags;
+	const char **source_dirs;
 	const char **csource_dirs;
 	const char **cinclude_dirs;
 	WinCrtLinking win_crt;

--- a/src/build/libraries.c
+++ b/src/build/libraries.c
@@ -4,7 +4,7 @@
 #define MANIFEST_FILE "manifest.json"
 
 const char *manifest_default_keys[][2] = {
-		{"sources", "Paths to library sources for targets."},
+		{"sources", "Paths to library sources for targets, such as interface files."},
 		{"c-sources", "Set the C sources to be compiled."},
 		{"c-include-dirs", "Set the include directories for C sources."},
 		{"cc", "Set C compiler (defaults to 'cc')."},
@@ -297,13 +297,16 @@ void resolve_libraries(BuildTarget *build_target)
 		{
 			vec_add(build_target->ccompiling_libraries, target);
 		}
-		if (target->source_dirs) {
+		if (target->source_dirs)
+		{
 			const char **files = target_expand_source_names(library->dir, target->source_dirs, c3_suffix_list, &build_target->object_files, 3, true);
 			FOREACH(const char *, file, files)
 			{
 				vec_add(build_target->sources, file);
 			}
-		} else {
+		}
+		else
+		{
 			// fallback if sources doesn't exist
 			file_add_wildcard_files(&build_target->sources, library->dir, false, c3_suffix_list, 3);
 		}

--- a/src/build/libraries.c
+++ b/src/build/libraries.c
@@ -297,10 +297,15 @@ void resolve_libraries(BuildTarget *build_target)
 		{
 			vec_add(build_target->ccompiling_libraries, target);
 		}
-		const char **files = target_expand_source_names(library->dir, target->source_dirs, c3_suffix_list, &build_target->object_files, 3, true);
-		FOREACH(const char *, file, files)
-		{
-			vec_add(build_target->sources, file);
+		if (target->source_dirs) {
+			const char **files = target_expand_source_names(library->dir, target->source_dirs, c3_suffix_list, &build_target->object_files, 3, true);
+			FOREACH(const char *, file, files)
+			{
+				vec_add(build_target->sources, file);
+			}
+		} else {
+			// fallback if sources doesn't exist
+			file_add_wildcard_files(&build_target->sources, library->dir, false, c3_suffix_list, 3);
 		}
 		vec_add(build_target->library_list, library);
 		const char *libdir = file_append_path(library->dir, arch_os_target[build_target->arch_os_target]);

--- a/src/build/libraries.c
+++ b/src/build/libraries.c
@@ -20,6 +20,7 @@ const char *manifest_default_keys[][2] = {
 const int manifest_default_keys_count = ELEMENTLEN(manifest_default_keys);
 
 const char *manifest_target_keys[][2] = {
+		{"sources", "Additional library sources to be compiled for this target."},
 		{"sources-override", "Paths to library sources for this target, overriding global settings."},
 		{"c-sources", "Additional C sources to be compiled for the target."},
 		{"c-sources-override", "C sources to be compiled, overriding global settings."},

--- a/src/build/project_creation.c
+++ b/src/build/project_creation.c
@@ -138,6 +138,7 @@ const char* JSON_DYNAMIC =
 const char *MANIFEST_TEMPLATE =
 		"{\n"
 		"  \"provides\" : \"%s\",\n"
+		"  \"sources\" : [ \"src/**\" ],\n"
 		"  \"targets\" : {\n"
 		"%s"
 		"  }\n"
@@ -219,14 +220,19 @@ void create_library(BuildOptions *build_options)
 	}
 
 	chdir_or_fail(build_options, dir);
+
 	create_file_or_fail(build_options, "LICENSE", NULL);
 	create_file_or_fail(build_options, "README.md", LIB_README, build_options->project_name);
 	mkdir_or_fail(build_options, "scripts");
+
+	mkdir_or_fail(build_options, "src");
+	chdir_or_fail(build_options, "src");
 	scratch_buffer_clear();
 	scratch_buffer_printf("%s.c3i", build_options->project_name);
 	const char *interface_file = scratch_buffer_copy();
 	create_file_or_fail(build_options, interface_file, MAIN_INTERFACE_TEMPLATE, module_name(build_options));
 	scratch_buffer_clear();
+	chdir_or_fail(build_options, "..");
 	for (int i = 0; i < sizeof(DEFAULT_TARGETS) / sizeof(char*); i++)
 	{
 		const char *target = DEFAULT_TARGETS[i];

--- a/src/build/project_creation.c
+++ b/src/build/project_creation.c
@@ -225,14 +225,11 @@ void create_library(BuildOptions *build_options)
 	create_file_or_fail(build_options, "README.md", LIB_README, build_options->project_name);
 	mkdir_or_fail(build_options, "scripts");
 
-	mkdir_or_fail(build_options, "src");
-	chdir_or_fail(build_options, "src");
 	scratch_buffer_clear();
 	scratch_buffer_printf("%s.c3i", build_options->project_name);
 	const char *interface_file = scratch_buffer_copy();
 	create_file_or_fail(build_options, interface_file, MAIN_INTERFACE_TEMPLATE, module_name(build_options));
 	scratch_buffer_clear();
-	chdir_or_fail(build_options, "..");
 	for (int i = 0; i < sizeof(DEFAULT_TARGETS) / sizeof(char*); i++)
 	{
 		const char *target = DEFAULT_TARGETS[i];

--- a/src/build/project_creation.c
+++ b/src/build/project_creation.c
@@ -138,7 +138,7 @@ const char* JSON_DYNAMIC =
 const char *MANIFEST_TEMPLATE =
 		"{\n"
 		"  \"provides\" : \"%s\",\n"
-		"  \"sources\" : [ \"src/**\" ],\n"
+		"  // \"sources\" : [ \"src/**\" ],\n"
 		"  \"targets\" : {\n"
 		"%s"
 		"  }\n"

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -751,60 +751,6 @@ void compiler_compile(void)
 	}
 	free(obj_files);
 }
-
-static const char **target_expand_source_names(const char *base_dir, const char** dirs, const char **suffix_list, const char ***object_list_ref, int suffix_count, bool error_on_mismatch)
-{
-	const char **files = NULL;
-	FOREACH(const char *, name, dirs)
-	{
-		if (base_dir) name = file_append_path(base_dir, name);
-		INFO_LOG("Searching for sources in %s", name);
-		size_t name_len = strlen(name);
-		if (name_len < 1) goto INVALID_NAME;
-		if (object_list_ref && (str_has_suffix(name, ".o") || str_has_suffix(name, ".obj")))
-		{
-			if (!file_exists(name))
-			{
-				if (!error_on_mismatch) continue;
-				error_exit("The object file '%s' could not be found.", name);
-			}
-			vec_add(*object_list_ref, name);
-			continue;
-		}
-		if (name[name_len - 1] == '*')
-		{
-			if (name_len == 1 || name[name_len - 2] == '/')
-			{
-				char *path = str_copy(name, name_len - 1);
-				file_add_wildcard_files(&files, path, false, suffix_list, suffix_count);
-				continue;
-			}
-			if (name[name_len - 2] != '*') goto INVALID_NAME;
-			INFO_LOG("Searching for wildcard sources in %s", name);
-			if (name_len == 2 || name[name_len - 3] == '/')
-			{
-				const char *path = str_copy(name, name_len - 2);
-				DEBUG_LOG("Reduced path %s", path);
-				file_add_wildcard_files(&files, path, true, suffix_list, suffix_count);
-				continue;
-			}
-			goto INVALID_NAME;
-		}
-		if (!file_has_suffix_in_list(name, name_len, suffix_list, suffix_count)) goto INVALID_NAME;
-		vec_add(files, name);
-		continue;
-		INVALID_NAME:
-		if (file_is_dir(name))
-		{
-			file_add_wildcard_files(&files, name, true, suffix_list, suffix_count);
-			continue;
-		}
-		if (!error_on_mismatch) continue;
-		error_exit("File names must be a non-empty name followed by %s or they cannot be compiled: '%s' is invalid.", suffix_list[0], name);
-	}
-	return files;
-}
-
 INLINE void expand_csources(const char *base_dir, const char **source_dirs, const char ***sources_ref)
 {
 	if (source_dirs)

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -90,6 +90,8 @@ void file_add_wildcard_files(const char ***files, const char *path, bool recursi
 const char *file_append_path(const char *path, const char *name);
 const char *file_append_path_temp(const char *path, const char *name);
 
+const char **target_expand_source_names(const char *base_dir, const char** dirs, const char **suffix_list, const char ***object_list_ref, int suffix_count, bool error_on_mismatch);
+
 const char *execute_cmd(const char *cmd, bool ignore_failure, const char *stdin_string);
 
 bool execute_cmd_failable(const char *cmd, const char **result, const char *stdin_string);
@@ -713,4 +715,3 @@ const char *zip_dir_iterator(FILE *zip, ZipDirIterator *iterator);
 const char *zip_dir_iterator_next(ZipDirIterator *iterator, ZipFile *file);
 const char *zip_file_read(FILE *zip, ZipFile *file, void **buffer_ptr);
 const char *zip_file_write(FILE *zip, ZipFile *file, const char *dir, bool overwrite);
-


### PR DESCRIPTION
Currently, files in libraries must be in the root folder next to the manifest.json.
This is cumbersome when organizing the files in this folder.  

Although, library system still in early alpha, but still, adding this feature would be great.