### PR TITLE
Added I18n library to std

### DIFF
--- a/lib/std/text/i18n.c3
+++ b/lib/std/text/i18n.c3
@@ -5,10 +5,12 @@ import std::os;
 import std::core::mem::allocator;
 import std::collections::map;
 import std::collections::object;
+import std::collections::list;
 import std::encoding::json;
 import std::time;
 
 alias LanguageMap = HashMap{String, Object*};
+alias LoadedFilesList = List{Object*};
 alias TranslationMap = HashMap{String, LanguageMap};
 
 // This fault raised when translation key not found.
@@ -18,6 +20,7 @@ struct Translator (Printable) {
 	Allocator allocator;
 	TranslationMap tmap;
 	String currentLanguage;
+	LoadedFilesList loadedFiles;
 }
 
 fn Translator new_translator(Allocator allocator, String currentLanguage = "en") {
@@ -25,11 +28,25 @@ fn Translator new_translator(Allocator allocator, String currentLanguage = "en")
 	t.allocator = allocator;
 	t.tmap.init(allocator);
 	t.currentLanguage = currentLanguage;
+	t.loadedFiles.init(allocator);
 	return t;
+}
+
+fn void Translator.free(&self) {
+	foreach (Object* object : self.loadedFiles)
+	{
+		object.free();
+	}
+
+	self.tmap.free();
+	self.loadedFiles.free();
+	self.currentLanguage.free(self.allocator); 
 }
 
 fn void? Translator.load_from_json(&self, String file_path, String code) {
 	String file_content = (String) file::load(self.allocator, file_path)!;
+	defer file_content.free(self.allocator);
+
 	Object* object = json::parse_string(self.allocator, file_content)!;
 
 	if (self.tmap.has_key(code)) {
@@ -37,6 +54,7 @@ fn void? Translator.load_from_json(&self, String file_path, String code) {
 	}
 
 	self.tmap.set(code, object.map);
+	self.loadedFiles.push(object);
 }
 
 fn void? Translator.set_language(&self, String code) {
@@ -50,6 +68,7 @@ fn void? Translator.set_language(&self, String code) {
 macro Translator.tr(&self, key, ...) {
 	if (try LanguageMap lmap = self.tmap.get(self.currentLanguage)) {
 		Object* value = lmap.get(key)!;
+		defer value.free();
 
 		if (!value.is_string()) {
 			return io::UNSUPPORTED_OPERATION?;

--- a/lib/std/text/i18n.c3
+++ b/lib/std/text/i18n.c3
@@ -1,0 +1,72 @@
+module std::text::i18n;
+import std::io;
+import std::io::file;
+import std::os;
+import std::core::mem::allocator;
+import std::collections::map;
+import std::collections::object;
+import std::encoding::json;
+import std::time;
+
+alias LanguageMap = HashMap{String, Object*};
+alias TranslationMap = HashMap{String, LanguageMap};
+
+// This fault raised when translation key not found.
+faultdef NOT_FOUND;
+
+struct Translator (Printable) {
+	Allocator allocator;
+	TranslationMap tmap;
+	String currentLanguage;
+}
+
+fn Translator new_translator(Allocator allocator, String currentLanguage = "en") {
+	Translator t;
+	t.allocator = allocator;
+	t.tmap.init(allocator);
+	t.currentLanguage = currentLanguage;
+	return t;
+}
+
+fn void? Translator.load_from_json(&self, String file_path, String code) {
+	String file_content = (String) file::load(self.allocator, file_path)!;
+	Object* object = json::parse_string(self.allocator, file_content)!;
+
+	if (self.tmap.has_key(code)) {
+		return io::ALREADY_EXISTS?;
+	}
+
+	self.tmap.set(code, object.map);
+}
+
+fn void? Translator.set_language(&self, String code) {
+	if (!self.tmap.has_key(code)) {
+		return io::FILE_NOT_FOUND?;
+	}
+	
+	self.currentLanguage = code;
+}
+
+macro Translator.tr(&self, key, ...) {
+	if (try LanguageMap lmap = self.tmap.get(self.currentLanguage)) {
+		Object* value = lmap.get(key)!;
+
+		if (!value.is_string()) {
+			return io::UNSUPPORTED_OPERATION?;
+		}
+																
+		return string::format(self.allocator, value.s, $vasplat[..]);
+	}
+
+	return NOT_FOUND?;
+}
+
+// TODO 
+// Implement Translator.load to load all .json files from directory as LanguageMap.
+// This requires iterating over the directory and loading each file.
+
+// TODO 
+// Implement pluralization support.
+
+// TODO 
+// Implement load from yaml.

--- a/lib/std/text/i18n.c3
+++ b/lib/std/text/i18n.c3
@@ -40,7 +40,6 @@ fn void Translator.free(&self) {
 
 	self.tmap.free();
 	self.loadedFiles.free();
-	self.currentLanguage.free(self.allocator); 
 }
 
 fn void? Translator.load_from_json(&self, String file_path, String code) {
@@ -67,14 +66,13 @@ fn void? Translator.set_language(&self, String code) {
 
 macro Translator.tr(&self, key, ...) {
 	if (try LanguageMap lmap = self.tmap.get(self.currentLanguage)) {
-		Object* value = lmap.get(key)!;
-		defer value.free();
+		Object* object = lmap.get(key)!;
 
-		if (!value.is_string()) {
+		if (!object.is_string()) {
 			return io::UNSUPPORTED_OPERATION?;
 		}
-																
-		return string::format(self.allocator, value.s, $vasplat[..]);
+
+		return string::format(self.allocator, object.s, $vasplat[..]);
 	}
 
 	return NOT_FOUND?;

--- a/test/unit/stdlib/text/i18n/i18n.c3
+++ b/test/unit/stdlib/text/i18n/i18n.c3
@@ -4,17 +4,14 @@ fn void translate_from_json() @test {
     Allocator allocator = allocator::heap();
 	Translator translator = new_translator(allocator);
 
-	if (catch excuse = translator.load_from_json("./i18n_en.json", "en")) {
-		io::printfn("Error loading JSON: %s\n", excuse);
-	}
+	translator.load_from_json("./i18n_en.json", "en")!!;
 
 	translator.set_language("en")!!;
-
-	io::printfn("Current Language: %s", translator.currentLanguage);
+	assert(translator.currentLanguage, "en");
 
 	String greeting = translator.tr("greeting", "C3")!!;
-	io::printfn("- Greeting: %s", greeting);
+	assert(greeting, "Hello, C3!");
 
 	String farewell = translator.tr("farewell", "C3")!!;
-	io::printfn("- Farewell: %s", farewell);
+	assert(farewell, "Goodbye, C3!");
 }

--- a/test/unit/stdlib/text/i18n/i18n.c3
+++ b/test/unit/stdlib/text/i18n/i18n.c3
@@ -1,15 +1,17 @@
 import std::text::i18n;
 import std::io::path;
 
+const I18N_EN = "/unit/stdlib/text/i18n/i18n_en.json";
+
 fn void translate_from_json() @test {
     Allocator allocator = allocator::heap();
 	Translator translator = i18n::new_translator(allocator);
 	defer translator.free();
 
-	String cwd = path::cwd(allocator)!!.dirname();
+	String cwd = path::cwd(allocator)!!.path_string;
 	defer cwd.free(allocator);
 
-	String file_path = string::format(allocator, "%s%s", cwd, "/test/unit/stdlib/text/i18n/i18n_en.json");
+	String file_path = string::format(allocator, "%s%s", cwd, I18N_EN);
 	defer file_path.free(allocator);
 	
 	translator.load_from_json(file_path, "en")!!;

--- a/test/unit/stdlib/text/i18n/i18n.c3
+++ b/test/unit/stdlib/text/i18n/i18n.c3
@@ -6,12 +6,12 @@ fn void translate_from_json() @test {
 
 	translator.load_from_json("./i18n_en.json", "en")!!;
 
-	translator.set_language("en")!!;
-	assert(translator.currentLanguage, "en");
+	// translator.set_language("en")!!;
+	// assert(translator.currentLanguage, "en");
 
-	String greeting = translator.tr("greeting", "C3")!!;
-	assert(greeting, "Hello, C3!");
+	// String greeting = translator.tr("greeting", "C3")!!;
+	// assert(greeting, "Hello, C3!");
 
-	String farewell = translator.tr("farewell", "C3")!!;
-	assert(farewell, "Goodbye, C3!");
+	// String farewell = translator.tr("farewell", "C3")!!;
+	// assert(farewell, "Goodbye, C3!");
 }

--- a/test/unit/stdlib/text/i18n/i18n.c3
+++ b/test/unit/stdlib/text/i18n/i18n.c3
@@ -2,7 +2,7 @@ import std::text::i18n;
 
 fn void translate_from_json() @test {
     Allocator allocator = allocator::heap();
-	Translator translator = new_translator(allocator);
+	Translator translator = i18n::new_translator(allocator);
 
 	translator.load_from_json("./i18n_en.json", "en")!!;
 

--- a/test/unit/stdlib/text/i18n/i18n.c3
+++ b/test/unit/stdlib/text/i18n/i18n.c3
@@ -1,0 +1,20 @@
+import std::text::i18n;
+
+fn void translate_from_json() @test {
+    Allocator allocator = allocator::heap();
+	Translator translator = new_translator(allocator);
+
+	if (catch excuse = translator.load_from_json("./i18n_en.json", "en")) {
+		io::printfn("Error loading JSON: %s\n", excuse);
+	}
+
+	translator.set_language("en")!!;
+
+	io::printfn("Current Language: %s", translator.currentLanguage);
+
+	String greeting = translator.tr("greeting", "C3")!!;
+	io::printfn("- Greeting: %s", greeting);
+
+	String farewell = translator.tr("farewell", "C3")!!;
+	io::printfn("- Farewell: %s", farewell);
+}

--- a/test/unit/stdlib/text/i18n/i18n.c3
+++ b/test/unit/stdlib/text/i18n/i18n.c3
@@ -1,8 +1,6 @@
 import std::text::i18n;
 import std::io::path;
 
-import std::io;
-
 fn void translate_from_json() @test {
     Allocator allocator = allocator::heap();
 	Translator translator = i18n::new_translator(allocator);

--- a/test/unit/stdlib/text/i18n/i18n.c3
+++ b/test/unit/stdlib/text/i18n/i18n.c3
@@ -1,17 +1,29 @@
 import std::text::i18n;
+import std::io::path;
+
+import std::io;
 
 fn void translate_from_json() @test {
     Allocator allocator = allocator::heap();
 	Translator translator = i18n::new_translator(allocator);
+	defer translator.free();
 
-	translator.load_from_json("./i18n_en.json", "en")!!;
+	String cwd = path::cwd(allocator)!!.dirname();
+	defer cwd.free(allocator);
 
-	// translator.set_language("en")!!;
-	// assert(translator.currentLanguage, "en");
+	String file_path = string::format(allocator, "%s%s", cwd, "/test/unit/stdlib/text/i18n/i18n_en.json");
+	defer file_path.free(allocator);
+	
+	translator.load_from_json(file_path, "en")!!;
 
-	// String greeting = translator.tr("greeting", "C3")!!;
-	// assert(greeting, "Hello, C3!");
+	translator.set_language("en")!!;
+	assert(translator.currentLanguage, "en");
 
-	// String farewell = translator.tr("farewell", "C3")!!;
-	// assert(farewell, "Goodbye, C3!");
+	String greeting = translator.tr("greeting", "C3")!!;
+	defer greeting.free(allocator); 
+	assert(greeting, "Hello, C3!");
+
+	String farewell = translator.tr("farewell", "C3")!!;
+	defer farewell.free(allocator); 
+	assert(farewell, "Goodbye, C3!");
 }

--- a/test/unit/stdlib/text/i18n/i18n_en.json
+++ b/test/unit/stdlib/text/i18n/i18n_en.json
@@ -1,0 +1,4 @@
+{
+    "greeting": "Hello, %s!",
+    "farewell": "Goodbye, %s!"
+}


### PR DESCRIPTION
Here is an uncompleted implementation of `i18n` that loads json files with language code and translates it. Format string works fine.

I know that it's not complete, But I opened PR to be sure my code is fine until this point.

I also consider to add following features:

- [x] Load from JSON
- [x] Formatting
- [ ] Load from `YAML`
- [ ] Pluralization Support
- [ ] Load `TranslationMap` from single file

Would you share more ideas with me if possible?

