### PR TITLE
math: fix adjoint of Matrix2

### DIFF
--- a/lib/std/math/math_matrix.c3
+++ b/lib/std/math/math_matrix.c3
@@ -197,7 +197,7 @@ fn Real Matrix4x4.determinant(&self)
 
 fn Matrix2x2 Matrix2x2.adjoint(&self)
 {
-	return { self.m00, -self.m01, -self.m10, self.m11 };
+	return { self.m11, -self.m01, -self.m10, self.m00 };
 }
 
 fn Matrix3x3 Matrix3x3.adjoint(&self)

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -39,6 +39,7 @@
 - Fix issue with accessing arrays in access-overloaded types, e.g. `list[1][2]` #1665.
 - Cast removing arbitrary array indices and converting them to pointers should always be fine #1664
 - Incorrect "no-libc" definition of `cos`, making it unavailable for wasm.
+- Fix issue with the adjoint and inverse calculations for `Matrix2x2`.
 
 ### Stdlib changes
 - Add `io::MultiReader`, `io::MultiWriter`, and `io::TeeReader` structs.

--- a/test/unit/stdlib/math/matrix.c3
+++ b/test/unit/stdlib/math/matrix.c3
@@ -106,6 +106,15 @@ fn void test_mat2()
 		assert(calc.m == value.m);
 }
 
+fn void! test_mat2_inverse()
+{
+		Matrix2 a = { 3, 5, 6, 2 };
+		Matrix2 a_inv = a.inverse()!;
+		double sum = ((double[<4>])a_inv.mul(a).m).sum();
+		assert(math::abs(sum - 2.0) < math::FLOAT_EPSILON,
+			"wrong inverse: sum of all elements should be 2, but got: %g", sum);
+}
+
 fn void test_vec3()
 {
 	Vec3 cross = Vec3{2,3,4}.cross(Vec3{5,6,7});


### PR DESCRIPTION
Fix the adjoint of the Matrix2x2 implementation in the math module. This also fixes the calculation of the inverse which depends on the adjoint.