### PR TITLE
C3_MATH feature

### DIFF
--- a/lib/std/math/math_nolibc/__cos.c3
+++ b/lib/std/math/math_nolibc/__cos.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 /* origin: FreeBSD /usr/src/lib/msun/src/k_cos.c */
 /*

--- a/lib/std/math/math_nolibc/__cosdf.c3
+++ b/lib/std/math/math_nolibc/__cosdf.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 /* origin: FreeBSD /usr/src/lib/msun/src/k_cosf.c */
 /*

--- a/lib/std/math/math_nolibc/__fmod.c3
+++ b/lib/std/math/math_nolibc/__fmod.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 union DoubleInternal
 {

--- a/lib/std/math/math_nolibc/__sin.c3
+++ b/lib/std/math/math_nolibc/__sin.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 /* origin: FreeBSD /usr/src/lib/msun/src/k_sin.c */
 /*

--- a/lib/std/math/math_nolibc/__sindf.c3
+++ b/lib/std/math/math_nolibc/__sindf.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 /* origin: FreeBSD /usr/src/lib/msun/src/k_sinf.c */
 /*

--- a/lib/std/math/math_nolibc/__tan.c3
+++ b/lib/std/math/math_nolibc/__tan.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 /* origin: FreeBSD /usr/src/lib/msun/src/k_tan.c */
 /*

--- a/lib/std/math/math_nolibc/__tandf.c3
+++ b/lib/std/math/math_nolibc/__tandf.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 /* origin: FreeBSD /usr/src/lib/msun/src/k_tanf.c */
 /*

--- a/lib/std/math/math_nolibc/atan.c3
+++ b/lib/std/math/math_nolibc/atan.c3
@@ -1,5 +1,17 @@
 module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
+/* origin: FreeBSD /usr/src/lib/msun/src/s_atan.c */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunPro, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
+
 const double[*] ATANHI @private = {
   4.63647609000806093515e-01, /* atan(0.5)hi 0x3FDDAC67, 0x0561BB4F */
   7.85398163397448278999e-01, /* atan(1.0)hi 0x3FE921FB, 0x54442D18 */
@@ -89,6 +101,21 @@ fn double _atan(double x) @weak @extern("atan") @nostrip
 	return sign ? -z : z;
 }
 
+/* origin: FreeBSD /usr/src/lib/msun/src/s_atanf.c */
+/*
+ * Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
+ */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunPro, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
+
 const float[*] ATANHIF @private = {
   4.6364760399e-01, /* atan(0.5)hi 0x3eed6338 */
   7.8539812565e-01, /* atan(1.0)hi 0x3f490fda */
@@ -175,6 +202,19 @@ fn float _atanf(float x) @weak @extern("atanf") @nostrip
 	return sign ? -z : z;
 }
 
+/* origin: FreeBSD /usr/src/lib/msun/src/e_atan2.c */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ *
+ */
+
 const PI_LO @private = 1.2246467991473531772E-16; /* 0x3CA1A626, 0x33145C07 */
 
 macro void extract_words(double d, uint* hi, uint* lo) @private
@@ -251,6 +291,21 @@ fn double _atan2(double y, double x) @weak @extern("atan2") @nostrip
 		default: return (z - PI_LO) - math::PI; /* atan(-,-) */
 	}
 }
+
+/* origin: FreeBSD /usr/src/lib/msun/src/e_atan2f.c */
+/*
+ * Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
+ */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunPro, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
 
 const float PI_F @private = 3.1415927410e+00; /* 0x40490fdb */
 const float PI_LO_F @private = -8.7422776573e-08; /* 0xb3bbbd2e */

--- a/lib/std/math/math_nolibc/atan.c3
+++ b/lib/std/math/math_nolibc/atan.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 const double[*] ATANHI @private = {
   4.63647609000806093515e-01, /* atan(0.5)hi 0x3FDDAC67, 0x0561BB4F */

--- a/lib/std/math/math_nolibc/ceil.c3
+++ b/lib/std/math/math_nolibc/ceil.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 fn double _ceil(double x) @weak @extern("ceil") @nostrip
 {

--- a/lib/std/math/math_nolibc/cos.c3
+++ b/lib/std/math/math_nolibc/cos.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 fn float _cosf(float x) @extern("cosf") @weak @nostrip
 {

--- a/lib/std/math/math_nolibc/exp2.c3
+++ b/lib/std/math/math_nolibc/exp2.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 macro uint _top12f(float x) @private => bitcast(x, uint) >> 20;
 

--- a/lib/std/math/math_nolibc/floor.c3
+++ b/lib/std/math/math_nolibc/floor.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 fn double _floor(double x) @weak @extern("floor") @nostrip
 {

--- a/lib/std/math/math_nolibc/math_nolibc.c3
+++ b/lib/std/math/math_nolibc/math_nolibc.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc;
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 const double TOINT = 1 / math::DOUBLE_EPSILON;
 const double TOINT15 = 1.5 / math::DOUBLE_EPSILON;

--- a/lib/std/math/math_nolibc/pow.c3
+++ b/lib/std/math/math_nolibc/pow.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 fn float powf_broken(float x, float f) @extern("powf") @weak @nostrip
 {

--- a/lib/std/math/math_nolibc/rempi.c3
+++ b/lib/std/math/math_nolibc/rempi.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 import std::math;
 
 /* origin: FreeBSD /usr/src/lib/msun/src/e_rem_pio2f.c */

--- a/lib/std/math/math_nolibc/round.c3
+++ b/lib/std/math/math_nolibc/round.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 fn double _round(double x) @extern("round") @weak @nostrip
 {

--- a/lib/std/math/math_nolibc/scalbn.c3
+++ b/lib/std/math/math_nolibc/scalbn.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 fn double _scalbn(double x, int n) @weak @extern("scalbn") @nostrip
 {

--- a/lib/std/math/math_nolibc/sin.c3
+++ b/lib/std/math/math_nolibc/sin.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 /* origin: FreeBSD /usr/src/lib/msun/src/s_sinf.c */
 /*

--- a/lib/std/math/math_nolibc/sincos.c3
+++ b/lib/std/math/math_nolibc/sincos.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 /* origin: FreeBSD /usr/src/lib/msun/src/s_sinf.c */
 /*

--- a/lib/std/math/math_nolibc/tan.c3
+++ b/lib/std/math/math_nolibc/tan.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 /* origin: FreeBSD /usr/src/lib/msun/src/s_tan.c */
 /*

--- a/lib/std/math/math_nolibc/trig.c3
+++ b/lib/std/math/math_nolibc/trig.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 fn double sincos_broken(double x) @extern("sincos") @weak @nostrip
 {

--- a/lib/std/math/math_nolibc/trunc.c3
+++ b/lib/std/math/math_nolibc/trunc.c3
@@ -1,4 +1,4 @@
-module std::math::nolibc @if(env::NO_LIBC);
+module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));
 
 fn double _trunc(double x) @weak @extern("trunc") @nostrip
 {


### PR DESCRIPTION
This feature allows the usage of nolibc math files even when libc is in use. The motivation is so that `compile-tests` may be used to test these functions without any hassle. If a nolibc definition exists, it will be used in place of libc, otherwise, it will default to libc.

To run math tests, for example,

```
c3c compile-test -D C3_MATH test/unit/stdlib/math/math.c3
```

The change involves swapping `module std::math::nolibc @if(env::NO_LIBC);` at the start of each nolibc math file with `module std::math::nolibc @if(env::NO_LIBC || $feature(C3_MATH));`.