### PR TITLE
Use `weak_odr` rather than `weak` on Windows which seems to prevent i…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -647,6 +647,11 @@ jobs:
           cd test
           ../build/c3c compile-test unit
 
+      - name: Test WASM
+        run: |
+          cd resources/testfragments
+          ../../build/c3c compile --target wasm32 -g0 --no-entry -Os wasm4.c3
+
       - name: Build testproject
         run: |
           cd resources/testproject

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -24,7 +24,8 @@
 - Fix bug in temp allocator when temp memory is exhausted and allocation needs overaligned mem. #1715
 - Incorrectly handles distinct enums and pointers with '+=' and '-=' #1717.
 - Prevent DString from being initialized with "".
-- Fix bug in OnStackAllocator when freeing overallocated data. # #1720
+- Fix bug in OnStackAllocator when freeing overallocated data. #1720
+- Use `weak_odr` rather than `weak` on Windows which seems to prevent issues such as #1704.
 
 ### Stdlib changes
 - Increase BitWriter.write_bits limit up to 32 bits.

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -181,6 +181,10 @@ static const char *exe_name(void)
 {
 	ASSERT0(compiler.build.output_name || compiler.build.name || compiler.context.main || compiler.build.no_entry);
 	const char *name = out_name();
+	if (!name && compiler.build.no_entry)
+	{
+		name = "out";
+	}
 	if (!name)
 	{
 		Path *path = compiler.context.main->unit->module->name;

--- a/src/compiler/llvm_codegen.c
+++ b/src/compiler/llvm_codegen.c
@@ -470,7 +470,7 @@ void llvm_set_global_tls(Decl *decl)
 
 static void llvm_set_weak(GenContext *c, LLVMValueRef global)
 {
-	LLVMSetLinkage(global, LLVMWeakAnyLinkage);
+	LLVMSetLinkage(global, compiler.platform.os == OS_TYPE_WIN32 ? LLVMWeakODRLinkage : LLVMWeakAnyLinkage);
 	LLVMSetVisibility(global, LLVMDefaultVisibility);
 	llvm_set_comdat(c, global);
 }

--- a/test/test_suite/functions/test_regression_mingw.c3t
+++ b/test/test_suite/functions/test_regression_mingw.c3t
@@ -625,7 +625,7 @@ entry:
 
 // #expect: foo.double.ll
 
-define weak double @"foo$double$.check"(double %0)
+define weak_odr double @"foo$double$.check"(double %0)
 entry:
   %fmul = fmul double %0, %0
   ret double %fmul
@@ -634,18 +634,18 @@ entry:
 // #expect: test2.int.ll
 
 %Blob = type { i32 }
-@"test2$int$.argh" = weak local_unnamed_addr global i32 234, comdat, align 4
+@"test2$int$.argh" = weak_odr local_unnamed_addr global i32 234, comdat, align 4
 
-define weak i32 @"test2$int$.getMult"(i32 %0)
+define weak_odr i32 @"test2$int$.getMult"(i32 %0)
 entry:
   %mul = mul i32 %0, %0
   ret i32 %mul
 
-define weak i32 @"test2$int$.hello"()
+define weak_odr i32 @"test2$int$.hello"()
 entry:
   ret i32 1
 }
-define weak i32 @"test2$int$.getValue"(i32 %0)
+define weak_odr i32 @"test2$int$.getValue"(i32 %0)
 entry:
   %blob = alloca %Blob, align 4
   store i32 %0, ptr %blob, align 4
@@ -658,19 +658,19 @@ entry:
 %Blob = type { double }
 
 
-@"test2$double$.argh" = weak local_unnamed_addr global double 2.340000e+02, comdat, align 8
+@"test2$double$.argh" = weak_odr local_unnamed_addr global double 2.340000e+02, comdat, align 8
 
-define weak double @"test2$double$.getMult"(double %0) #0 comdat {
+define weak_odr double @"test2$double$.getMult"(double %0) #0 comdat {
 entry:
   %fmul = fmul double %0, %0
   ret double %fmul
 
-define weak i32 @"test2$double$.hello"() #0 comdat {
+define weak_odr i32 @"test2$double$.hello"() #0 comdat {
 entry:
   ret i32 1
 }
 
-define weak double @"test2$double$.getValue"(i64 %0) #0 comdat {
+define weak_odr double @"test2$double$.getValue"(i64 %0) #0 comdat {
 entry:
   %blob = alloca %Blob, align 8
   store i64 %0, ptr %blob, align 8


### PR DESCRIPTION
…ssues such as #1704. Fix regression.