### PR TITLE
change cmake build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,9 @@ See the `build-with-docker.sh` script for more information on other configurable
 3. Install LLVM 17+: `brew install llvm`
 4. Clone the C3C github repository: `git clone https://github.com/c3lang/c3c.git`
 5. Enter the C3C directory `cd c3c`.
-6. Create a build directory `mkdir build`
-7. Change directory to the build directory `cd build`
-8. Set up CMake build for debug: `cmake ..`
-9. Build: `cmake --build .`
+6. Set up CMake build for debug: `cmake -B build -S .`
+7. Build: `cmake --build build`
+8. Change directory to the build directory `cd build`
 
 #### Installing on Windows using Scoop
 
@@ -350,10 +349,9 @@ You should now have a `c3c` executable in `build-debug\Debug`.
 2. Install LLVM 18 `sudo apt-get install cmake git clang zlib1g zlib1g-dev libllvm18 llvm llvm-dev llvm-runtime liblld-dev liblld-18 libpolly-18-dev`
 3. Clone the C3C github repository: `git clone https://github.com/c3lang/c3c.git`
 4. Enter the C3C directory `cd c3c`.
-5. Create a build directory `mkdir build`
-6. Change directory to the build directory `cd build`
-7. Set up CMake build: `cmake ..`
-8. Build: `cmake --build .`
+5. Set up CMake build: `cmake -B build -S .`
+6. Build: `cmake --build build`
+7. Change directory to the build directory `cd build`
 
 You should now have a `c3c` executable.
 
@@ -366,13 +364,12 @@ You can try it out by running some sample code: `./c3c compile ../resources/exam
 2. Clone the C3C repository: `git clone https://github.com/c3lang/c3c.git`
     - If you only need the latest commit, you may want to make a shallow clone instead: `git clone https://github.com/c3lang/c3c.git --depth=1`
 3. Enter the directory: `cd c3c`
-4. Create a build directory: `mkdir build`
-5. Enter the build directory: `cd build`
-6. Create the CMake build cache: `cmake ..`
-7. Build: `cmake --build .`
+4. Create the CMake build cache: `cmake -B build -S .`
+5. Build: `cmake --build build`
+6. Enter the build directory: `cd build`
 
 Your c3c executable should have compiled properly. You may want to test it: `./c3c compile ../resources/examples/hash.c3`  
-For a sytem-wide installation, run the following as root: `cmake --install .`
+For a system-wide installation, run the following as root: `cmake --install .`
 
 
 #### Compiling on Fedora
@@ -382,9 +379,9 @@ For a sytem-wide installation, run the following as root: `cmake --install .`
 3. Clone the C3C repository: `git clone https://github.com/c3lang/c3c.git`
     - If you only need the latest commit, you may want to make a shallow clone: `git clone https://github.com/c3lang/c3c.git --depth=1`
 4. Enter the C3C directory: `cd c3c`
-5. Create a build directory and navigate into it: `mkdir build && cd build`
-6. Create the CMake build cache. The Fedora repositories provide `.so` libraries for lld, so you need to set the C3_LINK_DYNAMIC flag: `cmake .. -DC3_LINK_DYNAMIC=1`
-7. Build the project: `cmake --build .`
+5. Create the CMake build cache. The Fedora repositories provide `.so` libraries for lld, so you need to set the C3_LINK_DYNAMIC flag: `cmake -B build -S . -DC3_LINK_DYNAMIC=1`
+6. Build the project: `cmake --build build`
+7. Enter the build directory: `cd build`
 
 The c3c binary should be created in the build directory. You can try it out by running some sample code: `./c3c compile ../resources/examples/hash.c3`
 
@@ -412,11 +409,10 @@ After compilation, the `c3c` binary will be located in the `build` directory. Yo
 2. Install or compile LLVM and LLD *libraries* (version 17+ or higher)
 3. Clone the C3C github repository: `git clone https://github.com/c3lang/c3c.git`
 4. Enter the C3C directory `cd c3c`.
