### PR TITLE
Fix `native_fputc`

### DIFF
--- a/lib/std/io/os/file_libc.c3
+++ b/lib/std/io/os/file_libc.c3
@@ -77,7 +77,7 @@ fn usz! native_fwrite(CFile file, char[] buffer) @inline
 
 fn void! native_fputc(CInt c, CFile stream) @inline
 {
-	if (!libc::fputc(c, stream)) return IoError.EOF?;
+	if (libc::fputc(c, stream) == libc::EOF) return IoError.EOF?;
 }
 
 fn usz! native_fread(CFile file, char[] buffer) @inline


### PR DESCRIPTION
Since C `libc::fputc` returns code of character which was written the original code wasn't working properly when writing 0 character.