### PR TITLE
allowing `c3c test -- <args1>`

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -27,6 +27,7 @@
 - Allow test runners to take String[] arguments.
 - Added `--lsp` output.
 - Improve the error message when running out of memory.
+- Allowed passing arguments to @test / @benchmark runners via `c3c test[benchmark] -- -o --opt1 <arg1>`
 
 ### Fixes
 - Fix case trying to initialize a `char[*]*` from a String.

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -53,8 +53,8 @@ static void usage(bool full)
 	PRINTF("  init <project name>                                 Initialize a new project structure.");
 	PRINTF("  init-lib <library name>                             Initialize a new library structure.");
 	PRINTF("  build [<target>]                                    Build the target in the current project.");
-	PRINTF("  benchmark                                           Run the benchmarks in the current project.");
-	PRINTF("  test                                                Run the unit tests in the current project.");
+	PRINTF("  benchmark [-- [<arg1> ...]]                         Run the benchmarks in the current project.");
+	PRINTF("  test [-- [<arg1] ...]                               Run the unit tests in the current project.");
 	PRINTF("  clean                                               Clean all build files.");
 	PRINTF("  run [<target>] [-- [<arg1> ...]]                    Run (and build if needed) the target in the current project.");
 	PRINTF("  dist [<target>]                                     Clean and build a target for distribution.");

--- a/src/build/builder.c
+++ b/src/build/builder.c
@@ -99,6 +99,8 @@ bool command_passes_args(CompilerCommand command)
 		case COMMAND_CLEAN_RUN:
 		case COMMAND_COMPILE_RUN:
 		case COMMAND_RUN:
+		case COMMAND_BENCHMARK:
+		case COMMAND_TEST:
 			return true;
 		case COMMAND_COMPILE:
 		case COMMAND_COMPILE_ONLY:
@@ -116,8 +118,6 @@ bool command_passes_args(CompilerCommand command)
 		case COMMAND_DOCS:
 		case COMMAND_BENCH:
 		case COMMAND_PRINT_SYNTAX:
-		case COMMAND_BENCHMARK:
-		case COMMAND_TEST:
 		case COMMAND_VENDOR_FETCH:
 		case COMMAND_PROJECT:
 			return false;
@@ -273,11 +273,13 @@ static void update_build_target_from_options(BuildTarget *target, BuildOptions *
 		case COMMAND_BENCHMARK:
 			target->run_after_compile = true;
 			target->type = TARGET_TYPE_BENCHMARK;
+			target->args = options->args;
 			break;
 		case COMMAND_COMPILE_TEST:
 		case COMMAND_TEST:
 			target->run_after_compile = true;
 			target->type = TARGET_TYPE_TEST;
+			target->args = options->args;
 			break;
 		case COMMAND_RUN:
 		case COMMAND_COMPILE_RUN:


### PR DESCRIPTION
A small improvement for #1774

Allowing custom and default test/bench runners receiving arguments:
```zig
fn bool default_test_runner(String[] args)
{
	io::printfn("default_test_runner: %s", args);
	return false;
}
```

```
> c3c test --testfn "std::core::test::default_test_runner" -- foo --bar

Program linked to executable 'build/testrun'.
Launching ./build/testrun foo --bar
default_test_runner: [./build/testrun, foo, --bar]
```

The same behavior is consistent when we do direct run of compiled test runner:
```
> ./build/testrun foo --bar

default_test_runner: [./build/testrun, foo, --bar]
```

We might be getting help via:
```
c3c test -- --help
```

This will decouple @tests/@benchmark runner logic completely from c3c compiler space into c3 (stdlib space) or custom runner space. 