### PR TITLE
fix quicksort stalling

### DIFF
--- a/lib/std/sort/quicksort.c3
+++ b/lib/std/sort/quicksort.c3
@@ -106,40 +106,40 @@ fn ElementType! qselect(Type list, isz low, isz high, isz k, CmpFn cmp, Context 
 	return SearchResult.MISSING?;
 }
 
-macro @partition(Type list, isz l, isz h, CmpFn cmp, Context context)
+macro @partition(Type #list, isz l, isz h, CmpFn cmp, Context context)
 {
 	var $has_cmp = @is_valid_macro_slot(cmp);
 	var $has_context = @is_valid_macro_slot(context);
-	var $cmp_by_value = $has_cmp &&& $assignable(list[0], $typefrom(CmpFn.paramsof[0].type));
+	var $cmp_by_value = $has_cmp &&& $assignable(#list[0], $typefrom(CmpFn.paramsof[0].type));
 
-	ElementType pivot = list[l];
+	ElementType pivot = #list[l];
 	while (l < h)
 	{
 		$switch
 			$case $cmp_by_value && $has_context:
-				while (cmp(list[h], pivot, context) >= 0 && l < h) h--;
-				if (l < h) list[l++] = list[h];
-				while (cmp(list[l], pivot, context) <= 0 && l < h) l++;
+				while (cmp(#list[h], pivot, context) >= 0 && l < h) h--;
+				if (l < h) #list[l++] = #list[h];
+				while (cmp(#list[l], pivot, context) <= 0 && l < h) l++;
 			$case $cmp_by_value:
-				while (cmp(list[h], pivot) >= 0 && l < h) h--;
-				if (l < h) list[l++] = list[h];
-				while (cmp(list[l], pivot) <= 0 && l < h) l++;
+				while (cmp(#list[h], pivot) >= 0 && l < h) h--;
+				if (l < h) #list[l++] = #list[h];
+				while (cmp(#list[l], pivot) <= 0 && l < h) l++;
 			$case $has_cmp && $has_context:
-				while (cmp(&list[h], &pivot, context) >= 0 && l < h) h--;
-				if (l < h) list[l++] = list[h];
-				while (cmp(&list[l], &pivot, context) <= 0 && l < h) l++;
+				while (cmp(&#list[h], &pivot, context) >= 0 && l < h) h--;
+				if (l < h) #list[l++] = #list[h];
+				while (cmp(&#list[l], &pivot, context) <= 0 && l < h) l++;
 			$case $has_cmp:
-				while (cmp(&list[h], &pivot) >= 0 && l < h) h--;
-				if (l < h) list[l++] = list[h];
-				while (cmp(&list[l], &pivot) <= 0 && l < h) l++;
+				while (cmp(&#list[h], &pivot) >= 0 && l < h) h--;
+				if (l < h) #list[l++] = #list[h];
+				while (cmp(&#list[l], &pivot) <= 0 && l < h) l++;
 			$default:
-				while (greater_eq(list[h], pivot) && l < h) h--;
-				if (l < h) list[l++] = list[h];
-				while (less_eq(list[l], pivot) && l < h) l++;
+				while (greater_eq(#list[h], pivot) && l < h) h--;
+				if (l < h) #list[l++] = #list[h];
+				while (less_eq(#list[l], pivot) && l < h) l++;
 		$endswitch
-		if (l < h) list[h--] = list[l];
+		if (l < h) #list[h--] = #list[l];
 	}
-	list[l] = pivot;
+	#list[l] = pivot;
 
 	return l;
 }

--- a/test/unit/stdlib/sort/quicksort.c3
+++ b/test/unit/stdlib/sort/quicksort.c3
@@ -54,6 +54,12 @@ fn void quicksort_with_value()
     }
 }
 
+fn void quicksort_with_fixed_array()
+{
+    int[*] tc = {3, 2, 1};
+    sort::quicksort(tc); // will not be sorted, but should return
+}
+
 fn void quicksort_with_lambda()
 {
     int[][] tcases = {


### PR DESCRIPTION
Fix quicksort stalling by passing `#list` instead of `list` to the `@partition` function. The stalling occurs when a fixed-sized array is passed to quicksort. Fixed-sized arrays parameters will be passed by value (and not by references); hence, a fixed-sized array will not be sorted but it should also not stall the algorithm.

As additional measure (or alternative), we could use a contract to avoid passing fixed-size arrays or vectors to the quicksort function, i.e.
```
@require values::@typekind(list) != ARRAY
@require values::@typekind(list) != VECTOR
```

Fixes: #1845