### PR TITLE
Disable libxml2 dependency on linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -288,6 +288,7 @@ jobs:
                 -DCMAKE_OBJCOPY=llvm-objcopy-${{matrix.llvm_version}} \
                 -DCMAKE_STRIP=llvm-strip-${{matrix.llvm_version}} \
                 -DCMAKE_DLLTOOL=llvm-dlltool-${{matrix.llvm_version}} \
+                -DLLVM_ENABLE_LIBXML2=OFF \
                 -DC3_LLVM_VERSION=${{matrix.llvm_version}}.1
           cmake --build build
 
@@ -440,6 +441,7 @@ jobs:
                 -DCMAKE_OBJCOPY=llvm-objcopy-${{matrix.llvm_version}} \
                 -DCMAKE_STRIP=llvm-strip-${{matrix.llvm_version}} \
                 -DCMAKE_DLLTOOL=llvm-dlltool-${{matrix.llvm_version}} \
+                -DLLVM_ENABLE_LIBXML2=OFF \
                 -DC3_LLVM_VERSION=${{matrix.llvm_version}}
           cmake --build build
       - name: CMake
@@ -454,6 +456,7 @@ jobs:
                 -DCMAKE_OBJCOPY=llvm-objcopy-${{matrix.llvm_version}} \
                 -DCMAKE_STRIP=llvm-strip-${{matrix.llvm_version}} \
                 -DCMAKE_DLLTOOL=llvm-dlltool-${{matrix.llvm_version}} \
+                -DLLVM_ENABLE_LIBXML2=OFF \
                 -DC3_LLVM_VERSION=${{matrix.llvm_version}}.1
           cmake --build build
       - name: Compile and run some examples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,6 +273,7 @@ jobs:
                 -DCMAKE_OBJCOPY=llvm-objcopy-${{matrix.llvm_version}} \
                 -DCMAKE_STRIP=llvm-strip-${{matrix.llvm_version}} \
                 -DCMAKE_DLLTOOL=llvm-dlltool-${{matrix.llvm_version}} \
+                -DLLVM_ENABLE_LIBXML2=OFF \
                 -DC3_LLVM_VERSION=${{matrix.llvm_version}}
           cmake --build build
       - name: CMake18


### PR DESCRIPTION
I get:

```
$ c3c compile-run ../resources/testfragments/helloworld.c3 
c3c: /usr/lib/libxml2.so.2: no version information available (required by c3c)
c3c: /usr/lib/libxml2.so.2: no version information available (required by c3c)
Program linked to executable 'helloworld'.
Launching ./helloworld
Hello, World!
Program completed with exit code 0.
```

Due to: https://gitlab.archlinux.org/archlinux/packaging/packages/libxml2/-/issues/4


LDC had same issue: https://github.com/ldc-developers/ldc/issues/4921

