### PR TITLE
add --no-run option

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -23,6 +23,7 @@
 - Test runner will also check for leaks.
 - Improve inference on `??` #1943.
 - Detect unaligned loads #1951.
+- Add flag `--no-run`. For commands which may run executable after building, skip the run step. #1931
 
 ### Fixes
 - Fix issue requiring prefix on a generic interface declaration.

--- a/src/build/build.h
+++ b/src/build/build.h
@@ -552,6 +552,7 @@ typedef struct BuildOptions_
 	bool print_output;
 	bool print_input;
 	bool run_once;
+	bool no_run;
 	int verbosity_level;
 	const char *panicfn;
 	const char *benchfn;

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -103,6 +103,7 @@ static void usage(bool full)
 		print_opt("--template <template>", "Select template for 'init': \"exe\", \"static-lib\", \"dynamic-lib\" or a path.");
 		print_opt("--symtab <value>", "Sets the preferred symtab size.");
 		print_opt("--run-once", "After running the output file, delete it immediately.");
+		print_opt("--no-run", "For commands which may run executable after building, skip the run step");
 		print_opt("--trust=<option>", "Trust level: none (default), include ($include allowed), full ($exec / exec allowed).");
 		print_opt("--output-dir <dir>", "Override general output directory.");
 		print_opt("--build-dir <dir>", "Override build output directory.");
@@ -1226,6 +1227,11 @@ static void parse_option(BuildOptions *options)
 			if (match_longopt("testing"))
 			{
 				options->testing = true;
+				return;
+			}
+			if (match_longopt("no-run"))
+			{
+				options->no_run = true;
 				return;
 			}
 			if (match_longopt("help"))

--- a/src/build/builder.c
+++ b/src/build/builder.c
@@ -321,6 +321,11 @@ static void update_build_target_from_options(BuildTarget *target, BuildOptions *
 			break;
 	}
 
+	if (options->no_run)
+	{
+		target->run_after_compile = false;
+	}
+
 	switch (options->command)
 	{
 		case COMMAND_BUILD:


### PR DESCRIPTION
`--no-run` option.

For commands which may run executable after building (`compile-test`, `compile-bench`, `compile-run`, and `clean-run`, skip the "run" step.

See https://github.com/c3lang/c3c/issues/1930