### PR TITLE
Type mismatch fix

### DIFF
--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -1458,8 +1458,8 @@ void append_file(BuildOptions *build_options)
 static inline const char *match_argopt(const char *name)
 {
 	size_t len = strlen(name);
-	if (!str_start_with(&current_arg[2], name)) return false;
-	if (current_arg[2 + len] != '=') return false;
+	if (!str_start_with(&current_arg[2], name)) return nullptr;
+	if (current_arg[2 + len] != '=') return nullptr;
 	return &current_arg[2 + len + 1];
 }
 


### PR DESCRIPTION
Fixed type mismatch in static function 'match_argopt' in file 'src/build/build_options.c',
where false was returned from the function which has a return type of 'const char *'.
I will note that clangd seems to be running c23 despite the compilation_commands.json I used,
allowing me to catch this (bug?) easily.