### PR TITLE
fix: use helper printing macros, to use the correct printing width

### DIFF
--- a/src/compiler/c_codegen.c
+++ b/src/compiler/c_codegen.c
@@ -1,5 +1,6 @@
 #include "c_codegen_internal.h"
 
+#include <inttypes.h>
 
 typedef struct OptionalCatch_
 {
@@ -346,11 +347,11 @@ static void c_emit_const_expr(GenContext *c, CValue *value, Expr *expr)
 			}
 			if (type_is_unsigned(t))
 			{
-				PRINTF("%s ___var_%d = %llu;\n", c_type_name(c, t), c_emit_temp(c, value, t), expr->const_expr.ixx.i.low);
+				PRINTF("%s ___var_%d = %" PRIu64 ";\n", c_type_name(c, t), c_emit_temp(c, value, t), expr->const_expr.ixx.i.low);
 			}
 			else
 			{
-				PRINTF("%s ___var_%d = %lld;\n", c_type_name(c, t), c_emit_temp(c, value, t), expr->const_expr.ixx.i.low);
+				PRINTF("%s ___var_%d = %" PRId64 ";\n", c_type_name(c, t), c_emit_temp(c, value, t), (int64_t)expr->const_expr.ixx.i.low);
 			}
 			return;
 		case CONST_BOOL:


### PR DESCRIPTION
This fixes a bug, I encountered when building c3c locally. 

(I am on commit f5cea221a6ed6b0eda26d0f45ce8df53670c6576)

I used the following workflow

```bash
mkdir build
cd build
cmake .. -DC3_LLVM_VERSION=18.1.8 -DLLVM_DIR=/usr/lib/llvm-18/lib
cmake --build .
```

env variables, that are maybe relevant:
```ini
CC_LD=mold
CC=clang-18
```
I used the clang-18 toolchain from https://apt.llvm.org/ for ubuntu 24.10 (oracular)

```
clang-18 --version
Ubuntu clang version 18.1.8 (11)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```

With this Commit it compiles locally, otherwise I get this error:


```bash
<>/c3c/src/compiler/c_codegen.c:349:83: error: format specifies type 'unsigned long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Werror,-Wformat]
  349 |                                 PRINTF("%s ___var_%d = %llu;\n", c_type_name(c, t), c_emit_temp(c, value, t), expr->const_expr.ixx.i.low);
      |                                                        ~~~~                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                        %lu
<>/c3c/src/compiler/c_codegen.c:44:47: note: expanded from macro 'PRINTF'
   44 | #define PRINTF(x, ...) fprintf(c->file, x, ## __VA_ARGS__) /* NOLINT */
      |                                         ~     ^~~~~~~~~~~
<>/c3c/src/compiler/c_codegen.c:353:83: error: format specifies type 'long long' but the argument has type 'uint64_t' (aka 'unsigned long') [-Werror,-Wformat]
  353 |                                 PRINTF("%s ___var_%d = %lld;\n", c_type_name(c, t), c_emit_temp(c, value, t), expr->const_expr.ixx.i.low);
      |                                                        ~~~~                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                        %lu
<>/c3c/src/compiler/c_codegen.c:44:47: note: expanded from macro 'PRINTF'
   44 | #define PRINTF(x, ...) fprintf(c->file, x, ## __VA_ARGS__) /* NOLINT */
      |                                         ~     ^~~~~~~~~~~
2 errors generated.
gmake[2]: *** [CMakeFiles/c3c.dir/build.make:965: CMakeFiles/c3c.dir/src/compiler/c_codegen.c.o] Fehler 1
gmake[1]: *** [CMakeFiles/Makefile2:253: CMakeFiles/c3c.dir/all] Fehler 2
```
So I used the `PRIu64` and `PRId64` macros, which are resolved to `"%lu"` and `"%ld"` on my platform, which works.

It is generally better to use such agnostic macros, as they do the correct thing on 32 and 64 bit architectures.


I am not sure, if the cast to `int64_t` is the intended way, but I assume so, since it was printed as signed integer ("%lld") and so we also should cast it to one explicitly.


Feel free to correct me in any point 😄 
