### PR TITLE
fix: memory leak in String.copy()

### DIFF
--- a/lib/std/core/string.c3
+++ b/lib/std/core/string.c3
@@ -529,9 +529,8 @@ fn ZString String.zstr_tcopy(s) => s.zstr_copy(allocator::temp()) @inline;
 fn String String.copy(s, Allocator allocator = allocator::heap())
 {
 	usz len = s.len;
-	char* str = allocator::malloc(allocator, len + 1);
+	char* str = allocator::malloc(allocator, len);
 	mem::copy(str, s.ptr, len);
-	str[len] = 0;
 	return (String)str[:len];
 }
 


### PR DESCRIPTION
Fix a one-byte memory leak in String.copy() when copying an empty String on the heap. The following code shows a leak:

```
fn void main()
{
	mem::@report_heap_allocs_in_scope()
	{
		String s = "".copy();
		s.free();
	};
}
```

The heap allocations are as follows:
```
Launching ./string_free
================================== Memory Report ==================================
Size in bytes   Address          Function
            1   0x5cdf6ee3e330   malloc_try:68
===================================================================================
- Total currently allocated memory:            1
- Total current allocations:                   1
- Total allocations (freed and retained):      1
- Total allocated memory (freed and retained): 1

Full leak report:
Allocation 1 (1 bytes):
   malloc_try (in /home/km/Documents/c3c/lib/std/core/mem_allocator.c3:68)
   malloc (in /home/km/Documents/c3c/lib/std/core/mem_allocator.c3:57)
   std.core.String.copy (in /home/km/Documents/c3c/lib/std/core/string.c3:532)
   string_free.main (in /tmp/string-free.c3:5)
   @main_to_void_main (in /home/km/Documents/c3c/lib/std/core/private/main_stub.c3:18)
   main (in /tmp/string-free.c3:1)
   __libc_init_first (source unavailable)
   __libc_start_main (source unavailable)
   _start (source unavailable)
Program completed with exit code 0.
```