### PR TITLE
fix allocator::new_aligned #1898

### DIFF
--- a/lib/std/core/mem_allocator.c3
+++ b/lib/std/core/mem_allocator.c3
@@ -184,12 +184,12 @@ macro new_try(Allocator allocator, $Type, ...) @nodiscard
  @require $vacount < 2 : "Too many arguments."
  @require $vacount == 0 ||| $assignable($vaexpr[0], $Type) : "The second argument must be an initializer for the type"
 *>
-macro new_aligned($Type, ...) @nodiscard
+macro new_aligned(Allocator allocator, $Type, ...) @nodiscard
 {
 	$if $vacount == 0:
 		return ($Type*)calloc_aligned(allocator, $Type.sizeof, $Type.alignof);
 	$else
-		$Type* val = malloc_aligned(allocator, $Type.sizeof, $Type.alignof);
+		$Type* val = malloc_aligned(allocator, $Type.sizeof, $Type.alignof)!;
 		*val = $vaexpr[0];
 		return val;
 	$endif

--- a/test/unit/stdlib/core/mem_allocator.c3
+++ b/test/unit/stdlib/core/mem_allocator.c3
@@ -1,0 +1,25 @@
+module std::core::allocator_test;
+
+import std;
+
+struct Foo
+{
+	int x;
+	int y;
+}
+
+struct Bar
+{
+	int x;
+	int y;
+	List(<Foo>) foos;
+}
+
+fn void test_new_aligned_compiles() @test
+{
+	Bar* bar2 = allocator::new_aligned(allocator::heap(), Bar)!!;
+	allocator::free_aligned(allocator::heap(), bar2);
+
+	Bar* bar = allocator::new_aligned(allocator::heap(), Bar, {.x = 1, .y = 2, .foos = {}})!!;
+	allocator::free_aligned(allocator::heap(), bar);
+}


### PR DESCRIPTION
Add `Allocator` as first argument for `allocator::new_aligned` and rethrow the optional returned from `malloc_aligned`.