### PR TITLE
Removed the unused command `headers`from the `usage()` in `src/build/build_options.c`

### DIFF
--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -67,7 +67,6 @@ static void usage(bool full)
 	PRINTF("  compile-test <file1> [<file2> ...]                  Compile files into an executable and run unit tests.");
 	PRINTF("  static-lib <file1> [<file2> ...]                    Compile files without a project into a static library.");
 	PRINTF("  dynamic-lib <file1> [<file2> ...]                   Compile files without a project into a dynamic library.");
-	PRINTF("  headers <file1> [<file2> ...]                       Analyse files and generate C headers for public methods.");
 	PRINTF("  vendor-fetch <library> ...                          Fetches one or more libraries from the vendor collection.");
 	PRINTF("  project <subcommand> ...                            Manipulate or view project files.");
 	PRINTF("");


### PR DESCRIPTION
There is also one internal command being undocumented, which is `utest`.

![image](https://github.com/user-attachments/assets/4a309808-6701-424b-877e-f655fa3f7a8e)

```c
if (arg_match("utest"))
{
	options->command = COMMAND_UNIT_TEST;
	return;
}
```

The name of the constant being used here implies that `utest` means "unit test", since it probably is a function that is used to debug and test some specific things, I think it's okay if it stays undocumented.