### PR TITLE
Add HashSet implementation

### DIFF
--- a/lib/std/collections/hashset.c3
+++ b/lib/std/collections/hashset.c3
@@ -340,7 +340,7 @@ fn void HashSet.reserve(&set, usz capacity)
  @param [&inout] allocator : "Allocator for the new set"
  @return "A new set containing the union of both sets"
 *>
-fn HashSet HashSet.union_with(&self, Allocator allocator, HashSet* other)
+fn HashSet HashSet.set_union(&self, Allocator allocator, HashSet* other)
 {
 	usz new_capacity = math::next_power_of_2(self.count + other.count);
 	HashSet result;
@@ -350,7 +350,7 @@ fn HashSet HashSet.union_with(&self, Allocator allocator, HashSet* other)
 	return result;
 }
 
-fn HashSet HashSet.tunion_with(&self, HashSet* other) => self.union_with(tmem, other);
+fn HashSet HashSet.tset_union(&self, HashSet* other) => self.set_union(tmem, other);
 
 <*
  Returns the intersection of the two sets (A & B)
@@ -400,6 +400,30 @@ fn HashSet HashSet.difference(&self, Allocator allocator, HashSet* other)
 }
 
 fn HashSet HashSet.tdifference(&self, HashSet* other) => self.difference(tmem, other) @inline;
+
+<*
+ Return (A ^ B)
+
+ @param [&in] other : "The other set to compare with"
+ @param [&inout] allocator : "Allocator for the new set"
+ @return "A new set containing elements in this set or the other, but not both"
+*>
+fn HashSet HashSet.symmetric_difference(&self, Allocator allocator, HashSet* other)
+{
+	HashSet result;
+	result.init(allocator, self.table.len, self.load_factor);
+	result.add_all_from(self);
+	other.@each(;Value value)
+	{
+		if (!result.add(value))
+		{
+			result.remove(value);
+		}
+	};
+	return result;
+}
+
+fn HashSet HashSet.tsymmetric_difference(&self, HashSet* other) => self.symmetric_difference(tmem, other) @inline;
 
 <*
  Check if this hash set is a subset of another set.

