### PR TITLE
Fix 'clean' command on Windows MinGW

### DIFF
--- a/src/utils/file_utils.c
+++ b/src/utils/file_utils.c
@@ -550,7 +550,7 @@ bool file_delete_file(const char *path)
 void file_delete_all_files_in_dir_with_suffix(const char *path, const char *suffix)
 {
 	ASSERT0(path);
-#if (_MSC_VER)
+#if (_WIN32)
 	const char *cmd = "del /q \"%s\\*%s\" >nul 2>&1";
 #else
 	const char *cmd = "rm -f %s/*%s";


### PR DESCRIPTION
'c3c clean' command try to use 'rm' on Windows MinGW compiled executable, since it does not define "_MSC_VER", but define "_WIN32"
There are other uses of "_MSC_VER" in the same file, some can probably be replaced by "_WIN32" too.