### PR TITLE
fix `types::may_load_atomic` with enums

### DIFF
--- a/lib/std/core/types.c3
+++ b/lib/std/core/types.c3
@@ -272,6 +272,7 @@ macro bool may_load_atomic($Type) @const
 	$case FLOAT:
 		return true;
 	$case DISTINCT:
+	$case ENUM:
 		return may_load_atomic($Type.inner);
 	$default:
 		return false;


### PR DESCRIPTION
it could probably just return true directly, but this works as well