### PR TITLE
Fix crt detection for Arch Linux

### DIFF
--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -1,5 +1,6 @@
 #include "compiler_internal.h"
 #include "../utils/whereami.h"
+#include "../utils/lib.h"
 #if LLVM_AVAILABLE
 #include "c3_llvm.h"
 #endif
@@ -308,6 +309,13 @@ static const char *find_arch_glob_path(const char *glob_path, int file_len)
 static const char *find_linux_crt(void)
 {
 	if (compiler.build.linuxpaths.crt) return compiler.build.linuxpaths.crt;
+	const char *archLinuxCrt1Path = "/usr/lib/crt1.o";
+	if (file_exists(archLinuxCrt1Path))
+	{
+		const char *archLinuxPath = "/usr/lib";
+		INFO_LOG("Found crt at %s", archLinuxPath);
+		return archLinuxPath;
+	}
 	const char *path = find_arch_glob_path("/usr/lib/*/crt1.o", 6);
 	if (!path)
 	{


### PR DESCRIPTION
Trying to build a simple dynamic library with c3c (with a command as simple as `c3c dynamic-lib myfile.c3` on Arch Linux fails with the error "Failed to find the C runtime at link time.". This is because on Arch Linux, the crt is stored directly inside /usr/lib, but c3c tries to find it inside a subdirectory of /usr/lib, which fails the detection. This PR fixes this issue by checking looking for the crt directly in /usr/lib before looking in any of its subdirectories.