### PR TITLE
fix: prevent infinite read-loop by updating `left_to_read` after write

### DIFF
--- a/src/build/libraries.c
+++ b/src/build/libraries.c
@@ -224,7 +224,7 @@ static inline JSONObject *resolve_zip_library(BuildTarget *build_target, const c
 		zip_check_err(lib, zip_dir_iterator_next(&iterator, &file));
 		if (file.uncompressed_size == 0 || file.name[0] == '.') continue;
 		// Copy file.
-		zip_file_write(f, &file, dir, false);
+		ASSERT0(zip_file_write(f, &file, dir, false) == NULL);
 	}
 	fclose(f);
 	*resulting_library = lib_dir;

--- a/src/utils/unzipper.c
+++ b/src/utils/unzipper.c
@@ -275,6 +275,7 @@ const char *zip_file_write(FILE *zip, ZipFile *file, const char *dir, bool overw
 				fclose(f);
 				return "Failed to write";
 			}
+			left_to_read -= written;
 		}
 		return NULL;
 	}


### PR DESCRIPTION
Fixed a bug where `left_to_read` was not updated after writing, causing the loop to continue indefinitely, resulting in over-read and write random data to the file.