### PR TITLE
Tidy up path.c3

### DIFF
--- a/lib/std/io/path.c3
+++ b/lib/std/io/path.c3
@@ -155,10 +155,7 @@ fn Path? from_wstring(Allocator allocator, WString path) => @pool()
 	return path::new(allocator, string::tfrom_wstring(path)!);
 }
 
-fn Path? from_win32_wstring(Allocator allocator, WString path) @deprecated => @pool()
-{
-	return path::new(allocator, string::tfrom_wstring(path)!);
-}
+fn Path? from_win32_wstring(Allocator allocator, WString path) @deprecated("Use 'from_wstring' instead") => from_wstring(allocator, path);
 
 fn Path? for_windows(Allocator allocator, String path) => new(allocator, path, WIN32);
 


### PR DESCRIPTION
- Added `@operator(==)` to `equals` function
- Inlined non-pool functions
- made `path` untyped in `mkdir`