### PR TITLE
[FIX] Let `c3c project` subcommands use same logic as others to get `project.json`

### DIFF
--- a/src/build/build_internal.h
+++ b/src/build/build_internal.h
@@ -125,6 +125,7 @@ static const char *sanitize_modes[4] = {
 	[SANITIZE_THREAD] = "thread",
 };
 
+JSONObject *project_JSON_load(const char **filename_ref);
 Project *project_load(const char **filename_ref);
 BuildTarget *project_select_target(const char *filename, Project *project, const char *optional_target);
 

--- a/src/build/build_internal.h
+++ b/src/build/build_internal.h
@@ -125,7 +125,7 @@ static const char *sanitize_modes[4] = {
 	[SANITIZE_THREAD] = "thread",
 };
 
-JSONObject *project_JSON_load(const char **filename_ref);
+JSONObject *project_json_load(const char **filename_ref);
 Project *project_load(const char **filename_ref);
 BuildTarget *project_select_target(const char *filename, Project *project, const char *optional_target);
 

--- a/src/build/builder.c
+++ b/src/build/builder.c
@@ -543,8 +543,6 @@ void init_default_build_target(BuildTarget *target, BuildOptions *options)
 void init_build_target(BuildTarget *target, BuildOptions *options)
 {
 	*target = (BuildTarget) { 0 };
-	// Locate the project.json
-	file_find_top_dir();
 	// Parse it
 	const char *filename;
 	Project *project = project_load(&filename);

--- a/src/build/project.c
+++ b/src/build/project.c
@@ -555,8 +555,12 @@ BuildTarget *project_select_target(const char *filename, Project *project, const
 	error_exit("No build target named '%s' was found in %s. Was it misspelled?", optional_target, filename);
 }
 
-JSONObject *project_JSON_load(const char *filename)
+JSONObject *project_JSON_load(const char **filename_ref)
 {
+	// Locate the project.json
+	file_find_top_dir();
+	const char *filename = *filename_ref = file_exists(PROJECT_JSON5) ? PROJECT_JSON5 : PROJECT_JSON;
+
 	size_t size;
 	char *read = file_read_all(filename, &size);
 
@@ -579,8 +583,7 @@ JSONObject *project_JSON_load(const char *filename)
 Project *project_load(const char **filename_ref)
 {
 	Project *project = CALLOCS(Project);
-	const char *filename = *filename_ref = file_exists(PROJECT_JSON5) ? PROJECT_JSON5 : PROJECT_JSON;
-	JSONObject *json = project_JSON_load(filename);
-	project_add_targets(filename, project, json);
+	JSONObject *json = project_JSON_load(filename_ref);
+	project_add_targets(*filename_ref, project, json);
 	return project;
 }

--- a/src/build/project.c
+++ b/src/build/project.c
@@ -176,7 +176,7 @@ static void load_into_build_target(const char *filename, JSONObject *json, const
 
 	// CFlags
 	target->cflags = get_cflags(filename, target_name, json, target->cflags);
-	
+
 	// C source dirs.
 	get_list_append_strings(filename, target_name, json, &target->csource_dirs, "c-sources", "c-sources-override", "c-sources-add");
 
@@ -555,15 +555,15 @@ BuildTarget *project_select_target(const char *filename, Project *project, const
 	error_exit("No build target named '%s' was found in %s. Was it misspelled?", optional_target, filename);
 }
 
-Project *project_load(const char **filename_ref)
+JSONObject *project_JSON_load(const char *filename)
 {
-	Project *project = CALLOCS(Project);
 	size_t size;
-	const char *filename = *filename_ref = file_exists(PROJECT_JSON5) ? PROJECT_JSON5 : PROJECT_JSON;
 	char *read = file_read_all(filename, &size);
+
 	JsonParser parser;
 	json_init_string(&parser, read);
 	JSONObject *json = json_parse(&parser);
+
 	if (parser.error_message)
 	{
 		error_exit("Error on line %d reading '%s':'%s'", parser.line, filename, parser.error_message);
@@ -572,6 +572,15 @@ Project *project_load(const char **filename_ref)
 	{
 		error_exit("Expected a map of targets in '%s'.", filename);
 	}
+
+	return json;
+}
+
+Project *project_load(const char **filename_ref)
+{
+	Project *project = CALLOCS(Project);
+	const char *filename = *filename_ref = file_exists(PROJECT_JSON5) ? PROJECT_JSON5 : PROJECT_JSON;
+	JSONObject *json = project_JSON_load(filename);
 	project_add_targets(filename, project, json);
 	return project;
 }

--- a/src/build/project.c
+++ b/src/build/project.c
@@ -555,7 +555,7 @@ BuildTarget *project_select_target(const char *filename, Project *project, const
 	error_exit("No build target named '%s' was found in %s. Was it misspelled?", optional_target, filename);
 }
 
-JSONObject *project_JSON_load(const char **filename_ref)
+JSONObject *project_json_load(const char **filename_ref)
 {
 	// Locate the project.json
 	file_find_top_dir();
@@ -583,7 +583,7 @@ JSONObject *project_JSON_load(const char **filename_ref)
 Project *project_load(const char **filename_ref)
 {
 	Project *project = CALLOCS(Project);
-	JSONObject *json = project_JSON_load(filename_ref);
+	JSONObject *json = project_json_load(filename_ref);
 	project_add_targets(*filename_ref, project, json);
 	return project;
 }

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -2,45 +2,14 @@
 #include "build_internal.h"
 #include "project.h"
 #include "utils/json.h"
+#include "utils/lib.h"
 #define PRINTFN(string, ...) fprintf(stdout, string "\n", ##__VA_ARGS__) // NOLINT
 #define PRINTF(string, ...) fprintf(stdout, string, ##__VA_ARGS__) // NOLINT
-
-static JSONObject *read_project(const char **file_used, bool assume_empty_if_not_exists)
-{
-	size_t size;
-	const char *project_filename = file_exists(PROJECT_JSON5) ? PROJECT_JSON5 : PROJECT_JSON;
-	*file_used = project_filename;
-	char *read;
-	if (assume_empty_if_not_exists)
-	{
-		// If project file does not exist assume the project simply being empty instead of
-		// failing. This is useful for such commands as `project add-target`. It enables
-		// them to update otherwise non-existing project files reducing the friction.
-		read = "{}";
-		if (file_exists(project_filename)) read = file_read_all(project_filename, &size);
-	}
-	else
-	{
-		read = file_read_all(project_filename, &size);
-	}
-	JsonParser parser;
-	json_init_string(&parser, read);
-	JSONObject *json = json_parse(&parser);
-	if (parser.error_message)
-	{
-		error_exit("Error on line %d reading '%s':'%s'", parser.line, project_filename, parser.error_message);
-	}
-	if (!json || json->type != J_OBJECT)
-	{
-		error_exit("Expected a map of project information in '%s'.", project_filename);
-	}
-	return json;
-}
 
 const char** get_project_dependency_directories()
 {
 	const char *filename;
-	JSONObject *json = read_project(&filename, false);
+	JSONObject *json = project_JSON_load(&filename);
 
 	const char *target = NULL;
 	const char **deps_dirs = NULL;
@@ -71,7 +40,7 @@ const char** get_project_dependencies()
 	const char *filename;
 	const char** dependencies = NULL;
 
-	JSONObject *project_json = read_project(&filename, false);
+	JSONObject *project_json = project_JSON_load(&filename);
 	JSONObject *dependencies_json = json_map_get(project_json, "dependencies");
 
 	FOREACH(JSONObject *, element, dependencies_json->elements)
@@ -312,7 +281,7 @@ void fetch_project(BuildOptions* options)
 	const char **libdirs = get_project_dependency_directories();
 	const char **deps = get_project_dependencies();
 	const char *filename;
-	JSONObject *project_json = read_project(&filename, false);
+	JSONObject *project_json = project_JSON_load(&filename);
 
 	JSONObject *targets_json = json_map_get(project_json, "targets");
 
@@ -381,7 +350,7 @@ void add_libraries_to_project_file(const char** libs, const char* target_name) {
 	//TODO! Target name option not implemented
 
 	const char *filename;
-	JSONObject *project_json = read_project(&filename, false);
+	JSONObject *project_json = project_JSON_load(&filename);
 
 	// TODO! check if target is specified and exists (NULL at the moment)
 	JSONObject *libraries_json = json_map_get(project_json, "dependencies");
@@ -418,7 +387,8 @@ void add_libraries_to_project_file(const char** libs, const char* target_name) {
 void add_target_project(BuildOptions *build_options)
 {
 	const char *filename;
-	JSONObject *project_json = read_project(&filename, true);
+	/* NOTE: this previously allowed project.json to not exist, and create it */
+	JSONObject *project_json = project_JSON_load(&filename);
 	JSONObject *targets_json = json_map_get(project_json, "targets");
 
 	if (targets_json == NULL)
@@ -542,7 +512,7 @@ static void view_filtered_project_properties(BuildOptions *build_options, const 
 void view_project(BuildOptions *build_options)
 {
 	const char *filename;
-	JSONObject *project_json = read_project(&filename, false);
+	JSONObject *project_json = project_JSON_load(&filename);
 
 	bool filter_properties = build_options->project_options.view_modifier.flags_bitvector != 0;
 

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -9,7 +9,7 @@
 const char** get_project_dependency_directories()
 {
 	const char *filename;
-	JSONObject *json = project_JSON_load(&filename);
+	JSONObject *json = project_json_load(&filename);
 
 	const char *target = NULL;
 	const char **deps_dirs = NULL;
@@ -40,7 +40,7 @@ const char** get_project_dependencies()
 	const char *filename;
 	const char** dependencies = NULL;
 
-	JSONObject *project_json = project_JSON_load(&filename);
+	JSONObject *project_json = project_json_load(&filename);
 	JSONObject *dependencies_json = json_map_get(project_json, "dependencies");
 
 	FOREACH(JSONObject *, element, dependencies_json->elements)
@@ -281,7 +281,7 @@ void fetch_project(BuildOptions* options)
 	const char **libdirs = get_project_dependency_directories();
 	const char **deps = get_project_dependencies();
 	const char *filename;
-	JSONObject *project_json = project_JSON_load(&filename);
+	JSONObject *project_json = project_json_load(&filename);
 
 	JSONObject *targets_json = json_map_get(project_json, "targets");
 
@@ -350,7 +350,7 @@ void add_libraries_to_project_file(const char** libs, const char* target_name) {
 	//TODO! Target name option not implemented
 
 	const char *filename;
-	JSONObject *project_json = project_JSON_load(&filename);
+	JSONObject *project_json = project_json_load(&filename);
 
 	// TODO! check if target is specified and exists (NULL at the moment)
 	JSONObject *libraries_json = json_map_get(project_json, "dependencies");
@@ -388,7 +388,7 @@ void add_target_project(BuildOptions *build_options)
 {
 	const char *filename;
 	/* NOTE: this previously allowed project.json to not exist, and create it */
-	JSONObject *project_json = project_JSON_load(&filename);
+	JSONObject *project_json = project_json_load(&filename);
 	JSONObject *targets_json = json_map_get(project_json, "targets");
 
 	if (targets_json == NULL)
@@ -512,7 +512,7 @@ static void view_filtered_project_properties(BuildOptions *build_options, const 
 void view_project(BuildOptions *build_options)
 {
 	const char *filename;
-	JSONObject *project_json = project_JSON_load(&filename);
+	JSONObject *project_json = project_json_load(&filename);
 
 	bool filter_properties = build_options->project_options.view_modifier.flags_bitvector != 0;
 


### PR DESCRIPTION
Implemented this as suggested in #1884 .

Closes #1884 .

