### PR TITLE
Introduce Socket.shutdown()

### DIFF
--- a/lib/std/libc/os/posix.c3
+++ b/lib/std/libc/os/posix.c3
@@ -1,5 +1,10 @@
 module libc @if(env::POSIX);
 
+const CInt SHUT_RD = 0;
+const CInt SHUT_WR = 1;
+const CInt SHUT_RDWR = 2;
+extern fn CInt shutdown(Fd sockfd, CInt how);
+
 extern fn isz recv(Fd socket, void *buffer, usz length, CInt flags);
 extern fn isz send(Fd socket, void *buffer, usz length, CInt flags);
 

--- a/lib/std/libc/os/win32.c3
+++ b/lib/std/libc/os/win32.c3
@@ -24,6 +24,11 @@ extern fn CInt _wremove(WString);
 extern fn int recv(Win32_SOCKET s, void* buf, int len, int flags);
 extern fn int send(Win32_SOCKET s, void* buf, int len, int flags);
 
+const CInt SD_RECEIVE = 0;
+const CInt SD_SEND = 1;
+const CInt SD_BOTH = 2;
+extern fn CInt shutdown(Win32_SOCKET s, CInt how);
+
 struct SystemInfo
 {
 	union {

--- a/lib/std/net/socket.c3
+++ b/lib/std/net/socket.c3
@@ -155,3 +155,36 @@ fn void! Socket.close(&self) @inline @dynamic
 {
 	self.sock.close()!;
 }
+
+enum SocketShutdownHow
+{
+	RECEIVE,
+	SEND,
+	BOTH,
+}
+
+fn CInt SocketShutdownHow.os_value(self)
+{
+	$switch
+		$case env::WIN32:
+			switch (self) {
+				case RECEIVE: return libc::SD_RECEIVE;
+				case SEND:    return libc::SD_SEND;
+				case BOTH:    return libc::SD_BOTH;
+			}
+		$case env::POSIX:
+			switch (self) {
+				case RECEIVE: return libc::SHUT_RD;
+				case SEND:    return libc::SHUT_WR;
+				case BOTH:    return libc::SHUT_RDWR;
+			}
+		$default: $error("Unsupported environment");
+	$endswitch
+}
+
+fn void! Socket.shutdown(&self, SocketShutdownHow how)
+{
+	if (libc::shutdown(self.sock, how.os_value()) < 0) {
+		return os::socket_error()?;
+	}
+}


### PR DESCRIPTION
One of the common operations used in TCP programming is shutting down parts of the full-duplex connection [[1]](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown) [[2]](https://www.man7.org/linux/man-pages/man2/shutdown.2.html). In c3ws [[3]](https://github.com/tsoding/c3ws) we are employing the technique described in [[4]](https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable) on closing the connection to ensure more reliable delivery of data which relies on the shutdown operation. But since c3ws is supposed to work with different variety of sockets  (blocking, non-blocking, encrypted, etc, etc) via an abstract interface to separate concerns, it would be nice if the shutdown operation was part of the cross-platform Socket interface.

This PR tries to introduce such operation for POSIX and WIN32 environment. I haven't tested it on WIN32 though, but it should be almost the same as on POSIX. 

References:
[1] [shutdown function (winsock.h)](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown)
[2] [shutdown(2) — Linux manual page](https://www.man7.org/linux/man-pages/man2/shutdown.2.html)
[3] [c3ws - WebSocket library in C3 ](https://github.com/tsoding/c3ws)
[4] [The ultimate SO_LINGER page, or: why is my tcp not reliable](https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable)