### PR TITLE
Add an optional 'Prefix' parameter to $echo

### DIFF
--- a/src/compiler/compiler_internal.h
+++ b/src/compiler/compiler_internal.h
@@ -1417,11 +1417,18 @@ typedef struct
 
 typedef struct
 {
-	bool is_ensure;
-	ExprId message;
-	ExprId expr;
-	Expr **args;
+    bool is_ensure;
+    ExprId message;
+    ExprId expr;
+    Expr **args;
 } AstAssertStmt;
+
+typedef struct
+{
+    bool has_prefix;
+    Expr *prefix;
+    Expr *message;
+} AstEchoStmt;
 
 
 typedef struct
@@ -1479,6 +1486,7 @@ typedef struct Ast_
 		AstAsmStmt asm_stmt;
 		const char *asm_label;
 		AstAssertStmt assert_stmt;          // 16
+        AstEchoStmt echo_stmt;
 		AstCaseStmt case_stmt;              // 32
 		AstCompoundStmt compound_stmt;      // 12
 		AstId ct_compound_stmt;

--- a/src/compiler/copying.c
+++ b/src/compiler/copying.c
@@ -730,6 +730,15 @@ RETRY:
 			fixup_astid(c, &ast->defer_stmt.prev_defer);
 			break;
 		case AST_CT_ECHO_STMT:
+            copy_reg_ref(c, source, ast);
+            SCOPE_FIXUP_START
+                MACRO_COPY_EXPR(ast->echo_stmt.message);
+                if (ast->echo_stmt.has_prefix)
+                {
+                    MACRO_COPY_EXPR(ast->echo_stmt.prefix);
+                }
+            SCOPE_FIXUP_END;
+            break;
 		case AST_EXPR_STMT:
 			MACRO_COPY_EXPR(ast->expr_stmt);
 			break;

--- a/src/compiler/parse_stmt.c
+++ b/src/compiler/parse_stmt.c
@@ -1258,7 +1258,13 @@ Ast *parse_ct_echo_stmt(ParseContext *c)
 {
 	Ast *ast = ast_new_curr(c, AST_CT_ECHO_STMT);
 	advance_and_verify(c, TOKEN_CT_ECHO);
-	ASSIGN_EXPR_OR_RET(ast->expr_stmt, parse_constant_expr(c), poisoned_ast);
+    ASSIGN_EXPR_OR_RET(ast->echo_stmt.message, parse_constant_expr(c), poisoned_ast);
+    ast->echo_stmt.has_prefix = false;
+    if (try_consume(c, TOKEN_COMMA))
+    {
+	    ASSIGN_EXPR_OR_RET(ast->echo_stmt.prefix, parse_constant_expr(c), poisoned_ast);
+        ast->echo_stmt.has_prefix = true;
+    }
 	return consume_eos(c, ast);
 }
 

--- a/src/compiler/sema_stmts.c
+++ b/src/compiler/sema_stmts.c
@@ -2936,14 +2936,31 @@ bool sema_analyse_ct_assert_stmt(SemaContext *context, Ast *statement)
 
 bool sema_analyse_ct_echo_stmt(SemaContext *context, Ast *statement)
 {
-	Expr *message = statement->expr_stmt;
+    Expr *message = statement->echo_stmt.message;
+    Expr *prefix = statement->echo_stmt.prefix;
+    bool has_prefix = statement->echo_stmt.has_prefix;
 	if (!sema_analyse_expr(context, message)) return false;
+    if (has_prefix && !sema_analyse_expr(context, prefix)) return false;
 	if (message->expr_kind != EXPR_CONST)
 	{
-		SEMA_ERROR(message, "Expected a constant value.");
+		SEMA_ERROR(message, "Expected a constant 'message' value.");
 		return false;
 	}
-	printf("] ");
+    else if (has_prefix && prefix->expr_kind != EXPR_CONST)
+    {
+        SEMA_ERROR(prefix, "Expected a constant 'prefix' value.");
+        return false;
+    }
+    if (has_prefix)
+    {
+        scratch_buffer_clear();
+        expr_const_to_scratch_buffer(&prefix->const_expr);
+        printf("%s", scratch_buffer_to_string());   // do not use 'puts' here
+    }
+    else
+    {
+        printf("] ");
+    }
 	scratch_buffer_clear();
 	expr_const_to_scratch_buffer(&message->const_expr);
 	puts(scratch_buffer_to_string());

--- a/src/compiler/sema_stmts.c
+++ b/src/compiler/sema_stmts.c
@@ -2938,21 +2938,20 @@ bool sema_analyse_ct_echo_stmt(SemaContext *context, Ast *statement)
 {
     Expr *message = statement->echo_stmt.message;
     Expr *prefix = statement->echo_stmt.prefix;
-    bool has_prefix = statement->echo_stmt.has_prefix;
 	if (!sema_analyse_expr(context, message)) return false;
-    if (has_prefix && !sema_analyse_expr(context, prefix)) return false;
 	if (message->expr_kind != EXPR_CONST)
 	{
 		SEMA_ERROR(message, "Expected a constant 'message' value.");
 		return false;
 	}
-    else if (has_prefix && prefix->expr_kind != EXPR_CONST)
+    if (statement->echo_stmt.has_prefix)
     {
-        SEMA_ERROR(prefix, "Expected a constant 'prefix' value.");
-        return false;
-    }
-    if (has_prefix)
-    {
+        if (!sema_analyse_expr(context, prefix)) return false;
+        if (prefix->expr_kind != EXPR_CONST)
+        {
+            SEMA_ERROR(prefix, "Expected a constant 'prefix' value.");
+            return false;
+        }
         scratch_buffer_clear();
         expr_const_to_scratch_buffer(&prefix->const_expr);
         printf("%s", scratch_buffer_to_string());   // do not use 'puts' here


### PR DESCRIPTION
Addresses Issue #1873 and attempts to resolve the `$echo` "better prefix" discussion by letting developers choose their own.

Code written against older versions of C3 which do not support prefixes will not be affected/broken because the prefix is the second (optional) param, i.e. $echo becomes `$echo MESSAGE[, PREFIX] ;`. Thus, messages without a `PREFIX` will still output the typical `] ` prefix.

The only notable constraint at the time of submission is that surrounding the two constant expressions with parentheses (_see below_) will not compile properly.

```c
module main;

import std::io;


macro beacon($msg)
{
    $echo $msg, @sprintf("[%s:%s]>  ", $$FILE, $$LINE);
}


fn void main()
{
    $echo "Old-school, backwards-compatible";
    $echo("simple, still works");

    $echo "example,test", "PFX>>> ";
    // DOES NOT WORK:  $echo("parens", "<<< WITH >>>  ");

    beacon("It's this location!");

    io::printn("Hello, World!");
}
```

```
$ ./build/c3c compile-run /tmp/tmp.YHrcPSCpdl/hw.c3
] Old-school, backwards-compatible
] simple, still works
PFX>>> example,test
[hw.c3:18]>  It's this location!
Program linked to executable 'hw'.
Launching ./hw
Hello, World!
Program completed with exit code 0.
```