-5. Create a build directory `mkdir build`
-6. Change directory to the build directory `cd build`
-7. Set up CMake build for debug: `cmake ..`. At this point you may need to manually 
-provide the link path to the LLVM CMake directories, e.g. `cmake -DLLVM_DIR=/usr/local/opt/llvm/lib/cmake/llvm/ ..`
-8. Build: `cmake --build .`
+5. Set up CMake build for debug: `cmake -B build -S .`. At this point you may need to manually 
+provide the link path to the LLVM CMake directories, e.g. `cmake -DLLVM_DIR=/usr/local/opt/llvm/lib/cmake/llvm/ .`
+6. Build: `cmake --build build`
+7. Change directory to the build directory `cd build`
 
 *A note on compiling for Linux/Unix/MacOS: to be able to fetch vendor libraries
 libcurl is needed. The CMake script should detect it if it is available. Note that

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ After compilation, the `c3c` binary will be located in the `build` directory. Yo
 3. Clone the C3C github repository: `git clone https://github.com/c3lang/c3c.git`
 4. Enter the C3C directory `cd c3c`.
 5. Set up CMake build for debug: `cmake -B build -S .`. At this point you may need to manually 
-provide the link path to the LLVM CMake directories, e.g. `cmake -DLLVM_DIR=/usr/local/opt/llvm/lib/cmake/llvm/ .`
+provide the link path to the LLVM CMake directories, e.g. `cmake -B build -S . -DLLVM_DIR=/usr/local/opt/llvm/lib/cmake/llvm/`
 6. Build: `cmake --build build`
 7. Change directory to the build directory `cd build`
 

--- a/README.md
+++ b/README.md
@@ -276,13 +276,15 @@ See the `build-with-docker.sh` script for more information on other configurable
 
 #### Installing on OS X using Homebrew
 
-2. Install CMake: `brew install cmake`
-3. Install LLVM 17+: `brew install llvm`
-4. Clone the C3C github repository: `git clone https://github.com/c3lang/c3c.git`
-5. Enter the C3C directory `cd c3c`.
-6. Set up CMake build for debug: `cmake -B build -S .`
-7. Build: `cmake --build build`
-8. Change directory to the build directory `cd build`
+1. Install [Homebrew](https://brew.sh/)
+2. Install LLVM 17+: `brew install llvm`
+3. Install lld: `brew install lld`
+4. Install CMake: `brew install cmake`
+5. Clone the C3C github repository: `git clone https://github.com/c3lang/c3c.git`
+6. Enter the C3C directory `cd c3c`.
+7. Set up CMake build for debug: `cmake -B build -S .`
+8. Build: `cmake --build build`
+9. Change directory to the build directory `cd build`
 
 #### Installing on Windows using Scoop
 
@@ -346,7 +348,7 @@ You should now have a `c3c` executable in `build-debug\Debug`.
 #### Compiling on Ubuntu 24.04 LTS
 
 1. Make sure you have a C compiler that handles C11 and a C++ compiler, such as GCC or Clang. Git also needs to be installed.
-2. Install LLVM 18 `sudo apt-get install cmake git clang zlib1g zlib1g-dev libllvm18 llvm llvm-dev llvm-runtime liblld-dev liblld-18 libpolly-18-dev`
+2. Install LLVM 18 `sudo apt-get install cmake git clang zlib1g zlib1g-dev libllvm18 llvm llvm-dev llvm-runtime liblld-dev liblld-18 libpolly-18-dev`. If you're using Ubuntu 25.04, also install `libpolly-20-dev`.
 3. Clone the C3C github repository: `git clone https://github.com/c3lang/c3c.git`
 4. Enter the C3C directory `cd c3c`.
 5. Set up CMake build: `cmake -B build -S .`
@@ -387,7 +389,7 @@ The c3c binary should be created in the build directory. You can try it out by r
 
 #### Compiling on Arch Linux
 
-1. Install required project dependencies: `sudo pacman -S curl lld llvm-libs clang cmake git libedit llvm`
+1. Install required project dependencies: `sudo pacman -S curl lld llvm-libs clang cmake git libedit llvm libxml2`
 2. Clone the C3C repository: `git clone https://github.com/c3lang/c3c.git`
     - If you only need the latest commit, you may want to make a shallow clone: `git clone https://github.com/c3lang/c3c.git --depth=1`
 3. Enter the C3C directory: `cd c3c`
@@ -397,7 +399,7 @@ cmake -B build \
     -D C3_LINK_DYNAMIC=ON \
     -D CMAKE_BUILD_TYPE=Release
 ```
-5. Build the project: `make -C build`.
+5. Build the project: `cmake --build build`.
 
 After compilation, the `c3c` binary will be located in the `build` directory. You can test it by compiling an example: `./build/c3c compile resources/examples/ls.c3`.
 


### PR DESCRIPTION
Draft PR to fix the build instructions. Some people in the Discord were having issues building c3c on different platforms from source with the given instructions; for me, I was missing the libpolly-20-dev apt package on Ubuntu 25.04. A docker image would fix the "works on my machine" problem.