### PR TITLE
use WORKING_DIRECTORY to ensure stability of finding the git hash

### DIFF
--- a/git_hash.cmake
+++ b/git_hash.cmake
@@ -4,6 +4,7 @@ set(GIT_HASH "unknown")
 
 if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git")
     execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
                     OUTPUT_VARIABLE GIT_HASH
                     OUTPUT_STRIP_TRAILING_WHITESPACE
                     COMMAND_ERROR_IS_FATAL ANY)


### PR DESCRIPTION
Without passing `WORKING_DIRECTORY` to `execute_process()`, the build directory _must_ be in the source tree for the `git` command to succeed.