### PR TITLE
[feat] add test tmp files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ result
 
 # macOS
 .DS_Store
+
+# tests
+/test/tmp/*
+/test/testrun

--- a/test/unit/stdlib/io/file_read_write_any.c3
+++ b/test/unit/stdlib/io/file_read_write_any.c3
@@ -57,15 +57,15 @@ fn void read_write_any()
 	data.total = 0xA55A;
 	data.hello = 0xCC;
 
-	File file = file::open("__file_read_write_any_test_file", "wb")!!;
+    File file = file::open("tmp/__file_read_write_any_test_file", "wb")!!;
 
 	io::write_any(&file, &data)!!;
 	file.flush()!!;
 	file.close()!!;
 
-	file = file::open("__file_read_write_any_test_file", "rb")!!;
-	Data rdata;
-	io::read_any(&file, &rdata)!!;
+    file = file::open("tmp/__file_read_write_any_test_file", "rb")!!;
+    Data rdata;
+    io::read_any(&file, &rdata)!!;
 
 	file.close()!!;
 


### PR DESCRIPTION
Every test run generates two files, which are visible for git:
- first one is the test binary itself `test/testrun`
- second one is from read/write test
This pr adds them to .gitignore