### PR TITLE
Fix Incorrect SHA256 Hashes for Large Inputs

### DIFF
--- a/lib/std/hash/sha256.c3
+++ b/lib/std/hash/sha256.c3
@@ -174,3 +174,4 @@ fn void sha256_transform(uint* state, char* buffer) @local {
     a = b = c = d = e = f = g = h = t1 = t2 = i = 0;
     m[:64] = buffer[:64] = 0;
 }
+

--- a/lib/std/hash/sha256.c3
+++ b/lib/std/hash/sha256.c3
@@ -71,7 +71,7 @@ fn void Sha256.update(&self, char[] data) {
     uint i = 0;
     uint len = data.len;
     uint buffer_pos = (uint)(self.bitcount / 8) % BLOCK_SIZE;
-    self.bitcount += (ulong)(len * 8);
+    self.bitcount += ((ulong)len * 8);
 
     while (len--) {
         self.buffer[buffer_pos++] = data[i++];

--- a/test/unit/stdlib/hash/sha256.c3
+++ b/test/unit/stdlib/hash/sha256.c3
@@ -84,3 +84,4 @@ fn void test_sha256_million_a()
    
     assert(sha.final() == x"CDC76E5C 9914FB92 81A1C7E2 84D73E67 F1809A48 A497200E 046D39CC C7112CD0");
 }
+

--- a/test/unit/stdlib/hash/sha256.c3
+++ b/test/unit/stdlib/hash/sha256.c3
@@ -27,6 +27,18 @@ fn void test_sha256_longer()
     assert(sha.final() == x"59F109D9 533B2B70 E7C3B814 A2BD218F 78EA5D37 14455BC6 7987CF0D 664399CF");
 }
 
+fn void gigahash_sha256()
+{
+    // > 256 MiB is just at the threshold where the SHA bitcounter rolls overflows 'len', but doesn't hit the uint.max limit...
+    char[] c = calloc(257 * (1024*1024))[:(257*1024*1024)];
+    defer free(c);
+
+    Sha256 sha;
+    sha.init();
+    sha.update(c);
+    assert(sha.final() == x"053EADFD EC682CF1 6F3F8704 C7609C57 868DD757 65E08DC5 A7491F5D 06BCB74D");
+}
+
 fn void test_pbkdf2()
 {
     char[] pw = "password";

--- a/test/unit/stdlib/hash/sha512.c3
+++ b/test/unit/stdlib/hash/sha512.c3
@@ -25,6 +25,18 @@ fn void test_sha512_longer()
     assert(sha.final() == x"7361ec4a617b6473fb751c44d1026db9442915a5fcea1a419e615d2f3bc5069494da28b8cf2e4412a1dc97d6848f9c84a254fb884ad0720a83eaa0434aeafd8c");
 }
 
+fn void gigahash_sha512()
+{
+    // This test is here because of an overflow that was present in SHA256.
+    char[] c = calloc(257 * (1024*1024))[:(257*1024*1024)];
+    defer free(c);
+
+    Sha512 sha;
+    sha.init();
+    sha.update(c);
+    assert(sha.final() == x"724999ca733fdd49f489fc59a49ce41460531a78aa0c03488be9f4a1e29f955bd325d47462c89234a8f587d8a5d6a9ab79137bc5ce3acbfb928553dba8431a36");
+}
+
 fn void test_pbkdf2()
 {
     char[] pw = "password";

--- a/test/unit/stdlib/hash/sha512.c3
+++ b/test/unit/stdlib/hash/sha512.c3
@@ -79,3 +79,4 @@ fn void test_sha512_million_a()
     }
     assert(sha.final() == x"e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b");
 }
+


### PR DESCRIPTION
A subtle `uint` overflow between 256 MiB and the `uint.max` limit was causing invalid and irregular values to appear in the `bitcounter` member, producing completely invalid hashes.

I only noticed this thanks to happenstance with a SHA256-HMAC test file just over 280 MiB. :smirk: 

Sanity check method:
```
> dd if=/dev/zero count=257 bs=1M 2>/dev/null | sha256sum \
    | cut -d' ' -f1 | sed -r 's/(.{8})/\1 /g' | tr '[:lower:]' '[:upper:]'
053EADFD EC682CF1 6F3F8704 C7609C57 868DD757 65E08DC5 A7491F5D 06BCB74D
```

