### PR TITLE
Readded System (wrapper for run_subprocess)

### DIFF
--- a/src/compiler/subprocess.c
+++ b/src/compiler/subprocess.c
@@ -154,3 +154,8 @@ int run_subprocess(const char *name, const char **args)
 	return cpid;
 #endif
 }
+
+// For C users, so that they can stay with "system"
+int system(const char *name, const char **args) {
+    return run_subprocess(name, args);
+}

--- a/src/compiler/subprocess.c
+++ b/src/compiler/subprocess.c
@@ -156,6 +156,7 @@ int run_subprocess(const char *name, const char **args)
 }
 
 // For C users, so that they can stay with "system"
-int system(const char *name, const char **args) {
+int system(const char *name, const char **args)
+{
     return run_subprocess(name, args);
 }

--- a/src/compiler/subprocess.h
+++ b/src/compiler/subprocess.h
@@ -1,3 +1,4 @@
 #pragma once
 
 int run_subprocess(const char *name, const char **args);
+int system(const char *name, const char **args);


### PR DESCRIPTION
C users may want "system" rather than run_subprocess, so I readded it.
It is basically a wrapper for it.