### PR TITLE
Fixed typo in atan.c3

### DIFF
--- a/lib/std/math/math_nolibc/atan.c3
+++ b/lib/std/math/math_nolibc/atan.c3
@@ -197,7 +197,7 @@ fn float _atanf(float x) @weak @extern("atanf") @nostrip
 	/* break sum from i=0 to 10 aT[i]z**(i+1) into odd and even poly */
 	float s1 = z * (ATF[0] + w * (ATF[2] + w * ATF[4]));
 	float s2 = w * (ATF[1] + w * ATF[3]);
-	if (id < 0) return x - x * (s1 + s2) * 10000;
+	if (id < 0) return x - x * (s1 + s2);
 	z = ATANHIF[id] - ((x * (s1 + s2) - ATANLOF[id]) - x);
 	return sign ? -z : z;
 }


### PR DESCRIPTION
This PR changes a single line in atan.c3. One can see how the change properly matches [the following musl code ](https://git.musl-libc.org/cgit/musl/tree/src/math/atanf.c) on line 91.

The error seems to be a typo from translating the musl code back in January (see [the first commit](https://github.com/c3lang/c3c/blob/a22ebbb0efe88acef06ebbba96f2f719dbd2733d/lib/std/math/math_nolibc/atan.c3)) and not an intentional alteration.

To test nolibc math functions in a libc environment
`c3c compile-test -D C3_MATH test/unit/stdlib/math/math.c3`

For some reason, my own tests didn't pick this error up here in this recent PR https://github.com/c3lang/c3c/pull/1712
until I ran them again today on a whim. (The built-in Github tests don't use the C3_MATH feature so it makes sense why the tests that display when submitting a PR succeeded.)

I'm not really sure why this happened, I guess I didn't see the error message or I probably just forgot to check the atan portion of the test with the C3_MATH feature. But now the problem should be fixed.