### PR TITLE
std::math::bigint: Fixed init_with_u128 and init_with_array

### DIFF
--- a/lib/std/math/bigint.c3
+++ b/lib/std/math/bigint.c3
@@ -63,6 +63,13 @@ fn BigInt* BigInt.init_with_u128(&self, uint128 value)
 fn BigInt* BigInt.init_with_array(&self, uint[] values)
 {
 	self.data[..] = 0;
+
+	if (values.len == 0)
+	{
+		self.len = 1;
+		return self;
+	}
+
 	self.len = values.len;
 
 	foreach_r(i, val : values)

--- a/test/unit/stdlib/math/bigint.c3
+++ b/test/unit/stdlib/math/bigint.c3
@@ -9,9 +9,8 @@ fn void test_init_with_u128()
 fn void init_with_array()
 {
 	BigInt bi @noinit;
-
+	assert(bi.init_with_array({}).equals(ZERO));
 	assert(bi.init_with_array({0, 0, 0, 1}).equals(bigint::from_int(1)));
-
 	assert("100000000" == bi.init_with_array({1, 0}).to_string_with_radix(16, allocator::temp()));
 }
 


### PR DESCRIPTION
 * `init_with_u128` creates negative number for values >= 2^127
 * `init_with_array` writes values to the input slice