### PR TITLE
Add @try_set Builtin

### DIFF
--- a/lib/std/core/builtin.c3
+++ b/lib/std/core/builtin.c3
@@ -410,6 +410,7 @@ macro swizzle2(v, v2, ...) @builtin
 {
 	return $$swizzle2(v, v2, $vasplat);
 }
+
 <*
  Return the excuse in the Optional if it is Empty, otherwise
  return a null fault.
@@ -432,6 +433,22 @@ macro bool @ok(#expr) @builtin
 {
 	if (catch #expr) return false;
 	return true;
+}
+
+<*
+ Check if an Optional expression evaluates to a fault. If so, return it;
+ else, assign the result to an expression.
+
+ @require @typeis(#expr, $typeof(#v)?) &&& @typekind(#expr) == OPTIONAL : `Type of #expr must be an Optional of #v`
+*>
+macro void? @assign_or(#v, #expr) @builtin
+{
+	var $Type = $typeof(#v);
+	$Type? res = #expr;
+
+	if (catch err = res) return err?;
+
+	#v = res;
 }
 
 <*

--- a/lib/std/core/builtin.c3
+++ b/lib/std/core/builtin.c3
@@ -441,7 +441,7 @@ macro bool @ok(#expr) @builtin
 
  @require @typeis(#expr, $typeof(#v)?) &&& @typekind(#expr) == OPTIONAL : `Type of #expr must be an Optional of #v`
 *>
-macro void? @assign_or(#v, #expr) @builtin
+macro void? @try_set(#v, #expr) @builtin
 {
 	var $Type = $typeof(#v);
 	$Type? res = #expr;

--- a/lib/std/core/builtin.c3
+++ b/lib/std/core/builtin.c3
@@ -439,16 +439,61 @@ macro bool @ok(#expr) @builtin
  Check if an Optional expression evaluates to a fault. If so, return it;
  else, assign the result to an expression.
 
- @require @typeis(#expr, $typeof(#v)?) &&& @typekind(#expr) == OPTIONAL : `Type of #expr must be an Optional of #v`
+ @require $defined(#v = #v) : "#v must be a variable"
+ @require $defined(#expr!) : "Expected an optional expression"
+ @require @assignable_to(#expr!!, $typeof(#v))  : `Type of #expr must be an optional of #v's type`
 *>
-macro void? @try_set(#v, #expr) @builtin
+macro void? @try(#v, #expr) @builtin
 {
-	var $Type = $typeof(#v);
-	$Type? res = #expr;
-
+	var res = #expr;
 	if (catch err = res) return err?;
-
 	#v = res;
+}
+
+<*
+ Check if an Optional expression evaluates to a fault. If so, return true if it is the
+ expected fault, the optional if it is unexpected, or false if there was no fault and
+ the assign happened.
+
+ This can be used in like this:
+
+  while (true)
+  {
+    char[] data;
+    // Read until end of file
+    if (@try_catch(data, load_line(), io::EOF)) break;
+    .. use data ..
+  }
+
+ In this example we read until we reach an EOF, which is expected. However, if we encounter some other
+ fault, we rethrow is. Without this macro, the code is instead written like:
+
+  while (true)
+  {
+    char[]? data;
+    data = load_line();
+    if (catch err = data)
+    {
+      if (err = io::EOF) break;
+      return err?
+    }
+    .. use data ..
+  }
+
+ @require $defined(#v = #v) : "#v must be a variable"
+ @require $defined(#expr!) : "Expected an optional expression"
+ @require @assignable_to(#expr!!, $typeof(#v))  : `Type of #expr must be an optional of #v's type`
+ @return "True if it was the expected fault, false if the variable was assigned, otherwise returns an optional."
+*>
+macro bool? @try_catch(#v, #expr, fault expected_fault) @builtin
+{
+	var res = #expr;
+	if (catch err = res)
+	{
+		return err == expected_fault ? true : err?;
+	}
+	#v = res;
+	return false;
 }
 
 <*

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -30,6 +30,7 @@
 - '$assignable' is deprecated.
 - Deprecate allocator::heap() and allocator::temp()
 - Add `thread::fence` providing a thread fence.
+- Add `@try` and `@try_catch`.
 
 ### Fixes
 - mkdir/rmdir would not work properly with substring paths on non-windows platforms.

--- a/test/unit/stdlib/core/builtintests.c3
+++ b/test/unit/stdlib/core/builtintests.c3
@@ -28,16 +28,16 @@ fn void test_enum_by_name()
 	assert(@catch(enum_by_name(Tester, "GHI")) == NOT_FOUND);
 }
 
-fn void test_assign_or()
+fn void test_try_set()
 {
 	assert(enum_by_name(Tester, "ABC")!! == Tester.ABC);
 
 	Tester val;
-	if (catch @assign_or(val, enum_by_name(Tester, "ABC"))) abort("Test failure");
+	if (catch @try_set(val, enum_by_name(Tester, "ABC"))) abort("Test failure");
 	assert(val == Tester.ABC);
 
 	Tester another;
-	if (catch err = @assign_or(another, enum_by_name(Tester, "GHI")))
+	if (catch err = @try_set(another, enum_by_name(Tester, "GHI")))
 	{
 		assert(err == NOT_FOUND);
 		return;

--- a/test/unit/stdlib/core/builtintests.c3
+++ b/test/unit/stdlib/core/builtintests.c3
@@ -28,6 +28,24 @@ fn void test_enum_by_name()
 	assert(@catch(enum_by_name(Tester, "GHI")) == NOT_FOUND);
 }
 
+fn void test_assign_or()
+{
+	assert(enum_by_name(Tester, "ABC")!! == Tester.ABC);
+
+	Tester val;
+	if (catch @assign_or(val, enum_by_name(Tester, "ABC"))) abort("Test failure");
+	assert(val == Tester.ABC);
+
+	Tester another;
+	if (catch err = @assign_or(another, enum_by_name(Tester, "GHI")))
+	{
+		assert(err == NOT_FOUND);
+		return;
+	}
+
+	abort("Test failure");
+}
+
 fn void test_likely()
 {
 	int a = 2;

--- a/test/unit/stdlib/core/builtintests.c3
+++ b/test/unit/stdlib/core/builtintests.c3
@@ -28,16 +28,33 @@ fn void test_enum_by_name()
 	assert(@catch(enum_by_name(Tester, "GHI")) == NOT_FOUND);
 }
 
+
+faultdef SOME_FAULT, ABC_FAULT;
+
+fn void test_try_catch()
+{
+	int val;
+	int? x = ABC_FAULT?;
+	assert(@try_catch(val, x, ABC_FAULT)!!);
+	assert(val == 0);
+	assert(!@catch(@try_catch(val, x, ABC_FAULT)));
+	x = SOME_FAULT?;
+	assert(@catch(@try_catch(val, x, ABC_FAULT)) == SOME_FAULT);
+	x = 3;
+	assert(!@try_catch(val, x, ABC_FAULT)!!);
+	assert(val == 3);
+}
+
 fn void test_try_set()
 {
 	assert(enum_by_name(Tester, "ABC")!! == Tester.ABC);
 
 	Tester val;
-	if (catch @try_set(val, enum_by_name(Tester, "ABC"))) abort("Test failure");
+	if (catch @try(val, enum_by_name(Tester, "ABC"))) abort("Test failure");
 	assert(val == Tester.ABC);
 
 	Tester another;
-	if (catch err = @try_set(another, enum_by_name(Tester, "GHI")))
+	if (catch err = @try(another, enum_by_name(Tester, "GHI")))
 	{
 		assert(err == NOT_FOUND);
 		return;


### PR DESCRIPTION
See Issue #2325 for more details on this.

Instead of needing to do this:
```c++
    File? f;
    // DOES NOT WORK
    // if (catch err = (f = file::open("/tmp/ooo", "w"))) @die("oh no %s", err);

    // WORKS
    f = file::open("/tmp/ooo", "w");
    if (catch err = f) @die("oh no");
```

Enable the "DOES NOT WORK" section in a slightly different way with this macro:
```c++
    File f;
    if (catch err = @assign_or(f, file::open("/tmp/ooo", "w"))) @die("oh no %s", err);
```

In this case, `f` is now of type `File` instead of `File?`, and we can use the assigned `f` just fine after the `if catch` if no fault was captured.

In the macro `#expr` is assigned to `res` in order to ensure the expression is only evaluated  once when `@assign_or` is called.