Before fix:
```
> ./bin/c3c compile-test test/unit/stdlib/hash/sha256.c3
Program linked to executable 'testrun'.
Launching ./testrun
--------------------------- TESTS ---------------------------
Testing std::hash::sha256_test::gigahash_sha256 ........ 
Testing std::hash::sha256_test::gigahash_sha256 [FAIL]

ERROR: 'Assert "sha.final() == x"053EADFD EC682CF1 6F3F8704 C7609C57 868DD757 65E08DC5 A7491F5D 06BCB74D"" failed.'
  in std.os.backtrace.capture_current (/home/zpuhl/source/c3c-me/lib/std/os/backtrace.c3:78) [/home/zpuhl/source/c3c-me/testrun]
  in std.core.builtin.print_backtrace (/home/zpuhl/source/c3c-me/lib/std/core/builtin.c3:110) [/home/zpuhl/source/c3c-me/testrun]
  in std.core.runtime.test_panic.3743 (/home/zpuhl/source/c3c-me/lib/std/core/runtime_test.c3:99) [/home/zpuhl/source/c3c-me/testrun]
  in std.hash.sha256_test.gigahash_sha256 (/home/zpuhl/source/c3c-me/test/unit/stdlib/hash/sha256.c3:39) [/home/zpuhl/source/c3c-me/testrun]
  in std.core.runtime.run_tests (/home/zpuhl/source/c3c-me/lib/std/core/runtime_test.c3:281) [/home/zpuhl/source/c3c-me/testrun]
  in std.core.runtime.default_test_runner (/home/zpuhl/source/c3c-me/lib/std/core/runtime_test.c3:332) [/home/zpuhl/source/c3c-me/testrun]
  in @_main_runner (/home/zpuhl/source/c3c-me/lib/std/core/private/main_stub.c3:54) [/home/zpuhl/source/c3c-me/testrun] [inline]
  in main (/home/zpuhl/source/c3c-me/lib/std/core/runtime_test.c3:329) [/home/zpuhl/source/c3c-me/testrun]
  in __libc_start_call_main (source unavailable) [/lib64/libc.so.6]
  in __libc_start_main_alias_2 (source unavailable) [/lib64/libc.so.6]
  in _start (source unavailable) [/home/zpuhl/source/c3c-me/testrun]

Test failed ^^^ ( sha256.c3:39 ) Assert "sha.final() == x"053EADFD EC682CF1 6F3F8704 C7609C57 868DD757 65E08DC5 A7491F5D 06BCB74D"" failed.
Testing std::hash::sha256_test::test_pbkdf2 ............ [PASS]
Testing std::hash::sha256_test::test_pbkdf2_2 .......... [PASS]
Testing std::hash::sha256_test::test_pbkdf2_3 .......... [PASS]
Testing std::hash::sha256_test::test_sha256_abc ........ [PASS]
Testing std::hash::sha256_test::test_sha256_empty ...... [PASS]
Testing std::hash::sha256_test::test_sha256_longer ..... [PASS]
Testing std::hash::sha256_test::test_sha256_million_a .. [PASS]

8 tests run.

Test Result: FAILED: 7 passed, 1 failed, 0 skipped.
Program completed with exit code 1.
```

After fix...
```
> ./bin/c3c compile-test test/unit/stdlib/hash/sha256.c3
Program linked to executable 'testrun'.
Launching ./testrun
--------------------------- TESTS ---------------------------
Testing std::hash::sha256_test::gigahash_sha256 ........ [PASS]
Testing std::hash::sha256_test::test_pbkdf2 ............ [PASS]
Testing std::hash::sha256_test::test_pbkdf2_2 .......... [PASS]
Testing std::hash::sha256_test::test_pbkdf2_3 .......... [PASS]
Testing std::hash::sha256_test::test_sha256_abc ........ [PASS]
Testing std::hash::sha256_test::test_sha256_empty ...... [PASS]
Testing std::hash::sha256_test::test_sha256_longer ..... [PASS]
Testing std::hash::sha256_test::test_sha256_million_a .. [PASS]

8 tests run.

Test Result: PASSED: 8 passed, 0 failed, 0 skipped.
Program completed with exit code 0.
```