### PR TITLE
Fix missing r15 register in inline assembly

### DIFF
--- a/src/compiler/asm_target.c
+++ b/src/compiler/asm_target.c
@@ -721,10 +721,10 @@ static void init_asm_x86(PlatformTarget* target)
 	}
 	else
 	{
-		reg_register_list(target, x64_quad_regs, 15, ASM_REG_INT, ARG_BITS_64, X86_RAX);
-		reg_register_list(target, x86_long_regs, 15, ASM_REG_INT, ARG_BITS_32, X86_RAX);
-		reg_register_list(target, x86_word_regs, 15, ASM_REG_INT, ARG_BITS_16, X86_RAX);
-		reg_register_list(target, x86_low_byte_regs, 15, ASM_REG_INT, ARG_BITS_8, X86_RAX);
+		reg_register_list(target, x64_quad_regs, 16, ASM_REG_INT, ARG_BITS_64, X86_RAX);
+		reg_register_list(target, x86_long_regs, 16, ASM_REG_INT, ARG_BITS_32, X86_RAX);
+		reg_register_list(target, x86_word_regs, 16, ASM_REG_INT, ARG_BITS_16, X86_RAX);
+		reg_register_list(target, x86_low_byte_regs, 16, ASM_REG_INT, ARG_BITS_8, X86_RAX);
 		reg_register_list(target, x86_high_byte_regs, 4, ASM_REG_INT, ARG_BITS_8, X86_RAX);
 		reg_register_list(target, x86_xmm_regs, 16, ASM_REF_FVEC, ARG_BITS_128, X86_XMM0);
 		reg_register_list(target, x86_ymm_regs, 16, ASM_REF_FVEC, ARG_BITS_256, X86_XMM0);


### PR DESCRIPTION
Steps to reproduce:

```console
$ c3c --version
C3 Compiler Version:       0.6.7 (Pre-release, Jan 28 2025 20:50:05)
Installed directory:       /home/rexim/opt/c3/bin/
Git Hash:                  02c3d5419be88ad905445c33f8c9aa6d8d3236a5
Backends:                  LLVM
LLVM version:              18.1.8
LLVM default target:       x86_64-unknown-linux-gnu
$ cat ./main.c3
fn void test() @naked {
    asm {
        pushq $r15;
        ret;
    }
}

fn void main() {
    test();
}
$ c3c compile ./main.c3
1: fn void test() @naked {
2:     asm {
3:         pushq $r15;
                 ^^^^
(/home/rexim/Programming/probe/c3-inline-assembly-r15/main.c3:3:15) Error: Expected a valid register name.

$
```