### PR TITLE
Clean up some linker/C compiler options

### DIFF
--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -388,7 +388,7 @@ static void linker_setup_linux(const char ***args_ref, Linker linker_type, bool 
 		if (is_pie(compiler.platform.reloc_model)) add_plain_arg("-pie");
 		if (is_no_pie(compiler.platform.reloc_model)) add_plain_arg("-no-pie");
 	}
-	if (compiler.platform.arch == ARCH_TYPE_X86_64) add_plain_arg("--eh-frame-hdr");
+	add_plain_arg("--eh-frame-hdr");
 	if (!link_libc()) return;
 	const char *crt_begin_dir = find_linux_crt_begin();
 	const char *crt_dir = find_linux_crt();
@@ -414,7 +414,6 @@ static void linker_setup_linux(const char ***args_ref, Linker linker_type, bool 
 	}
 	add_concat_file_arg(crt_dir, "crtn.o");
 	add_concat_quote_arg("-L", crt_dir);
-	add_plain_arg("-L/usr/lib/x86_64-linux-gnu/libdl.so");
 	add_plain_arg("--dynamic-linker=/lib64/ld-linux-x86-64.so.2");
 	linking_add_link(&compiler.linking, "m");
 	linking_add_link(&compiler.linking, "pthread");
@@ -434,7 +433,7 @@ static void linker_setup_freebsd(const char ***args_ref, Linker linker_type, boo
 	}
 	if (is_no_pie(compiler.platform.reloc_model)) add_plain_arg("-no-pie");
 	if (is_pie(compiler.platform.reloc_model)) add_plain_arg("-pie");
-	if (compiler.platform.arch == ARCH_TYPE_X86_64) add_plain_arg("--eh-frame-hdr");
+	add_plain_arg("--eh-frame-hdr");
 
 	if (!link_libc()) return;
 
@@ -648,9 +647,6 @@ static void append_fpie_pic_options(RelocModel reloc, const char ***args_ref)
 			UNREACHABLE
 		case RELOC_NONE:
 			add_plain_arg("-fno-pic");
-			add_plain_arg("-fno-pie");
-			add_plain_arg("-fno-PIC");
-			add_plain_arg("-fno-PIE");
 			break;
 		case RELOC_SMALL_PIC:
 			add_plain_arg("-fpic");
@@ -660,11 +656,9 @@ static void append_fpie_pic_options(RelocModel reloc, const char ***args_ref)
 			break;
 		case RELOC_SMALL_PIE:
 			add_plain_arg("-fpie");
-			add_plain_arg("-fpic");
 			break;
 		case RELOC_BIG_PIE:
 			add_plain_arg("-fPIE");
-			add_plain_arg("-fPIC");
 			break;
 	}
 }
@@ -864,7 +858,6 @@ void platform_linker(const char *output_file, const char **files, unsigned file_
 	{
 		INFO_LOG("Using cc linker.");
 		vec_add(parts, compiler.build.cc ? compiler.build.cc : default_c_compiler());
-		append_fpie_pic_options(compiler.platform.reloc_model, &parts);
 	}
 
 	linker_setup(&parts, files, file_count, output_file, linker_type, &compiler.linking);


### PR DESCRIPTION
-fno-pic/-fno-pie/-fpic/-fPIC/-fpie/-fPIE options belong to the same famility where the last option wins. These options have no effect in the link phase.

Clang and GCC usually pass `--eh-frame-hdr` to ld, with the exception that `gcc -static` does not pass `--eh-frame-hdr`. The difference is a historical choice related to `__register_frame_info`. We can behavle like Clang and always pass `--eh-frame-hdr`.

Remove a `-L` that does not specify a directory.