--- a/lib/std/collections/hashset.c3
+++ b/lib/std/collections/hashset.c3
@@ -1,0 +1,561 @@
+<*
+ @require $defined((Value){}.hash()) : `No .hash function found on the value`
+*>
+module std::collections::set {Value};
+import std::math;
+import std::io @norecurse;
+
+const uint DEFAULT_INITIAL_CAPACITY = 16;
+const uint MAXIMUM_CAPACITY = 1u << 31;
+const float DEFAULT_LOAD_FACTOR = 0.75;
+
+const Allocator SET_HEAP_ALLOCATOR = (Allocator)&dummy;
+
+const HashSet ONHEAP = { .allocator = SET_HEAP_ALLOCATOR };
+
+struct Entry 
+{
+	uint hash;
+	Value value;
+	Entry* next;
+}
+
+struct HashSet (Printable) 
+{
+	Entry*[] table;
+	Allocator allocator;
+	usz count; 		// Number of elements
+	usz threshold; 	// Resize limit
+	float load_factor;
+}
+
+fn int HashSet.len(&self) @operator(len) => (int) self.count;
+
+<*
+ @param [&inout] allocator : "The allocator to use"
+ @require capacity > 0 : "The capacity must be 1 or higher"
+ @require load_factor > 0.0 : "The load factor must be higher than 0"
+ @require !self.is_initialized() : "Set was already initialized"
+ @require capacity < MAXIMUM_CAPACITY : "Capacity cannot exceed maximum"
+*>
+fn HashSet* HashSet.init(&self, Allocator allocator, usz capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR) 
+{
+	capacity = math::next_power_of_2(capacity);
+	self.allocator = allocator;
+	self.threshold = (usz) (capacity * load_factor);
+    self.load_factor = load_factor;
+	self.table = allocator::new_array(allocator, Entry*, capacity);
+	return self;
+}
+
+<*
+ @require capacity > 0 : "The capacity must be 1 or higher"
+ @require load_factor > 0.0 : "The load factor must be higher than 0"
+ @require !self.is_initialized() : "Set was already initialized"
+ @require capacity < MAXIMUM_CAPACITY : "Capacity cannot exceed maximum"
+*>
+fn HashSet* HashSet.tinit(&self, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
+{
+	return self.init(tmem, capacity, load_factor) @inline;
+}
+
+<*
+ @param [&inout] allocator : "The allocator to use"
+ @require capacity > 0 : "The capacity must be 1 or higher"
+ @require load_factor > 0.0 : "The load factor must be higher than 0"
+ @require !self.is_initialized() : "Set was already initialized"
+ @require capacity < MAXIMUM_CAPACITY : "Capacity cannot exceed maximum"
+*>
+macro HashSet* HashSet.init_with_values(&self, Allocator allocator, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
+{
+	self.init(allocator, capacity, load_factor);
+	$for var $i = 0; $i < $vacount; $i++:
+		self.add($vaarg[$i]);
+	$endfor
+	return self;
+}
+
+<*
+ @require capacity > 0 : "The capacity must be 1 or higher"
+ @require load_factor > 0.0 : "The load factor must be higher than 0"
+ @require !self.is_initialized() : "Map was already initialized"
+ @require capacity < MAXIMUM_CAPACITY : "Capacity cannot exceed maximum"
+*>
+macro HashSet* HashSet.tinit_with_key_values(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
+{
+	return self.init_with_key_values(tmem, $vasplat, capacity: capacity, load_factor: load_factor);
+}
+
+<*
+ @param [in] values : "The values for the HashSet"
+ @param [&inout] allocator : "The allocator to use"
+ @require capacity > 0 : "The capacity must be 1 or higher"
+ @require load_factor > 0.0 : "The load factor must be higher than 0"
+ @require !self.is_initialized() : "Map was already initialized"
+ @require capacity < MAXIMUM_CAPACITY : "Capacity cannot exceed maximum"
+*>
+fn HashSet* HashSet.init_from_values(&self, Allocator allocator, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
+{
+	self.init(allocator, capacity, load_factor);
+	for (usz i = 0; i < values.len; i++)
+	{
+		self.add(values[i]);
+	}
+	return self;
+}
+
+<*
+ @param [in] values : "The values for the HashSet entries"
+ @require capacity > 0 : "The capacity must be 1 or higher"
+ @require load_factor > 0.0 : "The load factor must be higher than 0"
+ @require !self.is_initialized() : "Set was already initialized"
+ @require capacity < MAXIMUM_CAPACITY : "Capacity cannot exceed maximum"
+*>
+fn HashSet* HashSet.tinit_from_values(&self, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
+{
+	return self.init_from_values(tmem, values, capacity, load_factor);
+}
+
+<*
+ Has this hash set been initialized yet?
+
+ @param [&in] set : "The hash set we are testing"
+ @return "Returns true if it has been initialized, false otherwise"
+*>
+fn bool HashSet.is_initialized(&set)
+{
+	return set.allocator && set.allocator.ptr != &dummy;
+}
+
+<*
+ @param [&inout] allocator : "The allocator to use"
+ @param [&in] other_set : "The set to copy from."
+ @require !self.is_initialized() : "Set was already initialized"
+*>
+fn HashSet* HashSet.init_from_map(&self, Allocator allocator, HashSet* other_set)
+{
+	self.init(allocator, other_set.table.len, other_set.load_factor);
+	self.put_all_for_create(other_set);
+	return self;
+}
+
+<*
+ @param [&in] other_set : "The set to copy from."
+ @require !set.is_initialized() : "Set was already initialized"
+*>
+fn HashSet* HashSet.tinit_from_map(&set, HashSet* other_set)
+{
+	return set.init_from_map(tmem, other_set) @inline;
+}
+
+fn bool HashSet.is_empty(&set) @inline
+{
+	return !set.count;
+}
+
+<*
+ Get the value or add and
+ @require @assignable_to(#expr, Value)
+*>
+macro Value HashSet.@add_or_get(&set, Value #expr)
+{
+    if (!set.count)
+    {
+        Value val = #expr;
+        set.add(val);
+        return val;
+    }
+    uint hash = rehash(value.hash());
+    uint index = index_for(hash, set.table.len);
+    for (Entry *e = set.table[index]; e != null; e = e.next)
+    {
+        if (e.hash == hash && equals(value, e.value)) return e.value;
+    }
+    Value val = #expr;
+    set.add_entry(hash, val, index);
+    return val;
+}
+
+fn bool HashSet.add(&set, Value value)
+{
+	// If the set isn't initialized, use the defaults to initialize it.
+	switch (set.allocator.ptr)
+    {
+    	case &dummy:
+    	    set.init(mem);
+    	case null:
+    	    set.tinit();
+    	default:
+    		break;
+    }
+    uint hash = rehash(value.hash());
+    uint index = index_for(hash, set.table.len);
+    for (Entry *e = set.table[index]; e != null; e = e.next)
+    {
+        if (e.hash == hash && equals(value, e.value)) return false;
+    }
+    set.add_entry(hash, value, index);
+    return true;
+}
+
+macro HashSet.@each(set; @body(value))
+{
+    set.@each_entry(; Entry* entry)
+	{
+		@body(entry.value);
+	};
+}
+
+macro HashSet.@each_entry(set; @body(entry))
+{
+	if (!set.count) return;
+	foreach (Entry* entry : set.table)
+	{
+		while (entry)
+		{
+			@body(entry);
+			entry = entry.next;
+		}
+	}
+}
+
+fn bool HashSet.contains(&set, Value value)
+{
+    if (!set.count) return false;
+    uint hash = rehash(value.hash());
+    for (Entry *e = set.table[index_for(hash, set.table.len)]; e != null; e = e.next)
+    {
+        if (e.hash == hash && equals(value, e.value)) return true;
+    }
+    return false;
+}
+
+fn void? HashSet.remove(&set, Value value) @maydiscard
+{
+    if (!set.remove_entry_for_value(value)) return NOT_FOUND?;
+}
+
+fn void HashSet.free(&set) 
+{
+	if (!set.is_initialized()) return;
+	set.clear();
+	set.free_internal(set.table.ptr);
+	set.table = {};
+}
+
+<*
+ Clear all elements from the set while keeping the underlying storage
+*>
+fn void HashSet.clear(&set)
+{
+    if (!set.count) return;
+    
+    foreach (Entry** &entry_ref : set.table)
+    {
+        Entry* entry = *entry_ref;
+        if (!entry) continue;
+
+        Entry *next = entry.next;
+        while (next)
+        {
+            Entry *to_delete = next;
+            next = next.next;
+            set.free_entry(to_delete);
+        }
+        
+        set.free_entry(entry);
+        *entry_ref = null;
+    }
+    set.count = 0;
+}
+
+fn void HashSet.reserve(&set, usz capacity)
+{
+    if (capacity > set.threshold)
+    {
+        set.resize(math::next_power_of_2(capacity));
+    }
+}
+
+// --- Set Operations ---
+
+<*
+ @param [&in] other : "The other set to union with"
+ @param [&inout] allocator : "Allocator for the new set"
+ @return "A new set containing the union of both sets"
+*>
+fn HashSet* HashSet.merge(&self, Allocator allocator, HashSet* other)
+{
+    usz new_capacity = math::next_power_of_2(self.count + other.count);
+    HashSet* result = allocator::new(allocator, HashSet);
+    result.init(allocator, new_capacity, self.load_factor);
+    
+    self.@each_entry(; Entry* entry) {
+        result.add(entry.value);
+    };
+    
+    other.@each_entry(; Entry* entry) {
+        result.add(entry.value);
+    };
+    
+    return result;
+}
+
+fn HashSet* HashSet.tmerge(&self, HashSet* other) => self.merge(tmem, other);
+
+<*
+ @param [&in] other : "The other set to intersect with"
+ @param [&inout] allocator : "Allocator for the new set"
+ @return "A new set containing the intersection of both sets"
+*>
+fn HashSet* HashSet.intersection(&self, Allocator allocator, HashSet* other)
+{
+    HashSet* result = allocator::new(allocator, HashSet);
+    result.init(allocator, math::min(self.table.len, other.table.len), self.load_factor);
+    
+    // Iterate through the smaller set for efficiency
+    HashSet* smaller = self.count <= other.count ? self : other;
+    HashSet* larger = self.count > other.count ? self : other;
+    
+    smaller.@each_entry(; Entry* entry) {
+        if (larger.contains(entry.value)) {
+            result.add(entry.value);
+        }
+    };
+    
+    return result;
+}
+
+fn HashSet* HashSet.tintersection(&self, HashSet* other) => self.intersection(tmem, other);
+
+<*
+ @param [&in] other : "The other set to compare with"
+ @param [&inout] allocator : "Allocator for the new set"
+ @return "A new set containing elements in this set but not in the other"
+*>
+fn HashSet* HashSet.difference(&self, Allocator allocator, HashSet* other)
+{
+    HashSet* result = allocator::new(allocator, HashSet);
+    result.init(allocator, self.table.len, self.load_factor);
+    
+    self.@each_entry(; Entry* entry) {
+        if (!other.contains(entry.value)) {
+            result.add(entry.value);
+        }
+    };
+    
+    return result;
+}
+
+fn HashSet* HashSet.tdifference(&self, HashSet* other) => self.difference(tmem, other);
+
+<*
+ @param [&in] other : "The other set to check against"
+ @return "True if all elements of this set are in the other set"
+*>
+fn bool HashSet.is_subset(&self, HashSet* other)
+{
+    if (self.count == 0) return true;
+    if (self.count > other.count) return false;
+    
+    self.@each_entry(; Entry* entry) {
+        if (!other.contains(entry.value)) return false;
+    };
+    return true;
+}
+
+
+// --- private methods
+
+fn void HashSet.add_entry(&set, uint hash, Value value, uint bucket_index) @private
+{
+	Entry* entry = allocator::new(set.allocator, Entry, { .hash = hash, .value = value, .next = set.table[bucket_index] });
+	set.table[bucket_index] = entry;
+	if (set.count++ >= set.threshold)
+	{
+		set.resize(set.table.len * 2);
+	}
+}
+
+fn void HashSet.resize(&self, usz new_capacity) @private {
+	Entry*[] old_table = self.table;
+	usz old_capacity = old_table.len;
+	if (old_capacity == MAXIMUM_CAPACITY)
+	{
+		self.threshold = uint.max;
+		return;
+	}
+	Entry*[] new_table = allocator::new_array(self.allocator, Entry*, new_capacity);
+	self.transfer(new_table);
+	self.table = new_table;
+	self.free_internal(old_table.ptr);
+	self.threshold = (uint)(new_capacity * self.load_factor);
+}
+
+fn usz? HashSet.to_format(&self, Formatter* f) @dynamic
+{
+	usz len;
+	len += f.print("{ ")!;
+	self.@each_entry(; Entry* entry)
+	{
+		if (len > 2) len += f.print(", ")!;
+		len += f.printf("%s", entry.value)!;
+    };
+	return len + f.print(" }");
+}
+
+fn void HashSet.transfer(&self, Entry*[] new_table) @private
+{
+	Entry*[] src = self.table;
+	uint new_capacity = new_table.len;
+	foreach (uint j, Entry *e : src)
+	{
+		if (!e) continue;
+		do
+		{
+			Entry* next = e.next;
+			uint i = index_for(e.hash, new_capacity);
+			e.next = new_table[i];
+			new_table[i] = e;
+			e = next;
+		}
+		while (e);
+	}
+}
+
+fn void HashSet.put_all_for_create(&set, HashSet* other_set) @private
+{
+	if (!other_set.count) return;
+	foreach (Entry *e : other_set.table)
+	{
+		while (e)
+		{
+			set.put_for_create(e.value);
+			e = e.next;
+		}
+	}
+}
+
+fn void HashSet.put_for_create(&set, Value value) @private
+{
+    uint hash = rehash(value.hash());
+    uint i = index_for(hash, set.table.len);
+    for (Entry *e = set.table[i]; e != null; e = e.next)
+    {
+        if (e.hash == hash && equals(value, e.value))
+        {
+            // Value already exists, no need to do anything
+            return;
+        }
+    }
+    set.create_entry(hash, value, i);
+}
+
+fn void HashSet.free_internal(&self, void* ptr) @inline @private
+{
+	allocator::free(self.allocator, ptr);
+}
+
+fn void HashSet.create_entry(&set, uint hash, Value value, int bucket_index) @private
+{
+    Entry* entry = allocator::new(set.allocator, Entry, { 
+        .hash = hash, 
+        .value = value, 
+        .next = set.table[bucket_index] 
+    });
+    set.table[bucket_index] = entry;
+    set.count++;
+}
+
+<*
+ Removes the entry for the specified value if present
+ @return "true if found and removed, false otherwise"
+*>
+fn bool HashSet.remove_entry_for_value(&set, Value value) @private
+{
+    if (!set.count) return false;
+    uint hash = rehash(value.hash());
+    uint i = index_for(hash, set.table.len);
+    Entry* prev = set.table[i];
+    Entry* e = prev;
+    while (e)
+    {
+        Entry *next = e.next;
+        if (e.hash == hash && equals(value, e.value))
+        {
+            set.count--;
+            if (prev == e)
+            {
+                set.table[i] = next;
+            }
+            else
+            {
+                prev.next = next;
+            }
+            set.free_entry(e);
+            return true;
+        }
+        prev = e;
+        e = next;
+    }
+    
+    return false;
+}
+
+fn void HashSet.free_entry(&set, Entry *entry) @private
+{
+	// TODO: Maybe some checking for entry cleanup? Like
+    // $if $defined((Value){}.free()):
+    //     entry.value.free(); ?
+    // or  allocator::free(set.allocator, entry.value); ?
+    // $endif
+    
+    allocator::free(set.allocator, entry);
+}
+
+struct HashSetIterator
+{
+    HashSet* set;
+    usz bucket_index;
+    Entry* current;
+}
+
+fn HashSetIterator HashSet.iter(&set) => { .set = set, .bucket_index = 0, .current = null };
+
+fn Value? HashSetIterator.next(&self)
+{
+    if (self.current)
+    {
+        Value value = self.current.value;
+        self.current = self.current.next;
+        return value;
+    }
+
+    while (self.bucket_index < self.set.table.len)
+    {
+        self.current = self.set.table[self.bucket_index++];
+        if (self.current)
+        {
+            Value value = self.current.value;
+            self.current = self.current.next;
+            return value;
+        }
+    }
+
+    return NOT_FOUND?;
+}
+
+fn usz HashSetIterator.len(&self) @operator(len)
+{
+    return self.set.count;
+}
+
+fn uint rehash(uint hash) @inline @private
+{
+	hash ^= (hash >> 20) ^ (hash >> 12);
+	return hash ^ ((hash >> 7) ^ (hash >> 4));
+}
+
+macro uint index_for(uint hash, uint capacity) @private => hash & (capacity - 1);
+
+int dummy @local;

--- a/lib/std/collections/hashset.c3
+++ b/lib/std/collections/hashset.c3
@@ -43,7 +43,7 @@ fn HashSet* HashSet.init(&self, Allocator allocator, usz capacity = DEFAULT_INIT
 	capacity = math::next_power_of_2(capacity);
 	self.allocator = allocator;
 	self.threshold = (usz) (capacity * load_factor);
-    self.load_factor = load_factor;
+	self.load_factor = load_factor;
 	self.table = allocator::new_array(allocator, Entry*, capacity);
 	return self;
 }
@@ -97,10 +97,7 @@ macro HashSet* HashSet.tinit_with_values(&self, ..., uint capacity = DEFAULT_INI
 fn HashSet* HashSet.init_from_values(&self, Allocator allocator, Value[] values, uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
 {
 	self.init(allocator, capacity, load_factor);
-	for (usz i = 0; i < values.len; i++)
-	{
-		self.add(values[i]);
-	}
+	foreach (v : values) self.add(v);
 	return self;
 }
 
@@ -148,72 +145,44 @@ fn HashSet* HashSet.tinit_from_set(&set, HashSet* other_set)
 	return set.init_from_set(tmem, other_set) @inline;
 }
 
+<*
+ @pure
+*>
 fn bool HashSet.is_empty(&set) @inline
 {
 	return !set.count;
-}
-
-<*
- Get the value or add and
- @require @assignable_to(#expr, Value)
-*>
-macro Value HashSet.@add_or_get(&set, Value #expr)
-{
-    if (!set.count)
-    {
-        Value val = #expr;
-        set.add(val);
-        return val;
-    }
-    uint hash = rehash(value.hash());
-    uint index = index_for(hash, set.table.len);
-    for (Entry *e = set.table[index]; e != null; e = e.next)
-    {
-        if (e.hash == hash && equals(value, e.value)) return e.value;
-    }
-    Value val = #expr;
-    set.add_entry(hash, val, index);
-    return val;
 }
 
 fn bool HashSet.add(&set, Value value)
 {
 	// If the set isn't initialized, use the defaults to initialize it.
 	switch (set.allocator.ptr)
-    {
-    	case &dummy:
-    	    set.init(mem);
-    	case null:
-    	    set.tinit();
-    	default:
-    		break;
-    }
-    uint hash = rehash(value.hash());
-    uint index = index_for(hash, set.table.len);
-    for (Entry *e = set.table[index]; e != null; e = e.next)
-    {
-        if (e.hash == hash && equals(value, e.value)) return false;
-    }
-    set.add_entry(hash, value, index);
-    return true;
+	{
+		case &dummy:
+			set.init(mem);
+		case null:
+			set.tinit();
+		default:
+			break;
+	}
+	uint hash = rehash(value.hash());
+	uint index = index_for(hash, set.table.len);
+	for (Entry *e = set.table[index]; e != null; e = e.next)
+	{
+		if (e.hash == hash && equals(value, e.value)) return false;
+	}
+	set.add_entry(hash, value, index);
+	return true;
 }
 
 macro HashSet.@each(set; @body(value))
-{
-    set.@each_entry(; Entry* entry)
-	{
-		@body(entry.value);
-	};
-}
-
-macro HashSet.@each_entry(set; @body(entry))
 {
 	if (!set.count) return;
 	foreach (Entry* entry : set.table)
 	{
 		while (entry)
 		{
-			@body(entry);
+			@body(entry.value);
 			entry = entry.next;
 		}
 	}
@@ -221,18 +190,18 @@ macro HashSet.@each_entry(set; @body(entry))
 
 fn bool HashSet.contains(&set, Value value)
 {
-    if (!set.count) return false;
-    uint hash = rehash(value.hash());
-    for (Entry *e = set.table[index_for(hash, set.table.len)]; e != null; e = e.next)
-    {
-        if (e.hash == hash && equals(value, e.value)) return true;
-    }
-    return false;
+	if (!set.count) return false;
+	uint hash = rehash(value.hash());
+	for (Entry *e = set.table[index_for(hash, set.table.len)]; e != null; e = e.next)
+	{
+		if (e.hash == hash && equals(value, e.value)) return true;
+	}
+	return false;
 }
 
 fn void? HashSet.remove(&set, Value value) @maydiscard
 {
-    if (!set.remove_entry_for_value(value)) return NOT_FOUND?;
+	if (!set.remove_entry_for_value(value)) return NOT_FOUND?;
 }
 
 fn void HashSet.free(&set) 
@@ -240,41 +209,43 @@ fn void HashSet.free(&set)
 	if (!set.is_initialized()) return;
 	set.clear();
 	set.free_internal(set.table.ptr);
-    set.table = {};
+	*set = {};
 }
 
 <*
  Clear all elements from the set while keeping the underlying storage
+
+ @ensure set.count == 0
 *>
 fn void HashSet.clear(&set)
 {
-    if (!set.count) return;
-    
-    foreach (Entry** &entry_ref : set.table)
-    {
-        Entry* entry = *entry_ref;
-        if (!entry) continue;
+	if (!set.count) return;
 
-        Entry *next = entry.next;
-        while (next)
-        {
-            Entry *to_delete = next;
-            next = next.next;
-            set.free_entry(to_delete);
-        }
-        
-        set.free_entry(entry);
-        *entry_ref = null;
-    }
-    set.count = 0;
+	foreach (Entry** &entry_ref : set.table)
+	{
+		Entry* entry = *entry_ref;
+		if (!entry) continue;
+
+		Entry *next = entry.next;
+		while (next)
+		{
+			Entry *to_delete = next;
+			next = next.next;
+			set.free_entry(to_delete);
+		}
+
+		set.free_entry(entry);
+		*entry_ref = null;
+	}
+	set.count = 0;
 }
 
 fn void HashSet.reserve(&set, usz capacity)
 {
-    if (capacity > set.threshold)
-    {
-        set.resize(math::next_power_of_2(capacity));
-    }
+	if (capacity > set.threshold)
+	{
+		set.resize(math::next_power_of_2(capacity));
+	}
 }
 
 // --- Set Operations ---
@@ -284,70 +255,69 @@ fn void HashSet.reserve(&set, usz capacity)
  @param [&inout] allocator : "Allocator for the new set"
  @return "A new set containing the union of both sets"
 *>
-fn HashSet* HashSet.merge(&self, Allocator allocator, HashSet* other)
+fn HashSet HashSet.merge(&self, Allocator allocator, HashSet* other)
 {
-    usz new_capacity = math::next_power_of_2(self.count + other.count);
-    HashSet* result = allocator::new(allocator, HashSet);
-    result.init(allocator, new_capacity, self.load_factor);
-    
-    self.@each_entry(; Entry* entry) {
-        result.add(entry.value);
-    };
-    
-    other.@each_entry(; Entry* entry) {
-        result.add(entry.value);
-    };
-    
-    return result;
+	usz new_capacity = math::next_power_of_2(self.count + other.count);
+	HashSet result;
+	result.init(allocator, new_capacity, self.load_factor);
+	self.@each(;Value val)
+	{
+		result.add(val);
+	};
+	other.@each(;Value val)
+	{
+		result.add(val);
+	};
+	return result;
 }
 
-fn HashSet* HashSet.tmerge(&self, HashSet* other) => self.merge(tmem, other);
+fn HashSet HashSet.tmerge(&self, HashSet* other) => self.merge(tmem, other);
 
 <*
  @param [&in] other : "The other set to intersect with"
  @param [&inout] allocator : "Allocator for the new set"
  @return "A new set containing the intersection of both sets"
 *>
-fn HashSet* HashSet.intersection(&self, Allocator allocator, HashSet* other)
+fn HashSet HashSet.intersection(&self, Allocator allocator, HashSet* other)
 {
-    HashSet* result = allocator::new(allocator, HashSet);
-    result.init(allocator, math::min(self.table.len, other.table.len), self.load_factor);
-    
-    // Iterate through the smaller set for efficiency
-    HashSet* smaller = self.count <= other.count ? self : other;
-    HashSet* larger = self.count > other.count ? self : other;
-    
-    smaller.@each_entry(; Entry* entry) {
-        if (larger.contains(entry.value)) {
-            result.add(entry.value);
-        }
-    };
-    
-    return result;
+	HashSet result;
+	result.init(allocator, math::min(self.table.len, other.table.len), self.load_factor);
+
+	// Iterate through the smaller set for efficiency
+	HashSet* smaller = self.count <= other.count ? self : other;
+	HashSet* larger = self.count > other.count ? self : other;
+
+	smaller.@each(;Value value)
+	{
+		if (larger.contains(value)) result.add(value);
+	};
+
+	return result;
 }
 
-fn HashSet* HashSet.tintersection(&self, HashSet* other) => self.intersection(tmem, other);
+fn HashSet HashSet.tintersection(&self, HashSet* other) => self.intersection(tmem, other);
 
 <*
  @param [&in] other : "The other set to compare with"
  @param [&inout] allocator : "Allocator for the new set"
  @return "A new set containing elements in this set but not in the other"
 *>
-fn HashSet* HashSet.difference(&self, Allocator allocator, HashSet* other)
+fn HashSet HashSet.difference(&self, Allocator allocator, HashSet* other)
 {
-    HashSet* result = allocator::new(allocator, HashSet);
-    result.init(allocator, self.table.len, self.load_factor);
-    
-    self.@each_entry(; Entry* entry) {
-        if (!other.contains(entry.value)) {
-            result.add(entry.value);
-        }
-    };
-    
-    return result;
+	HashSet result;
+	result.init(allocator, self.table.len, self.load_factor);
+
+	self.@each(;Value value)
+	{
+		if (!other.contains(value))
+		{
+			result.add(value);
+		}
+	};
+	return result;
 }
 
-fn HashSet* HashSet.tdifference(&self, HashSet* other) => self.difference(tmem, other);
+fn HashSet HashSet.tdifference(&self, HashSet* other) => self.difference(tmem, other) @inline;
 
 <*
  @param [&in] other : "The other set to check against"
@@ -355,13 +325,14 @@ fn HashSet* HashSet.tdifference(&self, HashSet* other) => self.difference(tmem, 
 *>
 fn bool HashSet.is_subset(&self, HashSet* other)
 {
-    if (self.count == 0) return true;
-    if (self.count > other.count) return false;
-    
-    self.@each_entry(; Entry* entry) {
-        if (!other.contains(entry.value)) return false;
-    };
-    return true;
+	if (self.count == 0) return true;
+	if (self.count > other.count) return false;
+
+	self.@each(;Value value)
+	{
+		if (!other.contains(value)) return false;
+	};
+	return true;
 }
 
 
@@ -377,7 +348,8 @@ fn void HashSet.add_entry(&set, uint hash, Value value, uint bucket_index) @priv
 	}
 }
 
-fn void HashSet.resize(&self, usz new_capacity) @private {
+fn void HashSet.resize(&self, usz new_capacity) @private
+{
 	Entry*[] old_table = self.table;
 	usz old_capacity = old_table.len;
 	if (old_capacity == MAXIMUM_CAPACITY)
@@ -396,11 +368,11 @@ fn usz? HashSet.to_format(&self, Formatter* f) @dynamic
 {
 	usz len;
 	len += f.print("{ ")!;
-	self.@each_entry(; Entry* entry)
+	self.@each(; Value value)
 	{
 		if (len > 2) len += f.print(", ")!;
-		len += f.printf("%s", entry.value)!;
-    };
+		len += f.printf("%s", value)!;
+	};
 	return len + f.print(" }");
 }
 
@@ -438,17 +410,17 @@ fn void HashSet.put_all_for_create(&set, HashSet* other_set) @private
 
 fn void HashSet.put_for_create(&set, Value value) @private
 {
-    uint hash = rehash(value.hash());
-    uint i = index_for(hash, set.table.len);
-    for (Entry *e = set.table[i]; e != null; e = e.next)
-    {
-        if (e.hash == hash && equals(value, e.value))
-        {
-            // Value already exists, no need to do anything
-            return;
-        }
-    }
-    set.create_entry(hash, value, i);
+	uint hash = rehash(value.hash());
+	uint i = index_for(hash, set.table.len);
+	for (Entry *e = set.table[i]; e != null; e = e.next)
+	{
+		if (e.hash == hash && equals(value, e.value))
+		{
+			// Value already exists, no need to do anything
+			return;
+		}
+	}
+	set.create_entry(hash, value, i);
 }
 
 fn void HashSet.free_internal(&self, void* ptr) @inline @private
@@ -458,13 +430,13 @@ fn void HashSet.free_internal(&self, void* ptr) @inline @private
 
 fn void HashSet.create_entry(&set, uint hash, Value value, int bucket_index) @private
 {
-    Entry* entry = allocator::new(set.allocator, Entry, { 
-        .hash = hash, 
-        .value = value, 
-        .next = set.table[bucket_index] 
-    });
-    set.table[bucket_index] = entry;
-    set.count++;
+	Entry* entry = allocator::new(set.allocator, Entry, {
+		.hash = hash,
+		.value = value,
+		.next = set.table[bucket_index]
+	});
+	set.table[bucket_index] = entry;
+	set.count++;
 }
 
 <*
@@ -473,81 +445,75 @@ fn void HashSet.create_entry(&set, uint hash, Value value, int bucket_index) @pr
 *>
 fn bool HashSet.remove_entry_for_value(&set, Value value) @private
 {
-    if (!set.count) return false;
-    uint hash = rehash(value.hash());
-    uint i = index_for(hash, set.table.len);
-    Entry* prev = set.table[i];
-    Entry* e = prev;
-    while (e)
-    {
-        Entry *next = e.next;
-        if (e.hash == hash && equals(value, e.value))
-        {
-            set.count--;
-            if (prev == e)
-            {
-                set.table[i] = next;
-            }
-            else
-            {
-                prev.next = next;
-            }
-            set.free_entry(e);
-            return true;
-        }
-        prev = e;
-        e = next;
-    }
-    
-    return false;
+	if (!set.count) return false;
+	uint hash = rehash(value.hash());
+	uint i = index_for(hash, set.table.len);
+	Entry* prev = set.table[i];
+	Entry* e = prev;
+	while (e)
+	{
+		Entry *next = e.next;
+		if (e.hash == hash && equals(value, e.value))
+		{
+			set.count--;
+			if (prev == e)
+			{
+				set.table[i] = next;
+			}
+			else
+			{
+				prev.next = next;
+			}
+			set.free_entry(e);
+			return true;
+		}
+		prev = e;
+		e = next;
+	}
+
+	return false;
 }
 
 fn void HashSet.free_entry(&set, Entry *entry) @private
 {
-	// TODO: Maybe some checking for entry cleanup? Like
-    // $if $defined((Value){}.free()):
-    //     entry.value.free(); ?
-    // or  allocator::free(set.allocator, entry.value); ?
-    // $endif
-    
-    allocator::free(set.allocator, entry);
+	allocator::free(set.allocator, entry);
 }
 
 struct HashSetIterator
 {
-    HashSet* set;
-    usz bucket_index;
-    Entry* current;
+	HashSet* set;
+	usz bucket_index;
+	Entry* current;
 }
 
 fn HashSetIterator HashSet.iter(&set) => { .set = set, .bucket_index = 0, .current = null };
 
 fn Value? HashSetIterator.next(&self)
 {
-    if (self.current)
-    {
-        Value value = self.current.value;
-        self.current = self.current.next;
-        return value;
-    }
+	if (self.current)
+	{
+		Value value = self.current.value;
+		self.current = self.current.next;
+		return value;
+	}
 
-    while (self.bucket_index < self.set.table.len)
-    {
-        self.current = self.set.table[self.bucket_index++];
-        if (self.current)
-        {
-            Value value = self.current.value;
-            self.current = self.current.next;
-            return value;
-        }
-    }
+	while (self.bucket_index < self.set.table.len)
+	{
+		self.current = self.set.table[self.bucket_index++];
+		if (self.current)
+		{
+			Value value = self.current.value;
+			self.current = self.current.next;
+			return value;
+		}
+	}
 
-    return NOT_FOUND?;
+	return NOT_FOUND?;
 }
 
 fn usz HashSetIterator.len(&self) @operator(len)
 {
-    return self.set.count;
+	return self.set.count;
 }
 
 fn uint rehash(uint hash) @inline @private

--- a/lib/std/collections/hashset.c3
+++ b/lib/std/collections/hashset.c3
@@ -11,6 +11,7 @@ const float DEFAULT_LOAD_FACTOR = 0.75;
 
 const Allocator SET_HEAP_ALLOCATOR = (Allocator)&dummy;
 
+<* Copy the ONHEAP allocator to initialize to a set that is heap allocated *>
 const HashSet ONHEAP = { .allocator = SET_HEAP_ALLOCATOR };
 
 struct Entry 
@@ -146,6 +147,9 @@ fn HashSet* HashSet.tinit_from_set(&set, HashSet* other_set)
 }
 
 <*
+ Check if the set is empty
+
+ @return "true if it is empty"
  @pure
 *>
 fn bool HashSet.is_empty(&set) @inline
@@ -153,6 +157,42 @@ fn bool HashSet.is_empty(&set) @inline
 	return !set.count;
 }
 
+<*
+ Add all elements in the slice to the set.
+
+ @param [in] list
+ @return "The number of new elements added"
+ @ensure total <= list.len
+*>
+fn usz HashSet.add_all(&set, Value[] list)
+{
+	usz total;
+	foreach (v : list)
+	{
+		if (set.add(v)) total++;
+	}
+	return total;
+}
+
+<*
+ @param [&in] other
+ @return "The number of new elements added"
+ @ensure return <= other.count
+*>
+fn usz HashSet.add_all_from(&set, HashSet* other)
+{
+	usz total;
+	other.@each(;Value value)
+	{
+		if (set.add(value)) total++;
+	};
+	return total;
+}
+
+<*
+ @param value : "The value to add"
+ @return "true if the value didn't exist in the set"
+*>
 fn bool HashSet.add(&set, Value value)
 {
 	// If the set isn't initialized, use the defaults to initialize it.
@@ -175,6 +215,9 @@ fn bool HashSet.add(&set, Value value)
 	return true;
 }
 
+<*
+ Iterate over all the values in the set
+*>
 macro HashSet.@each(set; @body(value))
 {
 	if (!set.count) return;
@@ -188,6 +231,12 @@ macro HashSet.@each(set; @body(value))
 	}
 }
 
+<*
+ Check if the set contains the given value.
+
+ @param value : "The value to check"
+ @return "true if it exists in the set"
+*>
 fn bool HashSet.contains(&set, Value value)
 {
 	if (!set.count) return false;
@@ -199,11 +248,43 @@ fn bool HashSet.contains(&set, Value value)
 	return false;
 }
 
+<*
+ Remove a single value from the set.
+
+ @param value : "The value to remove"
+ @return? NOT_FOUND : "If the entry is not found"
+*>
 fn void? HashSet.remove(&set, Value value) @maydiscard
 {
 	if (!set.remove_entry_for_value(value)) return NOT_FOUND?;
 }
 
+fn usz HashSet.remove_all(&set, Value[] values)
+{
+	usz total;
+	foreach (v : values)
+	{
+		if (set.remove_entry_for_value(v)) total++;
+	}
+	return total;
+}
+
+<*
+ @param [&in] other : "Other set"
+*>
+fn usz HashSet.remove_all_from(&set, HashSet* other)
+{
+	usz total;
+	other.@each(;Value val)
+    {
+		if (set.remove_entry_for_value(val)) total++;
+    };
+    return total;
+}
+
+<*
+ Free all memory allocated by the hash set.
+*>
 fn void HashSet.free(&set) 
 {
 	if (!set.is_initialized()) return;
@@ -248,32 +329,32 @@ fn void HashSet.reserve(&set, usz capacity)
 	}
 }
 
+
+
 // --- Set Operations ---
 
 <*
+ Returns the union of two sets (A | B)
+
  @param [&in] other : "The other set to union with"
  @param [&inout] allocator : "Allocator for the new set"
  @return "A new set containing the union of both sets"
 *>
-fn HashSet HashSet.merge(&self, Allocator allocator, HashSet* other)
+fn HashSet HashSet.union_with(&self, Allocator allocator, HashSet* other)
 {
 	usz new_capacity = math::next_power_of_2(self.count + other.count);
 	HashSet result;
 	result.init(allocator, new_capacity, self.load_factor);
-	self.@each(;Value val)
-	{
-		result.add(val);
-	};
-	other.@each(;Value val)
-	{
-		result.add(val);
-	};
+	result.add_all_from(self);
+	result.add_all_from(other);
 	return result;
 }
 
-fn HashSet HashSet.tmerge(&self, HashSet* other) => self.merge(tmem, other);
+fn HashSet HashSet.tunion_with(&self, HashSet* other) => self.union_with(tmem, other);
 
 <*
+ Returns the intersection of the two sets (A & B)
+
  @param [&in] other : "The other set to intersect with"
  @param [&inout] allocator : "Allocator for the new set"
  @return "A new set containing the intersection of both sets"
@@ -298,6 +379,8 @@ fn HashSet HashSet.intersection(&self, Allocator allocator, HashSet* other)
 fn HashSet HashSet.tintersection(&self, HashSet* other) => self.intersection(tmem, other);
 
 <*
+ Return this set - other, so (A & ~B)
+
  @param [&in] other : "The other set to compare with"
  @param [&inout] allocator : "Allocator for the new set"
  @return "A new set containing elements in this set but not in the other"
@@ -306,7 +389,6 @@ fn HashSet HashSet.difference(&self, Allocator allocator, HashSet* other)
 {
 	HashSet result;
 	result.init(allocator, self.table.len, self.load_factor);
-
 	self.@each(;Value value)
 	{
 		if (!other.contains(value))
@@ -320,6 +402,8 @@ fn HashSet HashSet.difference(&self, Allocator allocator, HashSet* other)
 fn HashSet HashSet.tdifference(&self, HashSet* other) => self.difference(tmem, other) @inline;
 
 <*
+ Check if this hash set is a subset of another set.
+
  @param [&in] other : "The other set to check against"
  @return "True if all elements of this set are in the other set"
 *>
@@ -516,6 +600,7 @@ fn usz HashSetIterator.len(&self) @operator(len)
 	return self.set.count;
 }
 
+<* @pure *>
 fn uint rehash(uint hash) @inline @private
 {
 	hash ^= (hash >> 20) ^ (hash >> 12);

--- a/lib/std/collections/hashset.c3
+++ b/lib/std/collections/hashset.c3
@@ -81,9 +81,9 @@ macro HashSet* HashSet.init_with_values(&self, Allocator allocator, ..., uint ca
  @require !self.is_initialized() : "Map was already initialized"
  @require capacity < MAXIMUM_CAPACITY : "Capacity cannot exceed maximum"
 *>
-macro HashSet* HashSet.tinit_with_key_values(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
+macro HashSet* HashSet.tinit_with_values(&self, ..., uint capacity = DEFAULT_INITIAL_CAPACITY, float load_factor = DEFAULT_LOAD_FACTOR)
 {
-	return self.init_with_key_values(tmem, $vasplat, capacity: capacity, load_factor: load_factor);
+	return self.init_with_values(tmem, $vasplat, capacity: capacity, load_factor: load_factor);
 }
 
 <*
@@ -132,7 +132,7 @@ fn bool HashSet.is_initialized(&set)
  @param [&in] other_set : "The set to copy from."
  @require !self.is_initialized() : "Set was already initialized"
 *>
-fn HashSet* HashSet.init_from_map(&self, Allocator allocator, HashSet* other_set)
+fn HashSet* HashSet.init_from_set(&self, Allocator allocator, HashSet* other_set)
 {
 	self.init(allocator, other_set.table.len, other_set.load_factor);
 	self.put_all_for_create(other_set);
@@ -143,9 +143,9 @@ fn HashSet* HashSet.init_from_map(&self, Allocator allocator, HashSet* other_set
  @param [&in] other_set : "The set to copy from."
  @require !set.is_initialized() : "Set was already initialized"
 *>
-fn HashSet* HashSet.tinit_from_map(&set, HashSet* other_set)
+fn HashSet* HashSet.tinit_from_set(&set, HashSet* other_set)
 {
-	return set.init_from_map(tmem, other_set) @inline;
+	return set.init_from_set(tmem, other_set) @inline;
 }
 
 fn bool HashSet.is_empty(&set) @inline
@@ -240,7 +240,7 @@ fn void HashSet.free(&set)
 	if (!set.is_initialized()) return;
 	set.clear();
 	set.free_internal(set.table.ptr);
-	set.table = {};
+    set.table = {};
 }
 
 <*

--- a/test/unit/stdlib/collections/set.c3
+++ b/test/unit/stdlib/collections/set.c3
@@ -77,7 +77,7 @@ fn void set_operations()
 	set2.tinit_with_values(2, 3, 4);
 	defer set2.free();
 
-	IntSet union_set = set1.tmerge(&set2);
+	IntSet union_set = set1.tunion_with(&set2);
 	defer union_set.free();
 	assert(union_set.contains(1));
 	assert(union_set.contains(2));
@@ -186,6 +186,25 @@ fn void string_set_test()
 	assert(set.add("hello"));
 	assert(set.add("world"));
 	assert(!set.add("hello"));
+
+	assert(set.contains("hello"));
+	assert(set.contains("world"));
+	assert(!set.contains("foo"));
+
+	set.remove("hello");
+	assert(!set.contains("hello"));
+	assert(set.len() == 1);
+}
+
+fn void add_all_test()
+{
+	StringSet set;
+	set.init(mem);
+	defer set.free();
+
+	String[] list = { "hello", "world", "hello" };
+	usz total = set.add_all(list);
+	assert(total == 2);
 
 	assert(set.contains("hello"));
 	assert(set.contains("world"));

--- a/test/unit/stdlib/collections/set.c3
+++ b/test/unit/stdlib/collections/set.c3
@@ -77,7 +77,7 @@ fn void set_operations()
 	set2.tinit_with_values(2, 3, 4);
 	defer set2.free();
 
-	IntSet union_set = set1.tunion_with(&set2);
+	IntSet union_set = set1.tset_union(&set2);
 	defer union_set.free();
 	assert(union_set.contains(1));
 	assert(union_set.contains(2));
@@ -94,12 +94,18 @@ fn void set_operations()
 	assert(intersect_set.len() == 2);
 
 	IntSet diff_set = set1.tdifference(&set2);
-	defer diff_set.free();
 	assert(diff_set.contains(1));
 	assert(!diff_set.contains(2));
 	assert(!diff_set.contains(3));
 	assert(!diff_set.contains(4));
 	assert(diff_set.len() == 1);
+
+	IntSet sdiff_set = set1.tsymmetric_difference(&set2);
+	assert(sdiff_set.contains(1));
+	assert(!sdiff_set.contains(2));
+	assert(!sdiff_set.contains(3));
+	assert(sdiff_set.contains(4));
+	assert(sdiff_set.len() == 2);
 
 	IntSet subset;
 	subset.tinit_with_values(2, 3);

--- a/test/unit/stdlib/collections/set.c3
+++ b/test/unit/stdlib/collections/set.c3
@@ -1,0 +1,200 @@
+module set_test @test;
+import std::collections::set;
+
+alias IntSet = HashSet{int};
+
+fn void basic_operations()
+{
+    IntSet set;
+    defer set.free();
+
+    assert(set.is_empty());
+    assert(!set.contains(1));
+    
+    assert(set.add(1));
+    assert(set.contains(1));
+    assert(!set.is_empty());
+    assert(set.len() == 1);
+    
+    assert(!set.add(1));
+    assert(set.len() == 1);
+    
+    assert(set.add(2));
+    assert(set.add(3));
+    assert(set.len() == 3);
+    assert(set.contains(2));
+    assert(set.contains(3));
+    
+    set.remove(2);
+    assert(!set.contains(2));
+    assert(set.len() == 2);
+    
+    set.clear();
+    assert(set.is_empty());
+    assert(!set.contains(1));
+}
+
+fn void initialization_methods()
+{
+    IntSet set1;
+    set1.tinit();
+    defer set1.free();
+    assert(set1.is_initialized());
+    
+    IntSet set2;
+    set2.tinit_with_values(1, 2, 3);
+    defer set2.free();
+    assert(set2.contains(1));
+    assert(set2.contains(2));
+    assert(set2.contains(3));
+    assert(set2.len() == 3);
+    
+    int[] values = {4, 5, 6};
+    IntSet set3;
+    set3.tinit_from_values(values);
+    defer set3.free();
+    assert(set3.contains(4));
+    assert(set3.contains(5));
+    assert(set3.contains(6));
+    assert(set3.len() == 3);
+    
+    IntSet set4;
+    set4.tinit_from_set(&set3);
+    defer set4.free();
+    assert(set4.contains(4));
+    assert(set4.contains(5));
+    assert(set4.contains(6));
+    assert(set4.len() == 3);
+}
+
+fn void set_operations()
+{
+    IntSet set1;
+    set1.tinit_with_values(1, 2, 3);
+    defer set1.free();
+    
+    IntSet set2;
+    set2.tinit_with_values(2, 3, 4);
+    defer set2.free();
+    
+    IntSet* union_set = set1.tmerge(&set2);
+    defer union_set.free();
+    assert(union_set.contains(1));
+    assert(union_set.contains(2));
+    assert(union_set.contains(3));
+    assert(union_set.contains(4));
+    assert(union_set.len() == 4);
+    
+    IntSet* intersect_set = set1.tintersection(&set2);
+    defer intersect_set.free();
+    assert(intersect_set.contains(2));
+    assert(intersect_set.contains(3));
+    assert(!intersect_set.contains(1));
+    assert(!intersect_set.contains(4));
+    assert(intersect_set.len() == 2);
+    
+    IntSet* diff_set = set1.tdifference(&set2);
+    defer diff_set.free();
+    assert(diff_set.contains(1));
+    assert(!diff_set.contains(2));
+    assert(!diff_set.contains(3));
+    assert(!diff_set.contains(4));
+    assert(diff_set.len() == 1);
+    
+    IntSet subset;
+    subset.tinit_with_values(2, 3);
+    defer subset.free();
+    assert(subset.is_subset(&set1));
+    assert(!set1.is_subset(&subset));
+}
+
+fn void iterator_test()
+{
+    IntSet set;
+    set.tinit_with_values(1, 2, 3);
+    defer set.free();
+    
+    int count = 0;
+    bool found1 = false; bool found2 = false; bool found3 = false;
+    
+    set.@each(; int value) {
+        count++;
+        switch (value) {
+            case 1: found1 = true;
+            case 2: found2 = true;
+            case 3: found3 = true;
+        }
+    };
+    
+    assert(count == 3);
+    assert(found1 && found2 && found3);
+    
+    HashSetIterator {int} iter = set.iter();
+    count = 0;
+    while (@ok(iter.next())) {
+        count++;
+    }
+    assert(count == 3);
+}
+
+fn void edge_cases()
+{
+    IntSet empty;
+    empty.tinit();
+    defer empty.free();
+    
+    assert(empty.is_empty());
+    assert(!empty.contains(0));
+    empty.remove(0); // Shouldn't crash
+    
+    IntSet large;
+    large.tinit();
+    defer large.free();
+    
+    for (int i = 0; i < 1000; i++) {
+        large.add(i);
+    }
+    assert(large.len() == 1000);
+    for (int i = 0; i < 1000; i++) {
+        assert(large.contains(i));
+    }
+    
+    assert(@catch(large.remove(1001)));
+    assert(large.len() == 1000);
+    
+    large.clear();
+    assert(large.is_empty());
+    for (int i = 0; i < 1000; i++) {
+        assert(!large.contains(i));
+    }
+}
+
+alias StringSet = HashSet{String};
+
+fn void string_set_test()
+{    
+    StringSet set;
+    set.tinit();
+    defer set.free();
+    
+    assert(set.add("hello"));
+    assert(set.add("world"));
+    assert(!set.add("hello"));
+    
+    assert(set.contains("hello"));
+    assert(set.contains("world"));
+    assert(!set.contains("foo"));
+    
+    set.remove("hello");
+    assert(!set.contains("hello"));
+    assert(set.len() == 1);
+}
+
+fn void is_initialized_test()
+{
+    IntSet test;
+    assert(!test.is_initialized());
+    test.tinit();
+    assert(test.is_initialized());
+    test.free();
+}

--- a/test/unit/stdlib/collections/set.c3
+++ b/test/unit/stdlib/collections/set.c3
@@ -5,196 +5,202 @@ alias IntSet = HashSet{int};
 
 fn void basic_operations()
 {
-    IntSet set;
-    defer set.free();
+	IntSet set;
+	defer set.free();
 
-    assert(set.is_empty());
-    assert(!set.contains(1));
-    
-    assert(set.add(1));
-    assert(set.contains(1));
-    assert(!set.is_empty());
-    assert(set.len() == 1);
-    
-    assert(!set.add(1));
-    assert(set.len() == 1);
-    
-    assert(set.add(2));
-    assert(set.add(3));
-    assert(set.len() == 3);
-    assert(set.contains(2));
-    assert(set.contains(3));
-    
-    set.remove(2);
-    assert(!set.contains(2));
-    assert(set.len() == 2);
-    
-    set.clear();
-    assert(set.is_empty());
-    assert(!set.contains(1));
+	assert(set.is_empty());
+	assert(!set.contains(1));
+
+	assert(set.add(1));
+	assert(set.contains(1));
+	assert(!set.is_empty());
+	assert(set.len() == 1);
+
+	assert(!set.add(1));
+	assert(set.len() == 1);
+
+	assert(set.add(2));
+	assert(set.add(3));
+	assert(set.len() == 3);
+	assert(set.contains(2));
+	assert(set.contains(3));
+
+	set.remove(2);
+	assert(!set.contains(2));
+	assert(set.len() == 2);
+
+	set.clear();
+	assert(set.is_empty());
+	assert(!set.contains(1));
 }
 
 fn void initialization_methods()
 {
-    IntSet set1;
-    set1.tinit();
-    defer set1.free();
-    assert(set1.is_initialized());
-    
-    IntSet set2;
-    set2.tinit_with_values(1, 2, 3);
-    defer set2.free();
-    assert(set2.contains(1));
-    assert(set2.contains(2));
-    assert(set2.contains(3));
-    assert(set2.len() == 3);
-    
-    int[] values = {4, 5, 6};
-    IntSet set3;
-    set3.tinit_from_values(values);
-    defer set3.free();
-    assert(set3.contains(4));
-    assert(set3.contains(5));
-    assert(set3.contains(6));
-    assert(set3.len() == 3);
-    
-    IntSet set4;
-    set4.tinit_from_set(&set3);
-    defer set4.free();
-    assert(set4.contains(4));
-    assert(set4.contains(5));
-    assert(set4.contains(6));
-    assert(set4.len() == 3);
+	IntSet set1;
+	set1.tinit();
+	defer set1.free();
+	assert(set1.is_initialized());
+
+	IntSet set2;
+	set2.tinit_with_values(1, 2, 3);
+	defer set2.free();
+	assert(set2.contains(1));
+	assert(set2.contains(2));
+	assert(set2.contains(3));
+	assert(set2.len() == 3);
+
+	int[] values = {4, 5, 6};
+	IntSet set3;
+	set3.tinit_from_values(values);
+	defer set3.free();
+	assert(set3.contains(4));
+	assert(set3.contains(5));
+	assert(set3.contains(6));
+	assert(set3.len() == 3);
+
+	IntSet set4;
+	set4.tinit_from_set(&set3);
+	defer set4.free();
+	assert(set4.contains(4));
+	assert(set4.contains(5));
+	assert(set4.contains(6));
+	assert(set4.len() == 3);
 }
 
 fn void set_operations()
 {
-    IntSet set1;
-    set1.tinit_with_values(1, 2, 3);
-    defer set1.free();
-    
-    IntSet set2;
-    set2.tinit_with_values(2, 3, 4);
-    defer set2.free();
-    
-    IntSet* union_set = set1.tmerge(&set2);
-    defer union_set.free();
-    assert(union_set.contains(1));
-    assert(union_set.contains(2));
-    assert(union_set.contains(3));
-    assert(union_set.contains(4));
-    assert(union_set.len() == 4);
-    
-    IntSet* intersect_set = set1.tintersection(&set2);
-    defer intersect_set.free();
-    assert(intersect_set.contains(2));
-    assert(intersect_set.contains(3));
-    assert(!intersect_set.contains(1));
-    assert(!intersect_set.contains(4));
-    assert(intersect_set.len() == 2);
-    
-    IntSet* diff_set = set1.tdifference(&set2);
-    defer diff_set.free();
-    assert(diff_set.contains(1));
-    assert(!diff_set.contains(2));
-    assert(!diff_set.contains(3));
-    assert(!diff_set.contains(4));
-    assert(diff_set.len() == 1);
-    
-    IntSet subset;
-    subset.tinit_with_values(2, 3);
-    defer subset.free();
-    assert(subset.is_subset(&set1));
-    assert(!set1.is_subset(&subset));
+	IntSet set1;
+	set1.tinit_with_values(1, 2, 3);
+	defer set1.free();
+
+	IntSet set2;
+	set2.tinit_with_values(2, 3, 4);
+	defer set2.free();
+
+	IntSet union_set = set1.tmerge(&set2);
+	defer union_set.free();
+	assert(union_set.contains(1));
+	assert(union_set.contains(2));
+	assert(union_set.contains(3));
+	assert(union_set.contains(4));
+	assert(union_set.len() == 4);
+
+	IntSet intersect_set = set1.tintersection(&set2);
+	defer intersect_set.free();
+	assert(intersect_set.contains(2));
+	assert(intersect_set.contains(3));
+	assert(!intersect_set.contains(1));
+	assert(!intersect_set.contains(4));
+	assert(intersect_set.len() == 2);
+
+	IntSet diff_set = set1.tdifference(&set2);
+	defer diff_set.free();
+	assert(diff_set.contains(1));
+	assert(!diff_set.contains(2));
+	assert(!diff_set.contains(3));
+	assert(!diff_set.contains(4));
+	assert(diff_set.len() == 1);
+
+	IntSet subset;
+	subset.tinit_with_values(2, 3);
+	defer subset.free();
+	assert(subset.is_subset(&set1));
+	assert(!set1.is_subset(&subset));
 }
 
 fn void iterator_test()
 {
-    IntSet set;
-    set.tinit_with_values(1, 2, 3);
-    defer set.free();
-    
-    int count = 0;
-    bool found1 = false; bool found2 = false; bool found3 = false;
-    
-    set.@each(; int value) {
-        count++;
-        switch (value) {
-            case 1: found1 = true;
-            case 2: found2 = true;
-            case 3: found3 = true;
-        }
-    };
-    
-    assert(count == 3);
-    assert(found1 && found2 && found3);
-    
-    HashSetIterator {int} iter = set.iter();
-    count = 0;
-    while (@ok(iter.next())) {
-        count++;
-    }
-    assert(count == 3);
+	IntSet set;
+	set.tinit_with_values(1, 2, 3);
+	defer set.free();
+
+	int count = 0;
+	bool found1 = false; bool found2 = false; bool found3 = false;
+
+	set.@each(; int value)
+	{
+		count++;
+		switch (value)
+		{
+			case 1: found1 = true;
+			case 2: found2 = true;
+			case 3: found3 = true;
+		}
+	};
+
+	assert(count == 3);
+	assert(found1 && found2 && found3);
+
+	HashSetIterator {int} iter = set.iter();
+	count = 0;
+	while (@ok(iter.next()))
+	{
+		count++;
+	}
+	assert(count == 3);
 }
 
 fn void edge_cases()
 {
-    IntSet empty;
-    empty.tinit();
-    defer empty.free();
-    
-    assert(empty.is_empty());
-    assert(!empty.contains(0));
-    empty.remove(0); // Shouldn't crash
-    
-    IntSet large;
-    large.tinit();
-    defer large.free();
-    
-    for (int i = 0; i < 1000; i++) {
-        large.add(i);
-    }
-    assert(large.len() == 1000);
-    for (int i = 0; i < 1000; i++) {
-        assert(large.contains(i));
-    }
-    
-    assert(@catch(large.remove(1001)));
-    assert(large.len() == 1000);
-    
-    large.clear();
-    assert(large.is_empty());
-    for (int i = 0; i < 1000; i++) {
-        assert(!large.contains(i));
-    }
+	IntSet empty;
+	empty.tinit();
+	defer empty.free();
+
+	assert(empty.is_empty());
+	assert(!empty.contains(0));
+	empty.remove(0); // Shouldn't crash
+
+	IntSet large;
+	large.tinit();
+	defer large.free();
+
+	for (int i = 0; i < 1000; i++)
+	{
+		large.add(i);
+	}
+	assert(large.len() == 1000);
+	for (int i = 0; i < 1000; i++)
+	{
+		assert(large.contains(i));
+	}
+
+	assert(@catch(large.remove(1001)));
+	assert(large.len() == 1000);
+
+	large.clear();
+	assert(large.is_empty());
+	for (int i = 0; i < 1000; i++)
+	{
+		assert(!large.contains(i));
+	}
 }
 
 alias StringSet = HashSet{String};
 
 fn void string_set_test()
 {    
-    StringSet set;
-    set.tinit();
-    defer set.free();
-    
-    assert(set.add("hello"));
-    assert(set.add("world"));
-    assert(!set.add("hello"));
-    
-    assert(set.contains("hello"));
-    assert(set.contains("world"));
-    assert(!set.contains("foo"));
-    
-    set.remove("hello");
-    assert(!set.contains("hello"));
-    assert(set.len() == 1);
+	StringSet set;
+	set.tinit();
+	defer set.free();
+
+	assert(set.add("hello"));
+	assert(set.add("world"));
+	assert(!set.add("hello"));
+
+	assert(set.contains("hello"));
+	assert(set.contains("world"));
+	assert(!set.contains("foo"));
+
+	set.remove("hello");
+	assert(!set.contains("hello"));
+	assert(set.len() == 1);
 }
 
 fn void is_initialized_test()
 {
-    IntSet test;
-    assert(!test.is_initialized());
-    test.tinit();
-    assert(test.is_initialized());
-    test.free();
+	IntSet test;
+	assert(!test.is_initialized());
+	test.tinit();
+	assert(test.is_initialized());
+	test.free();
 }


### PR DESCRIPTION
Add a generic HashSet with allocator support and standard set operations.

- Basic operations: add/remove/contains/clear
- Set operations: merge/intersection/difference/is_subset
- Iteration support

Example Usage:
```c3
import std::collections::set;

fn int main() {
    HashSet{int} set;
    set.tinit();
    
    // Add values
    set.add(1);
    set.add(2);
    set.add(3);
    
    // Check contains
    if (set.contains(2)) {
        io::printn("Set contains 2!");
    }
    
    // Iterate
    set.@each(; int value) {
        io::printfn("%d", value);
    };
    
    // Set operations
    HashSet{int} other;
    other.tinit();

    other.add(2);
    other.add(3);
    other.add(4);
    
    io::printn(set);
    io::printn(other);

    HashSet{int}* merged = set.tmerge(&other);
    HashSet{int}* common = set.tintersection(&other);

    io::printn(merged);
    io::printn(common);
    
    return 0;
}
```

Output:
```
Set contains 2!
2
3
1
{ 2, 3, 1 }
{ 4, 2, 3 }
{ 3, 4, 1, 2 }
{ 2, 3 }
Program completed with exit code 0.
```