### PR TITLE
Fix Segfault and UX of the `c3c project add-target` subcommand

### DIFF
--- a/src/build/build.h
+++ b/src/build/build.h
@@ -453,6 +453,7 @@ typedef struct BuildOptions_
 		ProjectSubcommand command;
 		const char *target_name;
 		TargetType target_type;
+		const char **sources;
 	} project_options;
 	CompileOption compile_option;
 	TrustLevel trust_level;

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -222,7 +222,8 @@ static void parse_project_subcommand(BuildOptions *options)
 		if (at_end() || next_is_opt()) error_exit("Expected a target type like 'executable' or 'static-lib'");
 		options->project_options.target_type = (TargetType)get_valid_enum_from_string(next_arg(), "type", targets, ELEMENTLEN(targets), "a target type like 'executable' or 'static-lib'");
 
-		while (!at_end() && !next_is_opt()) {
+		while (!at_end() && !next_is_opt())
+		{
 			vec_add(options->project_options.sources, next_arg());
 		}
 

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -198,8 +198,8 @@ static void project_usage()
 	PRINTF("Usage: %s [<options>] project <subcommand> [<args>]", args[0]);
 	PRINTF("");
 	PRINTF("Project Subcommands:");
-	PRINTF("  view                                          view the current projects structure");
-	PRINTF("  add-target <name>  <target_type>              add a new target to the project");
+	PRINTF("  view                                            view the current projects structure");
+	PRINTF("  add-target <name>  <target_type>  [sources...]  add a new target to the project");
 	#if FETCH_AVAILABLE
 		PRINTF("  fetch              							fetch missing project libraries");
 	#endif
@@ -221,6 +221,10 @@ static void parse_project_subcommand(BuildOptions *options)
 
 		if (at_end() || next_is_opt()) error_exit("Expected a target type like 'executable' or 'static-lib'");
 		options->project_options.target_type = (TargetType)get_valid_enum_from_string(next_arg(), "type", targets, ELEMENTLEN(targets), "a target type like 'executable' or 'static-lib'");
+
+		while (!at_end() && !next_is_opt()) {
+			vec_add(options->project_options.sources, next_arg());
+		}
 
 		return;
 	}

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -299,7 +299,7 @@ void fetch_project(BuildOptions* options)
 	const char **libdirs = get_project_dependency_directories();
 	const char **deps = get_project_dependencies();
 	const char *filename;
-	JSONObject *project_json = read_project(&filename);
+	JSONObject *project_json = read_project(&filename, false);
 
 	JSONObject *targets_json = json_map_get(project_json, "targets");
 

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -9,13 +9,16 @@ static JSONObject *read_project(const char **file_used, bool assume_empty_if_not
 	const char *project_filename = file_exists(PROJECT_JSON5) ? PROJECT_JSON5 : PROJECT_JSON;
 	*file_used = project_filename;
 	char *read;
-	if (assume_empty_if_not_exists) {
+	if (assume_empty_if_not_exists)
+	{
 		// If project file does not exist assume the project simply being empty instead of
 		// failing. This is useful for such commands as `project add-target`. It enables
 		// them to update otherwise non-existing project files reducing the friction.
 		read = "{}";
 		if (file_exists(project_filename)) read = file_read_all(project_filename, &size);
-	} else {
+	}
+	else
+	{
 		read = file_read_all(project_filename, &size);
 	}
 	JsonParser parser;
@@ -424,7 +427,8 @@ void add_target_project(BuildOptions *build_options)
 	JSONObject *new_target = json_new_map();
 	json_map_set(new_target, "type", target_type_obj);
 	JSONObject *target_sources = json_new_object(J_ARRAY);
-	FOREACH(const char *, source, build_options->project_options.sources) {
+	FOREACH(const char *, source, build_options->project_options.sources)
+	{
 		vec_add(target_sources->elements, json_new_string(source));
 	}
 	json_map_set(new_target, "sources", target_sources);


### PR DESCRIPTION
My version:

```console
c3c --version
C3 Compiler Version:       0.6.6 (Pre-release, Dec 28 2024 03:58:06)
Installed directory:       /home/rexim/opt/c3/bin/
Git Hash:                  291b26f2300dfaaf8d6c3d8890a3c1294cd39cde
Backends:                  LLVM
LLVM version:              18.1.8
LLVM default target:       x86_64-unknown-linux-gnu
```

Consider the following workflow in a completely empty folder:

```console
$ cat > main.c3 <<END
import std::io;

fn void main() {
    io::printfn("Hello, World");
}
END
$ c3c project add-target main executable
Could not open file "project.json".

$ touch project.json
$ c3c project add-target main executable
Expected a map of project information in 'project.json'.

$ echo {} > project.json
$ c3c project add-target main executable
Segmentation fault
$ Uhm... EXCUSE ME?!!
```

First of all, we have an obvious NULL-dereferencing bug. But that's not the biggest problem. The whole process is absolutely and needlessly excruciating. Why do I have to create the file myself? Why do I have to initialize it? Why add-target can't just do what I mean and create everything for me?

In this patch we

- Fix segfault on `project.json` containing empty map `{}`
- Enable `add-target` to operate on non-existing project files
- Extend `add-target` syntax to accept source through CLI args

So the whole workflow turns into

```console
$ cat > main.c3 <<END
import std::io;

fn void main() {
    io::printfn("Hello, World");
}
END
$ c3c project add-target main executable main.c3
$ cat project.json
{
  "targets": {
    "main": {
      "type": "executable",
      "sources":  [ "main.c3" ]
    }
  }
}
$ c3c run
Hello, World
```

Bam! Very smooth, feels great! Minimum changes required. Please let me know if you see any problems with this patch.
