### PR TITLE
`clock_gettime` should return `CInt`, not `void`

### DIFF
--- a/lib/std/time/os/time_posix.c3
+++ b/lib/std/time/os/time_posix.c3
@@ -1,7 +1,7 @@
 module std::time::os @if(env::POSIX);
 import libc;
 
-extern fn void clock_gettime(int type, TimeSpec *time);
+extern fn CInt clock_gettime(int type, TimeSpec *time);
 
 fn Time native_timestamp()
 {


### PR DESCRIPTION
According to the documentation https://www.man7.org/linux/man-pages/man3/clock_gettime.3.html function
`clock_gettime` returns `CInt`. Here is the signature from the documentation:

```c
int clock_gettime(clockid_t clockid, struct timespec *tp);
```
