### PR TITLE
Fix libc::stat on FreeBSD (x86_64)

### DIFF
--- a/lib/std/libc/os/freebsd.c3
+++ b/lib/std/libc/os/freebsd.c3
@@ -1,15 +1,14 @@
 module libc @if(env::FREEBSD);
 
-// Checked for x86_64, this is notoriously incorrect when comparing with Rust code etc
+// Checked for x86_64
 
-def Blksize_t = $typefrom(env::X86_64 ? long.typeid : CInt.typeid);
+def Blksize_t = int;
 def Nlink_t = $typefrom(env::X86_64 ? ulong.typeid : CUInt.typeid);
-def Blkcnt_t = long;
-def Ino_t = ulong;
 def Dev_t = ulong;
-def Mode_t = uint;
-def Ino64_t = ulong;
-def Blkcnt64_t = long;
+def Ino_t = ulong;
+def Mode_t = ushort;
+def Blkcnt_t = long;
+def Fflags_t = uint;
 
 struct Stat @if(env::X86_64)
 {
@@ -17,22 +16,24 @@ struct Stat @if(env::X86_64)
 	Ino_t st_ino;
 	Nlink_t st_nlink;
 	Mode_t st_mode;
+	short __pad0;
 	Uid_t st_uid;
 	Gid_t st_gid;
-	CInt __pad0;
+	int __pad1;
 	Dev_t st_rdev;
+	TimeSpec st_atime;
+	TimeSpec st_mtime;
+	TimeSpec st_ctime;
+	TimeSpec st_birthtime;
 	Off_t st_size;
-	Blksize_t st_blksize;
 	Blkcnt_t st_blocks;
-	Time_t st_atime;
-	long st_atime_nsec;
-	Time_t st_mtime;
-	long st_mtime_nsec;
-	Time_t st_ctime;
-	long st_ctime_nsec;
-	long[3] __unused;
+	Blksize_t st_blksize;
+	Fflags_t st_flags;
+	ulong st_gen;
+	ulong[10] st_spare;
 }
 
+// TODO: Investigate if this needs to be fixed
 struct Stat @if(!env::X86_64)
 {
 	Dev_t st_dev;


### PR DESCRIPTION
Fixes libc::stat segfault on FreeBSD for x86_64

I've tested on a 32bit system where it still segfaults so probably disable support until
fixed.

I ran in to this when trying to use file::exists which uses stat, even with stat fixed, perhaps file::exists should be using access instead (which works fine)?

Please let me know if anything should be changed.