### PR TITLE
Add null check for thread function pointer

### DIFF
--- a/lib/std/threads/os/thread_posix.c3
+++ b/lib/std/threads/os/thread_posix.c3
@@ -164,6 +164,7 @@ fn void* callback(void* arg) @private
 {
 	NativeThread* thread = arg;
 	current_thread = *thread;
+	if (thread.thread_fn == null) return null;
 	return (void*)(iptr)thread.thread_fn(thread.arg);
 }
 


### PR DESCRIPTION
Check thread.thread_fn before calling to prevent null pointer panic.