### PR TITLE
Refactor Posix NativeThread to be able to free allocated memory

### DIFF
--- a/lib/std/threads/os/thread_posix.c3
+++ b/lib/std/threads/os/thread_posix.c3
@@ -8,8 +8,11 @@ struct NativeMutex
 }
 
 def NativeConditionVariable = Pthread_cond_t;
-def NativeThread = Pthread_t;
 def NativeOnceFlag = Pthread_once_t;
+struct NativeThread {
+	Pthread_t pthread;
+	PosixThreadData* data;
+}
 
 <*
  @require !self.is_initialized() : "Mutex is already initialized"
@@ -157,19 +160,27 @@ fn void* callback(void* arg) @private
 
 fn void! NativeThread.create(&thread, ThreadFn thread_fn, void* arg)
 {
-
+	Pthread_t pthread;
 	PosixThreadData *thread_data = mem::new(PosixThreadData, { .thread_fn = thread_fn, .arg = arg });
-	if (posix::pthread_create(thread, null, &callback, thread_data) != 0)
+	if (posix::pthread_create(&pthread, null, &callback, thread_data) != 0)
 	{
-		*thread = null;
+		pthread = null;
 		free(thread_data);
 		return ThreadFault.INIT_FAILED?;
 	}
+	thread.pthread = pthread;
+	thread.data = thread_data;
+}
+
+fn void NativeThread.destroy(thread)
+{
+	mem::free(thread.data);
+	//free((void*)thread.pthread);
 }
 
 fn void! NativeThread.detach(thread)
 {
-	if (posix::pthread_detach(thread)) return ThreadFault.DETACH_FAILED?;
+	if (posix::pthread_detach(thread.pthread)) return ThreadFault.DETACH_FAILED?;
 }
 
 fn void native_thread_exit(int result)
@@ -177,20 +188,20 @@ fn void native_thread_exit(int result)
 	posix::pthread_exit((void*)(iptr)result);
 }
 
-fn NativeThread native_thread_current()
+fn Pthread_t native_thread_current()
 {
-	return (NativeThread)posix::pthread_self();
+	return (Pthread_t)posix::pthread_self();
 }
 
 fn bool NativeThread.equals(thread, NativeThread other)
 {
-	return (bool)posix::pthread_equal(thread, other);
+	return (bool)posix::pthread_equal(thread.pthread, other.pthread);
 }
 
 fn int! NativeThread.join(thread)
 {
 	void *pres;
-	if (posix::pthread_join(thread, &pres)) return ThreadFault.JOIN_FAILED?;
+	if (posix::pthread_join(thread.pthread, &pres)) return ThreadFault.JOIN_FAILED?;
 	return (int)(iptr)pres;
 }
 

--- a/lib/std/threads/os/thread_win32.c3
+++ b/lib/std/threads/os/thread_win32.c3
@@ -249,6 +249,12 @@ fn void! NativeThread.create(&thread, ThreadFn func, void* args)
 	if (!(*thread = (NativeThread)win32::createThread(null, 0, func, args, 0, null))) return ThreadFault.INIT_FAILED?;
 }
 
+fn void NativeThread.destroy(&thread)
+{
+	// No allocations happen in create() for Windows threads
+	return;
+}
+
 fn void! NativeThread.detach(thread) @inline
 {
 	if (!win32::closeHandle(thread)) return ThreadFault.DETACH_FAILED?;

--- a/lib/std/threads/thread.c3
+++ b/lib/std/threads/thread.c3
@@ -60,6 +60,7 @@ macro void! ConditionVariable.wait_timeout(&cond, Mutex* mutex, ulong ms)
 
 
 macro void! Thread.create(&thread, ThreadFn thread_fn, void* arg) => NativeThread.create((NativeThread*)thread, thread_fn, arg);
+macro void Thread.destroy(thread) => NativeThread.destroy((NativeThread)thread);
 macro void! Thread.detach(thread) => NativeThread.detach((NativeThread)thread);
 macro int! Thread.join(thread) => NativeThread.join((NativeThread)thread);
 macro bool Thread.equals(thread, Thread other) => NativeThread.equals((NativeThread)thread, (NativeThread)other);


### PR DESCRIPTION
As discussed, the NativeThread implementation for Posix allocates memory on create(), which is passed to the pthread_create() function. However, since no reference to it was retained, the memory leaked after the thread finished. 

See: https://github.com/c3lang/c3c/blob/ad9cfcdcc7bf7fd8ac27803e81e0e596147e3194/lib/std/threads/os/thread_posix.c3#L161

According to my research, there's no way to get a reference to this memory block back from pthread, so I changed NativeThread so that a reference to this memory can be stored and added a `destroy()` method which ultimately can free the memory.

For the Win32 implementation, there is no special allocation. `destroy()` is therefore a no-op for the moment.

In my tests the leak disappeared and threads still worked.

This PR should just serve as a proposal, since I'm not so sure if I'm fully aware of the potential implications of this change. Please feel free to dismiss or ignore.