### PR TITLE
in new_struct_to_str, fix uaf

### DIFF
--- a/lib/std/core/string.c3
+++ b/lib/std/core/string.c3
@@ -757,8 +757,8 @@ macro String new_struct_to_str(x, Allocator allocator = allocator::heap())
 	{
 		s.new_init(allocator: mem);
 		io::fprint(&s, x)!!;
+		return s.copy_str(allocator);
 	};
-	return s.copy_str(allocator);
 }
 
 macro String temp_struct_to_str(x) => new_struct_to_str(x, allocator::temp());


### PR DESCRIPTION
In `new_struct_to_str`, a temporary DString (initialized within the scope of `@stack_mem`) is used for appending writes, before copying to the final result using the allocator passed in to `new_struct_to_str`. However, the final copy happens after the temp string is outside the scope of `@stack_mem`, resulting in use-after-free.