### PR TITLE
Add .tlb file extention from msvc files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # Libraries
 *.lib
+*.tlb
 *.a
 *.la
 *.lo


### PR DESCRIPTION
Simple change to .gitignore to prevent it from staging files from the msvc_sdk forder.
Alternative is to .gitignore the msvc_sdk folder itself.