### PR TITLE
Improve c3c --help/-hh and c3c project

### DIFF
--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -71,7 +71,7 @@ static void usage(bool full)
 	PRINTF("  vendor-fetch <library> ...                          Fetches one or more libraries from the vendor collection.");
 	PRINTF("  project <subcommand> ...                            Manipulate or view project files.");
 	PRINTF("");
-	PRINTF(full ? "Options:" : "Common options:");
+	PRINTF(full ? "Options:\n" : "Common options:");
 	PRINTF("  -h -hh --help              - Print the help, -h for the normal options, -hh for the full help.");
 	PRINTF("  -V --version               - Print version information.");
 	PRINTF("  -q --quiet                 - Silence unnecessary output.");
@@ -205,7 +205,7 @@ static void project_usage()
 	PRINTF("  view                                            view the current projects structure");
 	PRINTF("  add-target <name>  <target_type>  [sources...]  add a new target to the project");
 	#if FETCH_AVAILABLE
-		PRINTF("  fetch              							fetch missing project libraries");
+		PRINTF("  fetch                                           fetch missing project libraries");
 	#endif
 }
 
@@ -405,7 +405,7 @@ static void print_version(void)
     PRINTF("Backends:                  LLVM");
 #elif TB_AVAILABLE
     PRINTF("Backends:                  TB");
-#else 
+#else
 
     PRINTF("No backends available");
 #endif

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -71,7 +71,7 @@ static void usage(bool full)
 	PRINTF("  vendor-fetch <library> ...                          Fetches one or more libraries from the vendor collection.");
 	PRINTF("  project <subcommand> ...                            Manipulate or view project files.");
 	PRINTF("");
-	PRINTF(full ? "Options:\n" : "Common options:");
+	full ? PRINTF("Options:") : PRINTF("Common options:");
 	PRINTF("  -h -hh --help              - Print the help, -h for the normal options, -hh for the full help.");
 	PRINTF("  -V --version               - Print version information.");
 	PRINTF("  -q --quiet                 - Silence unnecessary output.");


### PR DESCRIPTION

### Long help missing newline
In the long help, there was a missing newline caused by a combination of a PRINTF macro appending a newline-character to the passed string and a ternary operator, causing the newline only to be applied to the second string of the ternary operator and not the first.
This resulted in:
```
Options:
  -h -hh --help              - Print the help, -h for the normal options, -hh for the full help.
  -V --version               - Print version information.
  ```
  And got fixed to:
  ```
  Options:  -h -hh --help              - Print the help, -h for the normal options, -hh for the full help.
  -V --version               - Print version information.
  ```

### project fetch help incorrect indentation
Another issue was that the indentation of the `fetch` help (subcommand of `project`) did not align due to using tabs where the rest use spaces. I converted the tabs to spaces, so now they will line up properly.
It went from this:
```
Project Subcommands:
  view                                            view the current projects structure
  add-target <name>  <target_type>  [sources...]  add a new target to the project
  fetch                                                                 fetch missing project libraries
  ```
  To this:
  ```
  Project Subcommands:
  view                                            view the current projects structure
  add-target <name>  <target_type>  [sources...]  add a new target to the project
  fetch                                           fetch missing project libraries
```