### PR TITLE
Add 'strdup' reference to libc

### DIFF
--- a/lib/std/libc/libc.c3
+++ b/lib/std/libc/libc.c3
@@ -168,6 +168,7 @@ extern fn CInt strcmp(ZString str1, ZString str2);
 extern fn CInt strcoll(ZString str1, ZString str2);
 extern fn usz strcspn(ZString str1, ZString str2);
 extern fn ZString strcpy(ZString dst, ZString src);
+extern fn ZString strdup(ZString s);
 extern fn ZString strerror(CInt errn);
 extern fn usz strftime(char* dest, usz maxsize, ZString format, Tm* timeptr);
 extern fn usz strlen(ZString str);

--- a/test/unit/stdlib/libc/libc.c3
+++ b/test/unit/stdlib/libc/libc.c3
@@ -375,6 +375,7 @@ fn void malloc_free() @test
 // fn void strcoll() @test {}
 // fn void strcspn() @test {}
 // fn void strcpy() @test {}
+// fn void strdup() @test {}
 // fn void strerror() @test {}
 // fn void strftime() @test {}
 // fn void strlen() @test {}


### PR DESCRIPTION
Noticed that the quick-and-easy `strdup` function was missing from `libc::` imports while working on a library. Adding it.