### PR TITLE
Slight updates in nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,20 +14,24 @@
         default = self.packages.${system}.c3c;
 
         c3c = pkgs.callPackage ./nix/default.nix {};
+        
+        c3c-checks = pkgs.callPackage ./nix/default.nix { 
+          checks = true; 
+        };
 
         c3c-debug = pkgs.callPackage ./nix/default.nix { 
           debug = true; 
         };
 
-        c3c-nochecks = pkgs.callPackage ./nix/default.nix { 
+        c3c-debug-checks = pkgs.callPackage ./nix/default.nix { 
           debug = true; 
-          checks = false; 
+          checks = true; 
         };
       };
 
       devShells = {
         default = pkgs.callPackage ./nix/shell.nix {
-          c3c = self.packages.${system}.c3c-nochecks; 
+          c3c = self.packages.${system}.c3c-debug; 
         };
       };
     }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,7 +8,7 @@
   libffi,
   xar,
   debug ? false,
-  checks ? true,
+  checks ? false,
 }: let 
   inherit (builtins) baseNameOf toString readFile elemAt;
   inherit (lib.sources) cleanSourceWith cleanSource; 


### PR DESCRIPTION
Made a flake.nix bit better for those who are using flakes to build c3c from source:
- got rid of tests by default (as they take sooooo much time to pass)
- added checks option for non-debug build