### PR TITLE
Fix missing __errno_location() to __errno() on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # C3 Language
 
+### Disclaimer
+This is the port for Android aarch64
+
 C3 is a programming language that builds on the syntax and semantics of the C language,
 with the goal of evolving it while still retaining familiarity for C programmers. 
 

--- a/lib/std/libc/os/errno.c3
+++ b/lib/std/libc/os/errno.c3
@@ -1,9 +1,10 @@
 module libc::os @if(env::LIBC);
 
-// Linux
-extern fn int* __errno_location() @if(env::LINUX);
-macro int errno() @if(env::LINUX) => *__errno_location();
-macro void errno_set(int err) @if(env::LINUX) => *(__errno_location()) = err;
+// Is there any env::ANDROID?
+// Linux (Android) 
+extern fn int* __errno() @if(env::LINUX);
+macro int errno() @if(env::LINUX) => *__errno();
+macro void errno_set(int err) @if(env::LINUX) => *(__errno()) = err;
 
 // Darwin
 extern fn int* __error() @if(env::DARWIN);


### PR DESCRIPTION
Hello

I know this fix would break for env::LINUX, but is there any macro-ish for android? Like env::ANDROID or how do i add those macro?