### PR TITLE
test::eq/ne/gt syntax

### DIFF
--- a/lib/std/core/test.c3
+++ b/lib/std/core/test.c3
@@ -27,7 +27,7 @@ fn void! test_div() @test
 	test::gt(2, divide(3, 3)!);
 	test::lt(2, 3);
 	test::le(2, 3);
-	test::@almost(m::divide(1, 3)!, 0.333, places: 3);
+	test::eq_approx(m::divide(1, 3)!, 0.333, places: 3);
 	test::@check(2 == 2, "divide: %d", divide(6, 3)!);
 	test::@error(m::divide(3, 0), MathError.DIVISION_BY_ZERO);
 }
@@ -127,7 +127,7 @@ macro eq(left, right)
  @require delta >= 0, delta <= 1 "delta must be a small number"
  @require runtime::test_context != null "Only allowed in @test functions"
 *>
-macro void @almost(double left, double right, uint places = 7, double delta = 0, bool equal_nan = true)
+macro void eq_approx(double left, double right, uint places = 7, double delta = 0, bool equal_nan = true)
 {
 	double diff = left - right;
 	double eps = delta;

--- a/lib/std/core/test.c3
+++ b/lib/std/core/test.c3
@@ -21,13 +21,13 @@ fn double! divide(int a, int b)
 
 fn void! test_div() @test
 {
-	test::is_equal(2, divide(6, 3)!);
-	test::is_not_equal(1, 2);
-	test::is_almost_equal(m::divide(1, 3)!, 0.333, places: 3);
-	test::is_greater_equal(3, 3);
-	test::is_greater(2, divide(3, 3)!);
-	test::is_less(2, 3);
-	test::is_less_equal(2, 3);
+	test::eq(2, divide(6, 3)!);
+	test::ne(1, 2);
+	test::ge(3, 3);
+	test::gt(2, divide(3, 3)!);
+	test::lt(2, 3);
+	test::le(2, 3);
+	test::@almost(m::divide(1, 3)!, 0.333, places: 3);
 	test::@check(2 == 2, "divide: %d", divide(6, 3)!);
 	test::@error(m::divide(3, 0), MathError.DIVISION_BY_ZERO);
 }
@@ -50,7 +50,7 @@ import std::math, std::io, libc;
  @require runtime::test_context != null "Only allowed in @test functions"
  @require setup_fn != null "setup_fn must always be set"
 *>
-macro setup(TestFn setup_fn, TestFn teardown_fn = null)
+macro @setup(TestFn setup_fn, TestFn teardown_fn = null)
 {
 	runtime::test_context.setup_fn = setup_fn;
 	runtime::test_context.teardown_fn = teardown_fn;
@@ -108,7 +108,7 @@ macro @error(#funcresult, anyfault error_expected)
  @param right `right argument of any comparable type`
  @require runtime::test_context != null "Only allowed in @test functions"
 *>
-macro is_equal(left, right)
+macro eq(left, right)
 {
 	if (!equals(left, right))
 	{
@@ -127,7 +127,7 @@ macro is_equal(left, right)
  @require delta >= 0, delta <= 1 "delta must be a small number"
  @require runtime::test_context != null "Only allowed in @test functions"
 *>
-fn void is_almost_equal(double left, double right, uint places = 7, double delta = 0, bool equal_nan = true)
+macro void @almost(double left, double right, uint places = 7, double delta = 0, bool equal_nan = true)
 {
 	double diff = left - right;
 	double eps = delta;
@@ -147,7 +147,7 @@ fn void is_almost_equal(double left, double right, uint places = 7, double delta
  @param right `right argument of any comparable type`
  @require runtime::test_context != null "Only allowed in @test functions"
 *>
-macro void is_not_equal(left, right)
+macro void ne(left, right)
 {
 	if (equals(left, right))
 	{
@@ -162,7 +162,7 @@ macro void is_not_equal(left, right)
  @param right `right argument of any comparable type`
  @require runtime::test_context != null "Only allowed in @test functions"
 *>
-macro is_greater(left, right)
+macro gt(left, right)
 {
 	if (!builtin::greater(left, right))
 	{
@@ -177,7 +177,7 @@ macro is_greater(left, right)
  @param right `right argument of any comparable type`
  @require runtime::test_context != null "Only allowed in @test functions"
 *>
-macro is_greater_equal(left, right)
+macro ge(left, right)
 {
 	if (!builtin::greater_eq(left, right))
 	{
@@ -192,7 +192,7 @@ macro is_greater_equal(left, right)
  @param right `right argument of any comparable type`
  @require runtime::test_context != null "Only allowed in @test functions"
 *>
-macro is_less(left, right)
+macro lt(left, right)
 {
 	if (!builtin::less(left, right))
 	{
@@ -207,7 +207,7 @@ macro is_less(left, right)
  @param right `right argument of any comparable type`
  @require runtime::test_context != null "Only allowed in @test functions"
 *>
-macro is_less_equal(left, right)
+macro le(left, right)
 {
 	if (!builtin::less_eq(left, right))
 	{

--- a/test/unit/regression/ct_slice.c3
+++ b/test/unit/regression/ct_slice.c3
@@ -12,7 +12,7 @@ fn void slice_bytes()
 fn void slice_string()
 {
 	String $a = "abcd";
-	test::is_equal($a, "abcd");
+	test::eq($a, "abcd");
 	var $c = $a[1:0];
 	String c = $c;
 	assert($c == "");

--- a/test/unit/stdlib/core/test_test.c3
+++ b/test/unit/stdlib/core/test_test.c3
@@ -71,73 +71,73 @@ TestState state =
 
 fn void test_eq()
 {
-	test::is_equal(1, 1);
-	test::is_equal(true, true);
-	test::is_equal(1.31, 1.31);
-	test::is_equal("foo", "foo");
+	test::eq(1, 1);
+	test::eq(true, true);
+	test::eq(1.31, 1.31);
+	test::eq("foo", "foo");
 }
 
 fn void test_almost_equal()
 {
-	test::is_almost_equal(1, 1);
-	test::is_almost_equal(1.31, 1.31);
-	test::is_almost_equal(1.31f, 1.31f);
-	test::is_almost_equal(double.nan, double.nan);
-	test::is_almost_equal(float.nan, float.nan);
-	test::is_almost_equal(1.31, 1.31, delta: 0.01);
-	test::is_almost_equal(1.311, 1.312, delta: 0.01);
-	test::is_almost_equal(1.311, 1.312, places: 2);
+	test::@almost(1, 1);
+	test::@almost(1.31, 1.31);
+	test::@almost(1.31f, 1.31f);
+	test::@almost(double.nan, double.nan);
+	test::@almost(float.nan, float.nan);
+	test::@almost(1.31, 1.31, delta: 0.01);
+	test::@almost(1.311, 1.312, delta: 0.01);
+	test::@almost(1.311, 1.312, places: 2);
 	// 7 decimal places are default
-	test::is_almost_equal(1.00000001, 1.00000000);
+	test::@almost(1.00000001, 1.00000000);
 }
 
 
 fn void test_almost_equal_fails()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
 	// 7 decimal places are default
-	test::is_almost_equal(1.0000001, 1.00000000);
+	test::@almost(1.0000001, 1.00000000);
 }
 
 fn void test_almost_equal_fails_nan()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_almost_equal(1.0000001, double.nan);
+	test::@almost(1.0000001, double.nan);
 }
 
 fn void test_almost_equal_fails_nan2()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_almost_equal(double.nan, 1);
+	test::@almost(double.nan, 1);
 }
 
 fn void test_almost_equal_fails_equal_nan_false()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_almost_equal(double.nan, double.nan, equal_nan: false);
+	test::@almost(double.nan, double.nan, equal_nan: false);
 }
 
 fn void setup_teardown()
 {
 	state.n_runs = 0; // just in case of previous test failed
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 
-	test::is_equal(state.n_runs, 1);
-	test::is_equal(state.n_fails, 0);
-	test::is_equal(state.expected_fail, false);
+	test::eq(state.n_runs, 1);
+	test::eq(state.n_fails, 0);
+	test::eq(state.expected_fail, false);
 }
 
 fn void setup_no_teardown()
 {
-	test::setup(state.setup_fn);
+	test::@setup(state.setup_fn);
 
-	test::is_equal(state.n_runs, 1);
-	test::is_equal(state.n_fails, 0);
-	test::is_equal(state.expected_fail, false);
+	test::eq(state.n_runs, 1);
+	test::eq(state.n_fails, 0);
+	test::eq(state.expected_fail, false);
 
 	// WARNING: reverting back original panic func
 	builtin::panic = state.old_panic;
@@ -145,103 +145,103 @@ fn void setup_no_teardown()
 
 fn void expected_fail()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_equal(state.n_fails, 0);
-	test::is_equal(2, 1); // this fails, and we test it
-	test::is_equal(state.n_fails, 1);
+	test::eq(state.n_fails, 0);
+	test::eq(2, 1); // this fails, and we test it
+	test::eq(state.n_fails, 1);
 }
 
 fn void test_neq()
 {
-	test::is_not_equal(2, 1);
-	test::is_not_equal(false, true);
-	test::is_not_equal(1.32, 1.31);
-	test::is_not_equal("foo", "bar");
+	test::ne(2, 1);
+	test::ne(false, true);
+	test::ne(1.32, 1.31);
+	test::ne("foo", "bar");
 }
 
 fn void test_neq_fails()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_not_equal(1, 1);
+	test::ne(1, 1);
 }
 
 fn void test_gt()
 {
-	test::is_greater(2, 1);
-	test::is_greater(true, false);
-	test::is_greater(1.32, 1.31);
+	test::gt(2, 1);
+	test::gt(true, false);
+	test::gt(1.32, 1.31);
 }
 
 fn void test_gt_fails_when_equal()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_greater(2, 2);
+	test::gt(2, 2);
 }
 
 fn void test_gt_fails_when_less()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_greater(1, 2);
+	test::gt(1, 2);
 }
 
 
 fn void test_gte()
 {
-	test::is_greater_equal(2, 1);
-	test::is_greater_equal(true, false);
-	test::is_greater_equal(1.32, 1.31);
-	test::is_greater_equal(2, 2);
-	test::is_greater_equal(true, true);
-	test::is_greater_equal(1.32, 1.32);
+	test::ge(2, 1);
+	test::ge(true, false);
+	test::ge(1.32, 1.31);
+	test::ge(2, 2);
+	test::ge(true, true);
+	test::ge(1.32, 1.32);
 }
 
 fn void test_gte_fails_when_less()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_greater_equal(1, 2);
+	test::ge(1, 2);
 }
 
 fn void test_lt()
 {
-	test::is_less(1, 2);
-	test::is_less(false, true);
-	test::is_less(1.31, 1.32);
+	test::lt(1, 2);
+	test::lt(false, true);
+	test::lt(1.31, 1.32);
 }
 
 fn void test_lt_fails_when_equal()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_less(2, 2);
+	test::lt(2, 2);
 }
 
 fn void test_lt_fails_when_greater()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_less(2, 1);
+	test::lt(2, 1);
 }
 
 fn void test_lte()
 {
-	test::is_less_equal(1, 2);
-	test::is_less_equal(false, true);
-	test::is_less_equal(1.31, 1.32);
-	test::is_less_equal(2, 2);
-	test::is_less_equal(true, true);
-	test::is_less_equal(1.32, 1.32);
+	test::le(1, 2);
+	test::le(false, true);
+	test::le(1.31, 1.32);
+	test::le(2, 2);
+	test::le(true, true);
+	test::le(1.32, 1.32);
 }
 
 fn void test_lte_fails_when_greater()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::is_less_equal(2, 1);
+	test::le(2, 1);
 }
 
 fn void test_check(){
@@ -253,14 +253,14 @@ fn void test_check(){
 
 fn void test_check_fails()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
 	test::@check(2 == 1, "2 == %d", 1 );
 }
 
 fn void test_check_fails_no_info()
 {
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
 	test::@check(2 == 1);
 }
@@ -284,7 +284,7 @@ fn void test_error()
 		if (b == 0) return IoError.FILE_NOT_FOUND?;
 		return a / b;
 	};
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 
 	test::@error(ffail_void(true), IoError.FILE_NOT_FOUND);
 	test::@error(ffail_int(1, 0), IoError.FILE_NOT_FOUND);
@@ -296,7 +296,7 @@ fn void test_error_not_raised()
 		if (b == 0) return IoError.FILE_NOT_FOUND?;
 		return a / b;
 	};
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
 	test::@error(ffail_int(1, 1), IoError.FILE_NOT_FOUND);
 }
@@ -307,7 +307,7 @@ fn void test_error_wrong_error_expected()
 		if (b == 0) return IoError.BUSY?;
 		return a / b;
 	};
-	test::setup(state.setup_fn, state.teardown_fn);
+	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
 
 	test::@error(ffail_int(1, 0), IoError.FILE_NOT_FOUND);
@@ -323,5 +323,5 @@ fn void test_std_out_hijack()
 	io::fprint(io::stderr(), "fprint: stderr aldsjalsdjlasjdlja\n")!!;
 	io::fprintf(io::stderr(), "fprintf: stderr aldsjalsdjlasjdlja\n")!!;
 	io::fprintf(io::stderr(), "fprintfn: stderr aldsjalsdjlasjdlja\n")!!;
-	test::is_equal(true, true);
+	test::eq(true, true);
 }

--- a/test/unit/stdlib/core/test_test.c3
+++ b/test/unit/stdlib/core/test_test.c3
@@ -79,16 +79,16 @@ fn void test_eq()
 
 fn void test_almost_equal()
 {
-	test::@almost(1, 1);
-	test::@almost(1.31, 1.31);
-	test::@almost(1.31f, 1.31f);
-	test::@almost(double.nan, double.nan);
-	test::@almost(float.nan, float.nan);
-	test::@almost(1.31, 1.31, delta: 0.01);
-	test::@almost(1.311, 1.312, delta: 0.01);
-	test::@almost(1.311, 1.312, places: 2);
+	test::eq_approx(1, 1);
+	test::eq_approx(1.31, 1.31);
+	test::eq_approx(1.31f, 1.31f);
+	test::eq_approx(double.nan, double.nan);
+	test::eq_approx(float.nan, float.nan);
+	test::eq_approx(1.31, 1.31, delta: 0.01);
+	test::eq_approx(1.311, 1.312, delta: 0.01);
+	test::eq_approx(1.311, 1.312, places: 2);
 	// 7 decimal places are default
-	test::@almost(1.00000001, 1.00000000);
+	test::eq_approx(1.00000001, 1.00000000);
 }
 
 
@@ -97,28 +97,28 @@ fn void test_almost_equal_fails()
 	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
 	// 7 decimal places are default
-	test::@almost(1.0000001, 1.00000000);
+	test::eq_approx(1.0000001, 1.00000000);
 }
 
 fn void test_almost_equal_fails_nan()
 {
 	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::@almost(1.0000001, double.nan);
+	test::eq_approx(1.0000001, double.nan);
 }
 
 fn void test_almost_equal_fails_nan2()
 {
 	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::@almost(double.nan, 1);
+	test::eq_approx(double.nan, 1);
 }
 
 fn void test_almost_equal_fails_equal_nan_false()
 {
 	test::@setup(state.setup_fn, state.teardown_fn);
 	state.expected_fail = true;
-	test::@almost(double.nan, double.nan, equal_nan: false);
+	test::eq_approx(double.nan, double.nan, equal_nan: false);
 }
 
 fn void setup_teardown()


### PR DESCRIPTION
Terse tests syntax proposal #1918 

The test module is refactored in the following logic:
1.  2-letters `eq/ne/gt/le` are for regular use (90% of the test code), they are macros but without `@`.
2. Special cases have `@` prefix, and also reduced to 1 word (it's better to remember). Also, `@` will be a reminder that we might have special behavior (less mental overhead for reader).
- `test::setup` now `test::@setup`
- `test::is_almost_equal` now `test::@almost`
3. Let's keep `test::` module instead of introducing new `assert_eq/ne/gt` keyword, because in the future I think it's possible to add more testing features (mocks maybe?). And `test::` is visually more readable due to `::` separation and different highlighting.