### PR TITLE
improve error message for uninitialized temp allocator pool on new threads

### DIFF
--- a/lib/std/core/mem_allocator.c3
+++ b/lib/std/core/mem_allocator.c3
@@ -433,7 +433,7 @@ fn Allocator create_temp_allocator_on_demand() @private
 	if (!auto_create_temp)
 	{
 	    auto_create_temp = true;
-	    abort("Only the main thread pool is implicitly created. Use '@pool_init()' to enable the temp allocator on other threads.");
+	    abort("Use '@pool_init()' to enable the temp allocator on a new thread. A pool is implicitly created only on the main thread.");
 	}
 	return create_temp_allocator(base_allocator(), temp_allocator_size());
 }


### PR DESCRIPTION
- put the most relevant part of the error and action first (you'll hit this error if you're making a new thread).
- disambiguate `main thread pool`.

Message could still be a bit clearer (where to call `@pool_init()`?) but I don't want it to get too long.