### PR TITLE
Fix weekday conversion from `tm.tm_wday`

### DIFF
--- a/lib/std/time/datetime.c3
+++ b/lib/std/time/datetime.c3
@@ -46,7 +46,7 @@ fn TzDateTime DateTime.to_local(&self)
 	dt.day = (char)tm.tm_mday;
 	dt.month = (Month)tm.tm_mon;
 	dt.year = tm.tm_year + 1900;
-	dt.weekday = !tm.tm_wday ? Weekday.SUNDAY : (Weekday)tm.tm_wday + 1;
+	dt.weekday = !tm.tm_wday ? Weekday.SUNDAY : (Weekday)tm.tm_wday - 1;
 	dt.year_day = (ushort)tm.tm_yday;
 	dt.time = self.time;
 	$if $defined(tm.tm_gmtoff):
@@ -144,7 +144,7 @@ fn void DateTime.set_time(&self, Time time)
 	self.day = (char)tm.tm_mday;
 	self.month = (Month)tm.tm_mon;
 	self.year = tm.tm_year + 1900;
-	self.weekday = !tm.tm_wday ? Weekday.SUNDAY : (Weekday)tm.tm_wday + 1;
+	self.weekday = !tm.tm_wday ? Weekday.SUNDAY : (Weekday)tm.tm_wday - 1;
 	self.year_day = (ushort)tm.tm_yday;
 	self.time = time;
 }


### PR DESCRIPTION
Currently

```c3
import std;

fn void main()
{
    DateTime dt = datetime::now();
    io::printfn("%s %s %s %s %s %s %s", dt.year, dt.month, dt.day, dt.hour, dt.min, dt.sec, dt.weekday);
}
```

prints `2024 DECEMBER 12 15 33 30 SATURDAY` but it should print `2024 DECEMBER 12 15 33 30 THURSDAY`.