### PR TITLE
Fix hashmap put all for create + test case

### DIFF
--- a/lib/std/collections/hashmap.c3
+++ b/lib/std/collections/hashmap.c3
@@ -455,8 +455,11 @@ fn void HashMap.put_all_for_create(&map, HashMap* other_map) @private
 	if (!other_map.count) return;
 	foreach (Entry *e : other_map.table)
 	{
-		if (!e) continue;
-		map.put_for_create(e.key, e.value);
+		while (e)
+		{
+			map.put_for_create(e.key, e.value);
+			e = e.next;
+		}
 	}
 }
 

--- a/lib/std/collections/map.c3
+++ b/lib/std/collections/map.c3
@@ -131,8 +131,11 @@ fn Map new_from_map(Map other_map, Allocator allocator = null)
 	if (!other_map_impl.count) return (Map)map;
 	foreach (Entry *e : other_map_impl.table)
 	{
-		if (!e) continue;
-		map._put_for_create(e.key, e.value);
+		while (e)
+		{
+			map._put_for_create(e.key, e.value);
+			e = e.next;
+		}
 	}
 	return (Map)map;
 }

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -7,6 +7,7 @@ None
 
 ### Fixes
 - Fix case trying to initialize a `char[*]*` from a String.
+- Fix Map & HashMap `put_all_for_create` not copying all elements, causing `init_from_map` to create incomplete copy.
 
 ### Stdlib changes
 - Increase BitWriter.write_bits limit up to 32 bits.

--- a/test/unit/stdlib/collections/map.c3
+++ b/test/unit/stdlib/collections/map.c3
@@ -4,7 +4,8 @@ import std::collections::map;
 import std::sort;
 import std::io;
 
-def Map = HashMap(<String, usz>);
+def TestHashMap = HashMap(<String, usz>);
+def TestMap = Map(<String, usz>);
 
 struct MapTest
 {
@@ -15,7 +16,7 @@ def List = List(<MapTest>);
 
 fn void map()
 {
-    Map m;
+    TestHashMap m;
     assert(!m.is_initialized());
     m.temp_init();
     assert(m.is_initialized());
@@ -57,10 +58,35 @@ fn void map()
 
 fn void map_remove()
 {
-	Map m;
+	TestHashMap m;
 	assert(!@ok(m.remove("A")));
 	m.temp_init();
 	assert(!@ok(m.remove("A")));
 	m.set("A", 0);
 	assert(@ok(m.remove("A")));
+}
+
+fn void map_copy()
+{
+	TestHashMap hash_map;
+	hash_map.temp_init();
+
+	hash_map.set("aa", 1);
+	hash_map.set("b", 2);
+	hash_map.set("bb", 1);
+
+	TestHashMap hash_map_copy;
+	hash_map_copy.temp_init_from_map(&hash_map);
+
+	assert(hash_map_copy.len() == hash_map.len());
+
+	TestMap map = map::temp(<String, usz>)();
+
+	map.set("aa", 1);
+	map.set("b", 2);
+	map.set("bb", 1);
+
+	TestMap map_copy = map::temp_from_map(<String, usz>)(map);
+
+	assert(map_copy.len() == map.len());
 }


### PR DESCRIPTION
I based these changes on the implementation of `@each`, which does an inner `while` loop, checking for `entry.next`.

Closes: #1695