### PR TITLE
fix hashmap tinit_with_key_values

### DIFF
--- a/lib/std/collections/hashmap.c3
+++ b/lib/std/collections/hashmap.c3
@@ -90,7 +90,7 @@ macro HashMap* HashMap.init_with_key_values(&self, Allocator allocator, ..., uin
 *>
 macro HashMap* HashMap.tinit_with_key_values(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
 {
-	return self.tinit_with_key_values(tmem, capacity, load_factor);
+	return self.init_with_key_values(tmem, $vasplat, capacity: capacity, load_factor: load_factor);
 }
 
 <*


### PR DESCRIPTION
Fix call in `std::collections::map` module; method was calling itself.
Added `$vasplat` Named parameters must be explicit to make `$vasplat` work correctly.

```c
fn void main() => @pool()
{
    HashMap { String, int } simple_map;
    simple_map.tinit_with_key_values(
        "First", 123,
        "Second", 456,
        "Third", 789,
    );

    io::printf("%d\n%d\n%d\n", simple_map["First"]!!, simple_map["Second"]!!, simple_map["Third"]!!);
    foreach (e : simple_map.key_iter()) io::printf("%s: %d\n", e, simple_map[e]!!);
}
```

Before:
```text
> c3c compile-run main.c3
 90: *>
 91: macro HashMap* HashMap.tinit_with_key_values(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_fact|
 92: {
 93:    return self.tinit_with_key_values(tmem, capacity, load_factor);
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
([...]/lib/std/collections/hashmap.c3:93:9) Error: @require "$vacount % 2 == 0" violated: 'There must be an even number of arguments provided for keys and values'.
```

After:
```text
123
456
789
Third: 789
Second: 456
First: 123
```