### PR TITLE
windows: detect MSVC cpp build tools

### DIFF
--- a/src/utils/find_msvc.c
+++ b/src/utils/find_msvc.c
@@ -34,7 +34,7 @@ static char *find_visual_studio(void)
 	// Let's locate vswhere.exe
 	char *path = win_utf16to8(_wgetenv(L"ProgramFiles(x86)"));
 	scratch_buffer_clear();
-	scratch_buffer_printf("\"%s\\Microsoft Visual Studio\\Installer\\vswhere.exe\" -latest -prerelease -property installationPath", path);
+	scratch_buffer_printf("\"%s\\Microsoft Visual Studio\\Installer\\vswhere.exe\" -latest -prerelease -property installationPath -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -products *", path);
 	const char *install_path = NULL;
 
 	// Call vswhere.exe


### PR DESCRIPTION
I'm not familiar with C so the code is pretty messy. But it solves problem addressed in #1713.
I have tested on my local windows 11 machine with msvc version 17.13.35617.110 and on a clean install of Windows Sandbox with latest version of https://visualstudio.microsoft.com/visual-cpp-build-tools/