### PR TITLE
Add --print-env option to c3c

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -10,6 +10,7 @@
 - Output into /.build/obj/<platform> by default.
 - Output llvm/asm into llvm/<platform> and asm/<platform> by default.
 - Add flag `--suppress-run`. For commands which may run executable after building, skip the run step. #1931
+- Add `--build-env` for build environment information.
 
 ### Fixes
 - Bug appearing when `??` was combined with boolean in some cases.

--- a/src/build/build.h
+++ b/src/build/build.h
@@ -589,6 +589,7 @@ typedef struct BuildOptions_
 	bool print_manifest_properties;
 	bool print_precedence;
 	bool print_linking;
+	bool print_env;
 	bool benchmarking;
 	bool testing;
 } BuildOptions;
@@ -832,3 +833,4 @@ void resolve_libraries(BuildTarget *build_target);
 void view_project(BuildOptions *build_options);
 void add_target_project(BuildOptions *build_options);
 void fetch_project(BuildOptions* options);
+void print_build_env(void);

--- a/src/build/build.h
+++ b/src/build/build.h
@@ -652,6 +652,7 @@ typedef struct
 	const char *ir_file_dir;
 	const char *asm_file_dir;
 	const char *script_dir;
+	bool is_non_project;
 	bool run_after_compile;
 	bool delete_after_run;
 	bool generate_benchmark_runner;
@@ -769,6 +770,7 @@ static const char *x86_cpu_set[8] = {
 };
 
 static BuildTarget default_build_target = {
+		.is_non_project = true,
 		.optlevel = OPTIMIZATION_NOT_SET,
 		.optsetting = OPT_SETTING_NOT_SET,
 		.memory_environment = MEMORY_ENV_NORMAL,

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -92,6 +92,7 @@ static void usage(bool full)
 	print_opt("-U <name>", "Remove feature flag <name>.");
 	PRINTF("");
 	print_opt("--about", "Prints a short description of C3.");
+	print_opt("--build-env", "Prints build environment information.");
 	print_opt("--libdir <dir>", "Add this directory to the c3l library search paths.");
 	print_opt("--lib <name>", "Add this c3l library to the compilation.");
 	if (full)
@@ -733,6 +734,11 @@ static void parse_option(BuildOptions *options)
 			{
 				options->silence_deprecation = true;
 				silence_deprecation = true;
+				return;
+			}
+			if (match_longopt("build-env"))
+			{
+				options->print_env = true;
 				return;
 			}
 			if (match_longopt("symtab"))

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -87,6 +87,12 @@ void compiler_init(BuildOptions *build_options)
 	{
 		compiler.context.lib_dir = find_lib_dir();
 	}
+
+	if (build_options->print_env)
+	{
+		print_build_env();
+		exit_compiler(COMPILER_SUCCESS_EXIT);
+	}
 }
 
 static void compiler_lex(void)
@@ -1593,4 +1599,71 @@ const char *default_c_compiler(void)
 #else
 	return cc = "cc";
 #endif
