### PR TITLE
add check for to_string in is_struct_with_default_print

### DIFF
--- a/lib/std/io/formatter.c3
+++ b/lib/std/io/formatter.c3
@@ -28,7 +28,8 @@ macro bool is_struct_with_default_print($Type)
 {
 	return $Type.kindof == STRUCT
 		&&& !$defined($Type.to_format)
-		&&& !$defined($Type.to_new_string);
+		&&& !$defined($Type.to_new_string)
+		&&& !$defined($Type.to_string);
 }
 
 <*


### PR DESCRIPTION
The function wasn't checking if the struct had the method `to_string` which caused a segfault when trying to override the default to_string on a struct