### PR TITLE
Add external __errno() function for env::ANDROID

### DIFF
--- a/lib/std/libc/os/errno.c3
+++ b/lib/std/libc/os/errno.c3
@@ -5,6 +5,11 @@ extern fn int* __errno_location() @if(env::LINUX);
 macro int errno() @if(env::LINUX) => *__errno_location();
 macro void errno_set(int err) @if(env::LINUX) => *(__errno_location()) = err;
 
+// Android 9
+extern fn int* __errno() @if(env::ANDROID);
+macro int errno() @if(env::ANDROID) => *__errno();
+macro void errno_set(int err) @if(env::ANDROID) => *(__errno()) = err;
+
 // Darwin
 extern fn int* __error() @if(env::DARWIN);
 macro int errno() @if(env::DARWIN) => *__error();


### PR DESCRIPTION
Using __errno() for Android 9 rather than __errno_location(), as defined in errno.h

```c
int* _Nonnull __errno(void) __attribute_const__;

#define errno (*__errno())
```