### PR TITLE
String.to_float("+") fails

### DIFF
--- a/lib/std/core/string_to_real.c3
+++ b/lib/std/core/string_to_real.c3
@@ -464,13 +464,16 @@ macro String.to_real(chars, $Type) @private
 
 	while (chars.len && chars[0] == ' ') chars = chars[1..];
 	if (!chars.len) return NumberConversion.MALFORMED_FLOAT?;
-	switch (chars[0])
-	{
-		case '-':
-			sign = -1;
-			nextcase;
-		case '+':
-			chars = chars[1..];
+
+	if (chars.len != 1) {
+		switch (chars[0])
+		{
+			case '-':
+				sign = -1;
+				nextcase;
+			case '+':
+				chars = chars[1..];
+		}
 	}
 	if (chars == "infinity" || chars == "INFINITY") return sign * $Type.inf;
 	if (chars == "NAN" || chars == "nan") return $Type.nan;

--- a/test/unit/stdlib/string_to_float.c3
+++ b/test/unit/stdlib/string_to_float.c3
@@ -12,6 +12,16 @@ fn void test_float() @test
 	assert(String.to_float("-23.545")!! == -23.545f);
 	assert(String.to_float("1.5555555555555")!! == 1.5555555555555f);
 	assert(String.to_float("1.5555555555556666")!! == 1.5555555555556666f);
+	if (catch excuse = String.to_float("+")) {
+		assert(excuse == NumberConversion.MALFORMED_FLOAT);
+	} else {
+		assert(false);
+	}
+	if (catch excuse = String.to_float("-")) {
+		assert(excuse == NumberConversion.MALFORMED_FLOAT);
+	} else {
+		assert(false);
+	}
 }
 
 fn void test_double() @test
@@ -26,4 +36,14 @@ fn void test_double() @test
 	assert(String.to_double("-23.545")!! == -23.545);
 	assert(String.to_double("1.5555555555555")!! == 1.5555555555555);
 	assert(String.to_double("1.5555555555556666")!! == 1.5555555555556666);
+	if (catch excuse = String.to_double("+")) {
+		assert(excuse == NumberConversion.MALFORMED_FLOAT);
+	} else {
+		assert(false);
+	}
+	if (catch excuse = String.to_double("-")) {
+		assert(excuse == NumberConversion.MALFORMED_FLOAT);
+	} else {
+		assert(false);
+	}
 }


### PR DESCRIPTION
Doing `String.to_float("+")` panics.

This is due to the string_to_real macro preemptively chopping a "+" or "-" from the start of the string.  Once this is done, the string is effectively empty, and so the `@require chars.len > 0` contract at the top of the `decfloat` macro is violated.

I wrapped the code that chops the +/- from the start of the string in a check for the length of the string, and this chop will only be done if the string is not 1 character long.

This fixes the bug.