### PR TITLE
Add read_until_delimiter macro

### DIFF
--- a/lib/std/io/stream.c3
+++ b/lib/std/io/stream.c3
@@ -165,6 +165,73 @@ fn usz? copy_to(InStream in, OutStream dst, char[] buffer = {})
 	$endswitch
 }
 
+
+<*
+ Read from input stream byte by byte until delimiter is found, writing each byte to output stream.
+
+ @param [&inout] in : "The input stream to read from"
+ @param [&inout] out : "The output stream to write to"
+ @param delimiter : "The delimiter (single character or string) to stop reading at"
+ @return "Number of bytes read from input stream (excluding delimiter), or error"
+ @require @is_instream(in)
+ @require @is_outstream(out)
+*>
+macro usz? read_until_delimiter(in, out, String delimiter)
+{
+	if (delimiter.len == 0) return 0;
+
+	usz bytes_read = 0;
+	usz match_pos = 0;
+	char[] match_buffer = mem::temp_array(char, delimiter.len);
+
+	while (true)
+	{
+		char c = in.read_byte()!;
+
+		// Check if this character matches the current position in delimiter
+		if (c == delimiter[match_pos])
+		{
+			match_buffer[match_pos] = c;
+			match_pos++;
+
+			// Full delimiter matched?
+			if (match_pos == delimiter.len)
+			{
+				return bytes_read;
+			}
+		}
+		else
+		{
+			// No match, write any buffered characters first
+			if (match_pos > 0)
+			{
+				out.write(match_buffer[:match_pos])!;
+				bytes_read += match_pos;
+				match_pos = 0;
+
+				// Check if current character starts a new potential match
+				if (c == delimiter[0])
+				{
+					match_buffer[0] = c;
+					match_pos = 1;
+				}
+				else
+				{
+					// Write the current character
+					out.write_byte(c)!;
+					bytes_read++;
+				}
+			}
+			else
+			{
+				// Write the current character
+				out.write_byte(c)!;
+				bytes_read++;
+			}
+		}
+	}
+}
+
 macro usz? copy_through_buffer(InStream in, OutStream dst, char[] buffer) @local
 {
 	usz total_copied;

--- a/test/unit/stdlib/io/stream.c3
+++ b/test/unit/stdlib/io/stream.c3
@@ -87,3 +87,117 @@ fn void read_short_bytearray_test()
 	assert(read == &&x'aabbcc00112233');
 	free(read);
 }
+
+fn void read_until_delimiter_test()
+{
+	// Test basic functionality - read until delimiter found
+	ByteReader reader = io::wrap_bytes("hello,world");
+	ByteWriter writer;
+	writer.tinit();
+
+	usz bytes_read = io::read_until_delimiter(&reader, &writer, ",")!!;
+	assert(bytes_read == 5);
+	assert(writer.str_view() == "hello");
+}
+
+fn void read_until_delimiter_eof_test()
+{
+	// Test EOF case - delimiter not found
+	ByteReader reader = io::wrap_bytes("hello");
+	ByteWriter writer;
+	writer.tinit();
+
+	assert(@catch(io::read_until_delimiter(&reader, &writer, ",")));
+}
+
+fn void read_until_delimiter_empty_test()
+{
+	// Test empty input
+	ByteReader reader = io::wrap_bytes("");
+	ByteWriter writer;
+	writer.tinit();
+
+	assert(@catch(io::read_until_delimiter(&reader, &writer, ",")));
+}
+
+fn void read_until_delimiter_immediate_test()
+{
+	// Test delimiter at start
+	ByteReader reader = io::wrap_bytes(",hello");
+	ByteWriter writer;
+	writer.tinit();
+
+	usz bytes_read = io::read_until_delimiter(&reader, &writer, ",")!!;
+	assert(bytes_read == 0);
+	assert(writer.str_view() == "");
+}
+
+fn void read_until_delimiter_output_full_test()
+{
+	// Test output stream full/failed to write
+	ByteReader reader = io::wrap_bytes("hello,world");
+	ByteWriter writer;
+	char[3] small_buffer;
+	writer.init_with_buffer(&small_buffer);
+
+	// This should fail when trying to write the 4th byte since buffer is only 3 bytes
+	assert(@catch(io::read_until_delimiter(&reader, &writer, ",")));
+}
+
+fn void read_until_delimiter_crlf_test()
+{
+	// Test CRLF delimiter
+	ByteReader reader = io::wrap_bytes("hello\r\nworld");
+	ByteWriter writer;
+	writer.tinit();
+
+	usz bytes_read = io::read_until_delimiter(&reader, &writer, "\r\n")!!;
+	assert(bytes_read == 5);
+	assert(writer.str_view() == "hello");
+}
+
+fn void read_until_delimiter_single_char_test()
+{
+	// Test single character - should behave like read_until_delimiter
+	ByteReader reader = io::wrap_bytes("hello,world");
+	ByteWriter writer;
+	writer.tinit();
+
+	usz bytes_read = io::read_until_delimiter(&reader, &writer, ",")!!;
+	assert(bytes_read == 5);
+	assert(writer.str_view() == "hello");
+}
+
+fn void read_until_delimiter_empty_delimiter_test()
+{
+	// Test empty delimiter - should return 0
+	ByteReader reader = io::wrap_bytes("hello");
+	ByteWriter writer;
+	writer.tinit();
+
+	usz bytes_read = io::read_until_delimiter(&reader, &writer, "")!!;
+	assert(bytes_read == 0);
+	assert(writer.str_view() == "");
+}
+
+fn void read_until_delimiter_partial_match_test()
+{
+	// Test partial match that doesn't complete
+	ByteReader reader = io::wrap_bytes("hello\rworld\r\nend");
+	ByteWriter writer;
+	writer.tinit();
+
+	usz bytes_read = io::read_until_delimiter(&reader, &writer, "\r\n")!!;
+	assert(bytes_read == 11); // "hello\rworld"
+	assert(writer.str_view() == "hello\rworld");
+}
+
+fn void read_until_delimiter_multichar_eof_test()
+{
+	// Test EOF without finding delimiter
+	ByteReader reader = io::wrap_bytes("hello\rworld");
+	ByteWriter writer;
+	writer.tinit();
+
+	assert(@catch(io::read_until_delimiter(&reader, &writer, "\r\n")));
+}


### PR DESCRIPTION
This macro reads from an input stream byte by byte until a specified delimiter is found, writing each byte to an output stream. It returns the number of bytes read (excluding the delimiter) or an error.

Key features:
- Reads byte-by-byte until delimiter is encountered
- Writes data to output stream as it reads
- Proper error handling for EOF and write failures
- Compile-time type checking with @require constraints

Potential use cases:
- Parse HTTP headers (read until '\r\n')
- Extract fields from CSV files (read until ',')
- Parse configuration files (read until '=')
- Process line-based protocols
- Extract tokens from streams

Added comprehensive tests covering:
- Basic functionality with delimiter found
- EOF handling when delimiter not found
- Empty input streams
- Immediate delimiter at start
- Output stream write failures