### PR TITLE
Fixed -P JSON syntax, string conversion.

### DIFF
--- a/src/compiler/json_output.c
+++ b/src/compiler/json_output.c
@@ -408,7 +408,7 @@ void print_var_expr(FILE *file, Expr *expr)
                             fputs("\\\"", file);
                             break;
                         }
-                        const unsigned char *ptr = expr->const_expr.bytes.ptr;
+                        const unsigned char *ptr = (unsigned char *)expr->const_expr.bytes.ptr;
                         char *res = malloc_string((size_t)(len * 3 + 1));
                         char *c = res;
                         for (ArraySize i = 0; i < len; ++i)

--- a/src/compiler/json_output.c
+++ b/src/compiler/json_output.c
@@ -403,6 +403,11 @@ void print_var_expr(FILE *file, Expr *expr)
                     {
                         fputs("x\\\"", file);
                         ArraySize len = expr->const_expr.bytes.len;
+                        if (len == 0)
+                        {
+                            fputs("\\\"", file);
+                            break;
+                        }
                         const unsigned char *ptr = expr->const_expr.bytes.ptr;
                         char *res = malloc_string((size_t)(len * 3 + 1));
                         char *c = res;
@@ -410,12 +415,9 @@ void print_var_expr(FILE *file, Expr *expr)
                         {
                             unsigned char curr = ptr[i];
                             char h = (curr & 0xF0) >> 4;
-                            if (h > 0x09) *(c++) = h - 10 + 'A';
-                            else *(c++) = h + '0';
+                            *(c++) = h > 0x09 ? h - 10 + 'A' : h + '0';
                             char l = curr & 0x0F;
-                            if (l > 0x09) *(c++) = l - 10 + 'A';
-                            else *(c++) = l + '0';
-                            *(c++) = ' ';
+                            *(c++) = l > 0x09 ? l - 10 + 'A' : l + '0';
                         }
                         *(c - 1) = '\\';
                         *c = 0;
@@ -441,8 +443,7 @@ void print_var_expr(FILE *file, Expr *expr)
                                 *(c++) = '0';
                                 *(c++) = ((curr & 0x10) >> 4) + '0';
                                 char b = curr & 0x0F;
-                                if (b > 0x09) *(c++) = b - 10 + 'A';
-                                else *(c++) = b + '0';
+                                *(c++) = b > 0x09 ? b - 10 + 'A' : b + '0';
                             }
                             else
                             {

--- a/src/compiler/json_output.c
+++ b/src/compiler/json_output.c
@@ -400,6 +400,29 @@ void print_var_expr(FILE *file, Expr *expr)
                     fputs("TODO: CONST_ERR", file);
                     break;
                 case CONST_BYTES:
+                    {
+                        fputs("x\\\"", file);
+                        ArraySize len = expr->const_expr.bytes.len;
+                        const unsigned char *ptr = expr->const_expr.bytes.ptr;
+                        char *res = malloc_string((size_t)(len * 3 + 1));
+                        char *c = res;
+                        for (ArraySize i = 0; i < len; ++i)
+                        {
+                            unsigned char curr = ptr[i];
+                            char h = (curr & 0xF0) >> 4;
+                            if (h > 0x09) *(c++) = h - 10 + 'A';
+                            else *(c++) = h + '0';
+                            char l = curr & 0x0F;
+                            if (l > 0x09) *(c++) = l - 10 + 'A';
+                            else *(c++) = l + '0';
+                            *(c++) = ' ';
+                        }
+                        *(c - 1) = '\\';
+                        *c = 0;
+                        fputs(res, file);
+                        fputs("\"", file);
+                    }
+                    break;
                 case CONST_STRING:
                     {
                         fputs("\\\"", file);

--- a/src/compiler/json_output.c
+++ b/src/compiler/json_output.c
@@ -14,24 +14,6 @@
 #define FOREACH_DECL_END } } }
 #define INSERT_COMMA do { if (first) { first = false; } else { fputs(",\n", file); } } while(0)
 
-typedef enum {
-    JSON_ESCAPE_NONE,
-    JSON_ESCAPE_CONTROL,
-    JSON_ESCAPE_CHARACTER
-} JsonEscapeKind;
-
-static inline JsonEscapeKind get_character_escape(char c)
-{
-    if (c >= 0x00 && c <= 0x1F) return JSON_ESCAPE_CONTROL;
-    if (c == '\"' || c == '\\') return JSON_ESCAPE_CHARACTER;
-    return JSON_ESCAPE_NONE;
-}
-
-static inline char *string_const_json_format(Expr *expr)
-{
-
-}
-
 static inline void emit_modules(FILE *file)
 {
 


### PR DESCRIPTION
- Changed incorrect `[` `]` to `{` `}`
- Implemented string conversions for `CONST_BYTES` that will now translate to `x\"01 23 4F F0\"`
- `CONST_STRING` is now "JSON legal", i.e. all escapes that are necessary (per [JSON RFC](https://datatracker.ietf.org/doc/html/rfc8259#section-7), double quotes, backslashes, ASCII control characters) will happen, such that it won't break formatting.