+}
+
+void print_build_env(void)
+{
+	printf("{\n");
+	printf("  \"c3c\": {\n");
+	printf("    \"version\": \"%s\",\n", COMPILER_VERSION);
+	printf("    \"stdlib\": \"%s\",\n", compiler.context.lib_dir);
+	printf("    \"c3c_exe\": \"%s\"\n", compiler_exe_name);
+	printf("  },\n");
+	printf("  \"project\": {\n");
+	printf("    \"path\": \"%s\",\n", getcwd(NULL, 0));
+	printf("    \"target\": \"%s\"\n", compiler.build.name);
+	printf("  },\n");
+	printf("  \"environment\": {\n");
+	printf("    \"system_path\": \"%s\",\n", getenv("PATH"));
+	printf("    \"os\": \"%s\",\n", os_type_to_string(compiler.platform.os));
+	printf("    \"variables\": {\n");
+	printf("      \"env::POSIX\": %s,\n", compiler.platform.os == OS_TYPE_LINUX ? "true" : "false");
+	printf("      \"env::win32\": %s,\n", compiler.platform.os == OS_TYPE_WIN32 ? "true" : "false");
+	printf("      \"LIBC\": %s\n", link_libc() ? "true" : "false");
+	printf("    }\n");
+	printf("  }\n");
+	printf("}\n");
+}
+
+const char *os_type_to_string(OsType os)
+{
+	switch (os)
+	{
+		case OS_TYPE_UNKNOWN: return "UNKNOWN";
+		case OS_TYPE_NONE: return "NONE";
+		case OS_TYPE_ANANAS: return "ANANAS";
+		case OS_TYPE_CLOUD_ABI: return "CLOUD_ABI";
+		case OS_TYPE_DRAGON_FLY: return "DRAGON_FLY";
+		case OS_TYPE_FUCHSIA: return "FUCHSIA";
+		case OS_TYPE_IOS: return "IOS";
+		case OS_TYPE_KFREEBSD: return "KFREEBSD";
+		case OS_TYPE_LINUX: return "LINUX";
+		case OS_TYPE_PS3: return "PS3";
+		case OS_TYPE_MACOSX: return "MACOSX";
+		case OS_TYPE_NETBSD: return "NETBSD";
+		case OS_TYPE_OPENBSD: return "OPENBSD";
+		case OS_TYPE_SOLARIS: return "SOLARIS";
+		case OS_TYPE_WIN32: return "WIN32";
+		case OS_TYPE_HAIKU: return "HAIKU";
+		case OS_TYPE_MINIX: return "MINIX";
+		case OS_TYPE_RTEMS: return "RTEMS";
+		case OS_TYPE_NACL: return "NACL";
+		case OS_TYPE_CNK: return "CNK";
+		case OS_TYPE_AIX: return "AIX";
+		case OS_TYPE_CUDA: return "CUDA";
+		case OS_TYPE_NVOPENCL: return "NVOPENCL";
+		case OS_TYPE_AMDHSA: return "AMDHSA";
+		case OS_TYPE_PS4: return "PS4";
+		case OS_TYPE_ELFIAMCU: return "ELFIAMCU";
+		case OS_TYPE_TVOS: return "TVOS";
+		case OS_TYPE_WATCHOS: return "WATCHOS";
+		case OS_TYPE_MESA3D: return "MESA3D";
+		case OS_TYPE_CONTIKI: return "CONTIKI";
+		case OS_TYPE_AMDPAL: return "AMDPAL";
+		case OS_TYPE_HERMITCORE: return "HERMITCORE";
+		case OS_TYPE_HURD: return "HURD";
+		case OS_TYPE_WASI: return "WASI";
+		case OS_TYPE_EMSCRIPTEN: return "EMSCRIPTEN";
+		default: return "UNKNOWN";
+	}
 }

--- a/src/compiler/compiler_internal.h
+++ b/src/compiler/compiler_internal.h
@@ -1839,6 +1839,7 @@ typedef struct
 
 typedef struct
 {
+	bool should_print_environment;
 	HTable modules;
 	Module *core_module;
 	CompilationUnit *core_unit;

--- a/src/compiler/compiler_internal.h
+++ b/src/compiler/compiler_internal.h
@@ -4118,3 +4118,6 @@ INLINE bool check_module_name(Path *path)
 void assert_print_line(SourceSpan span);
 
 const char *default_c_compiler(void);
+
+void print_build_env(void);
+const char *os_type_to_string(OsType os);

--- a/src/main.c
+++ b/src/main.c
@@ -58,13 +58,6 @@ int main_real(int argc, const char *argv[])
 	// Init the compiler
 	compiler_init(&build_options);
 
-	if (build_options.print_env)
-	{
-		print_build_env();
-		cleanup();
-		return EXIT_SUCCESS;
-	}
-
 	switch (build_options.command)
 	{
 		case COMMAND_PRINT_SYNTAX:

--- a/src/main.c
+++ b/src/main.c
@@ -58,6 +58,13 @@ int main_real(int argc, const char *argv[])
 	// Init the compiler
 	compiler_init(&build_options);
 
+	if (build_options.print_env)
+	{
+		print_build_env();
+		cleanup();
+		return EXIT_SUCCESS;
+	}
+
 	switch (build_options.command)
 	{
 		case COMMAND_PRINT_SYNTAX:


### PR DESCRIPTION
Add `--print-env` option to `c3c` to print build environment in JSON format as requested in #1832