### PR TITLE
Fix fnv a hashes

### DIFF
--- a/lib/std/hash/fnv32a.c3
+++ b/lib/std/hash/fnv32a.c3
@@ -8,7 +8,7 @@ distinct Fnv32a = uint;
 const FNV32A_START @private = 0x811c9dc5;
 const FNV32A_MUL @private = 0x01000193;
 
-macro void @update(uint* &h, char x) @private => *h = (*h * FNV32A_MUL) ^ x;
+macro void @update(uint* &h, char x) @private => *h = (*h ^ x) * FNV32A_MUL;
 
 fn void Fnv32a.init(&self)
 {
@@ -27,7 +27,9 @@ fn void Fnv32a.update(&self, char[] data)
 
 macro void Fnv32a.update_char(&self, char c)
 {
-	@update(*self, x);
+	uint h = (uint)*self;
+	@update(h, c);
+	*self = (Fnv32a)h;
 }
 
 fn uint encode(char[] data)

--- a/lib/std/hash/fnv32a.c3
+++ b/lib/std/hash/fnv32a.c3
@@ -8,7 +8,7 @@ distinct Fnv32a = uint;
 const FNV32A_START @private = 0x811c9dc5;
 const FNV32A_MUL @private = 0x01000193;
 
-macro void @update(uint* &h, char x) @private => *h = (*h ^ x) * FNV32A_MUL;
+macro void @update(&h, char x) @private => *h = (*h ^ ($typeof(*h))x) * FNV32A_MUL;
 
 fn void Fnv32a.init(&self)
 {
@@ -17,19 +17,17 @@ fn void Fnv32a.init(&self)
 
 fn void Fnv32a.update(&self, char[] data)
 {
-	uint h = (uint)*self;
+	Fnv32a h = *self;
 	foreach (char x : data)
 	{
 		@update(h, x);
 	}
-	*self = (Fnv32a)h;
+	*self = h;
 }
 
 macro void Fnv32a.update_char(&self, char c)
 {
-	uint h = (uint)*self;
-	@update(h, c);
-	*self = (Fnv32a)h;
+	@update(*self, c);
 }
 
 fn uint encode(char[] data)

--- a/lib/std/hash/fnv64a.c3
+++ b/lib/std/hash/fnv64a.c3
@@ -8,7 +8,7 @@ distinct Fnv64a = ulong;
 const FNV64A_START @private = 0xcbf29ce484222325;
 const FNV64A_MUL @private = 0x00000100000001b3;
 
-macro void @update(ulong* &h, char x) @private => *h = (*h * FNV64A_MUL) ^ x;
+macro void @update(ulong* &h, char x) @private => *h = (*h ^ x) * FNV64A_MUL;
 
 fn void Fnv64a.init(&self)
 {
@@ -27,7 +27,9 @@ fn void Fnv64a.update(&self, char[] data)
 
 macro void Fnv64a.update_char(&self, char c)
 {
-	@update(*self, x);
+	ulong h = (ulong)*self;
+	@update(h, c);
+	*self = (Fnv64a)h;
 }
 
 fn ulong encode(char[] data)

--- a/lib/std/hash/fnv64a.c3
+++ b/lib/std/hash/fnv64a.c3
@@ -8,7 +8,7 @@ distinct Fnv64a = ulong;
 const FNV64A_START @private = 0xcbf29ce484222325;
 const FNV64A_MUL @private = 0x00000100000001b3;
 
-macro void @update(ulong* &h, char x) @private => *h = (*h ^ x) * FNV64A_MUL;
+macro void @update(&h, char x) @private => *h = (*h ^ ($typeof(*h))x) * FNV64A_MUL;
 
 fn void Fnv64a.init(&self)
 {
@@ -17,19 +17,17 @@ fn void Fnv64a.init(&self)
 
 fn void Fnv64a.update(&self, char[] data)
 {
-	ulong h = (ulong)*self;
+	Fnv64a h = *self;
 	foreach (char x : data)
 	{
 		@update(h, x);
 	}
-	*self = (Fnv64a)h;
+	*self = h;
 }
 
 macro void Fnv64a.update_char(&self, char c)
 {
-	ulong h = (ulong)*self;
-	@update(h, c);
-	*self = (Fnv64a)h;
+	@update(*self, c);
 }
 
 fn ulong encode(char[] data)

--- a/test/unit/stdlib/hash/fnv32a.c3
+++ b/test/unit/stdlib/hash/fnv32a.c3
@@ -1,0 +1,24 @@
+module std::hash::fnv32a_test @test;
+import std::hash::fnv32a;
+
+fn void test_fnv32a()
+{
+	Fnv32a hash;
+
+	char[] input = "Hello world";
+	uint want = 0x594d29c7;
+
+	// update
+	hash.init();
+	hash.update(input);
+	assert ((uint)hash == want, "got: %d, want: %d", hash, want);
+
+	// update_char
+	hash.init();
+	foreach (c : input) hash.update_char(c);
+	assert ((uint)hash == want, "got: %d, want: %d", hash, want);
+
+	// encode
+	uint encoded = fnv32a::encode(input);
+	assert (encoded == want, "got: %d, want: %d", encoded, want);
+}

--- a/test/unit/stdlib/hash/fnv64a.c3
+++ b/test/unit/stdlib/hash/fnv64a.c3
@@ -1,0 +1,24 @@
+module std::hash::fnv64a_test @test;
+import std::hash::fnv64a;
+
+fn void test_fnv64a()
+{
+	Fnv64a hash;
+
+	char[] input = "Hello world";
+	ulong want = 0x2713f785a33764c7;
+
+	// update
+	hash.init();
+	hash.update(input);
+	assert ((ulong)hash == want, "got: %d, want: %d", hash, want);
+
+	// update_char
+	hash.init();
+	foreach (c : input) hash.update_char(c);
+	assert ((ulong)hash == want, "got: %d, want: %d", hash, want);
+
+	// encode
+	ulong encoded = fnv64a::encode(input);
+	assert (encoded == want, "got: %d, want: %d", encoded, want);
+}


### PR DESCRIPTION
Order of the multiplication and XOR operations should be reversed for FNV-1a hashes.

Link: https://datatracker.ietf.org/doc/draft-eastlake-fnv/
Link: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
Link: https://md5calc.com/hash/fnv132/Hello+world
