### PR TITLE
fix: base64 decoding

### DIFF
--- a/lib/std/encoding/base64.c3
+++ b/lib/std/encoding/base64.c3
@@ -124,26 +124,12 @@ fn void! Base64Decoder.init(&self, String alphabet, int padding = '=')
 	check_alphabet(alphabet, padding)!;
 	*self = { .padding = padding, .alphabet = alphabet };
 
-	bool[256] checked;
+	self.invalid = 0xff;
+	self.reverse[..] = self.invalid;
+
 	foreach (i, c : alphabet)
 	{
-		checked[c] = true;
 		self.reverse[c] = (char)i;
-	}
-	if (padding < 0)
-	{
-		self.invalid = 255;
-		return;
-	}
-	// Find a character for invalid neither in the alphabet nor equal to the padding.
-	char pad = (char)padding;
-	foreach (i, ok : checked)
-	{
-		if (!ok && (char)i != pad)
-		{
-			self.invalid = (char)i;
-			break;
-		}
 	}
 }
 

--- a/test/unit/stdlib/encoding/base64.c3
+++ b/test/unit/stdlib/encoding/base64.c3
@@ -19,6 +19,7 @@ fn void encode()
         { "foob", "Zm9vYg==" },
         { "fooba", "Zm9vYmE=" },
         { "foobar", "Zm9vYmFy" },
+        { "test", "dGVzdA==" },
     };
     foreach (tc : tcases)
     {
@@ -41,6 +42,7 @@ fn void encode_nopadding()
         { "foob", "Zm9vYg" },
         { "fooba", "Zm9vYmE" },
         { "foobar", "Zm9vYmFy" },
+        { "test", "dGVzdA" },
     };
     foreach (tc : tcases)
     {
@@ -63,6 +65,8 @@ fn void decode()
         { "Zm9vYg==", "foob" },
         { "Zm9vYmE=", "fooba" },
         { "Zm9vYmFy", "foobar" },
+        { "Zm9vYmFy", "foobar" },
+        { "dGVzdA==", "test" },
     };
     foreach (tc : tcases)
     {
@@ -85,6 +89,7 @@ fn void decode_nopadding()
         { "Zm9vYg", "foob" },
         { "Zm9vYmE", "fooba" },
         { "Zm9vYmFy", "foobar" },
+        { "dGVzdA", "test" },
     };
     foreach (tc : tcases)
     {


### PR DESCRIPTION
Fix the base64 decoding. If there's an 'A' character in the encoded text, the base64 decode function returns an INVALID_PADDING error. The reason lies in the way Base64Decoder.init tries to find a suitable invalid character. Fix this by defining the invalid character as 0xff (which is already the case for a decoding without padding).

This error has not been caught by the test harness, because no test contains an 'A' character in the the encoded text yet. Add a new test.