### PR TITLE
socket.c3: optimize poll() duration wrapping

### DIFF
--- a/lib/std/net/socket.c3
+++ b/lib/std/net/socket.c3
@@ -56,9 +56,9 @@ struct Poll
  @param [inout] polls
  @param timeout "duration to poll (clamped to CInt.max ms), or POLL_FOREVER."
 *>
-fn ulong! poll_ms(Poll[] polls, long timeout_ms)
+fn ulong! poll_ms(Poll[] polls, Duration timeout)
 {
-	return poll(polls, time::ms(timeout_ms)) @inline;
+	return poll(polls, timeout.to_ms()) @inline;
 }
 
 <*
@@ -67,7 +67,7 @@ fn ulong! poll_ms(Poll[] polls, long timeout_ms)
 *>
 fn ulong! poll(Poll[] polls, long timeout_ms)
 {
-	if (timeout_ms > CInt.max) time_ms = CInt.max;
+	if (timeout_ms > CInt.max) timeout_ms = CInt.max;
 	$if env::WIN32:
 		CInt result = win32_WSAPoll((Win32_LPWSAPOLLFD)polls.ptr, (Win32_ULONG)polls.len, (CInt)timeout_ms);
 	$else

--- a/lib/std/net/socket.c3
+++ b/lib/std/net/socket.c3
@@ -52,6 +52,10 @@ struct Poll
 	PollEvents revents;
 }
 
+<*
+ @param [inout] polls
+ @param timeout "duration to poll (clamped to CInt.max ms), or POLL_FOREVER."
+*>
 fn ulong! poll_ms(Poll[] polls, long timeout_ms)
 {
 	return poll(polls, time::ms(timeout_ms)) @inline;
@@ -59,16 +63,15 @@ fn ulong! poll_ms(Poll[] polls, long timeout_ms)
 
 <*
  @param [inout] polls
- @param timeout "duration to poll."
+ @param timeout_ms "duration to poll in ms or -1. Clamped to CInt.max"
 *>
-fn ulong! poll(Poll[] polls, Duration timeout)
+fn ulong! poll(Poll[] polls, long timeout_ms)
 {
-	long time_ms = (timeout < 0) ? (long)POLL_FOREVER : timeout.to_ms();
-	if (time_ms > CInt.max) time_ms = CInt.max;
+	if (timeout_ms > CInt.max) time_ms = CInt.max;
 	$if env::WIN32:
-		CInt result = win32_WSAPoll((Win32_LPWSAPOLLFD)polls.ptr, (Win32_ULONG)polls.len, (CInt)time_ms);
+		CInt result = win32_WSAPoll((Win32_LPWSAPOLLFD)polls.ptr, (Win32_ULONG)polls.len, (CInt)timeout_ms);
 	$else
-		CInt result = os::poll((Posix_pollfd*)polls.ptr, (Posix_nfds_t)polls.len, (CInt)time_ms);
+		CInt result = os::poll((Posix_pollfd*)polls.ptr, (Posix_nfds_t)polls.len, (CInt)timeout_ms);
 	$endif
 	return result < 0 ? os::socket_error()? : (ulong)result;
 }

--- a/lib/std/net/socket.c3
+++ b/lib/std/net/socket.c3
@@ -56,16 +56,16 @@ struct Poll
  @param [inout] polls
  @param timeout "duration to poll (clamped to CInt.max ms), or POLL_FOREVER."
 *>
-fn ulong! poll_ms(Poll[] polls, Duration timeout)
+fn ulong! poll(Poll[] polls, Duration timeout)
 {
-	return poll(polls, timeout.to_ms()) @inline;
+	return poll_ms(polls, timeout.to_ms()) @inline;
 }
 
 <*
  @param [inout] polls
  @param timeout_ms "duration to poll in ms or -1. Clamped to CInt.max"
 *>
-fn ulong! poll(Poll[] polls, long timeout_ms)
+fn ulong! poll_ms(Poll[] polls, long timeout_ms)
 {
 	if (timeout_ms > CInt.max) timeout_ms = CInt.max;
 	$if env::WIN32:


### PR DESCRIPTION
I saw you fixed it in response to @rexim Video, but I think switching the wrapper would make it a bit more efficient since it avoids a time::ms()/Duration::to_ms() roundtrip for These who prefer the raw long. I can understand to use the more expressive types for the actual implementation, but in the specific case Duration isnt even the best fit.

I also made sure POLL_FOREVER and the Clint.max Champing is documented.

BTW do you also need to clamp for underflows or maybe have a (timeout_ms<0)-1:(timeout_ms<CInt.max)?(CInt)timeout_ms:CInt.max) instead?

this is only a draft PR for discussion 