### PR TITLE
Fix error maybe-uninitialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,7 @@ The c3c binary should be created in the build directory. You can try it out by r
 ```bash
 cmake -B build \
     -D C3_LINK_DYNAMIC=ON \
-    -D CMAKE_BUILD_TYPE=Release \
-    -D CMAKE_C_FLAGS_RELEASE="-Wno-error=maybe-uninitialized"
+    -D CMAKE_BUILD_TYPE=Release
 ```
 5. Build the project: `make -C build`.
 

--- a/src/compiler/llvm_codegen_expr.c
+++ b/src/compiler/llvm_codegen_expr.c
@@ -2051,7 +2051,7 @@ static inline LLVMValueRef llvm_emit_inc_dec_value(GenContext *c, SourceSpan spa
 			Type *element = type_lowering(type->array.base);
 			LLVMValueRef diff_value;
 			bool is_integer = type_kind_is_any_integer(element->type_kind);
-			bool is_ptr;
+			bool is_ptr = false;
 			if (is_integer)
 			{
 				diff_value = LLVMConstInt(llvm_get_type(c, element), 1, false);


### PR DESCRIPTION
On Arch Linux, the current Clang version is 20.1.6, which triggers a warning treated as an error in `src/compiler/llvm_codegen_expr.c`. Specifically, the variable `is_ptr` may be read before it is initialized when the `is_integer` branch is taken.

To address this, the initialization logic for `is_ptr` has been adjusted to ensure it's always set before use, even in branches where it's not explicitly assigned beforehand.

This change makes the code compatible with Clang 20.1.6, avoiding future compilation failures on other systems.