### PR TITLE
Fix issue when building on NixOS, firstly occured under commit 819a85ee

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ if(C3_WITH_LLVM)
         endif()
     endif()
 
-    if (NOT WIN32)
+    if (EXISTS /usr/lib)
         # Some systems (such as Alpine Linux) seem to put some of the relevant
         # LLVM files in /usr/lib, but this doesn't seem to be included in the
         # value of LLVM_LIBRARY_DIRS.


### PR DESCRIPTION
There is no `/usr/lib` on NixOS. Apparently, cmake doesn't like it)