### PR TITLE
Support full paths with `$embed`

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -30,6 +30,7 @@
 - '$assignable' is deprecated.
 - Deprecate allocator::heap() and allocator::temp()
 - Add `thread::fence` providing a thread fence.
+- Allow absolute paths for `$embed`.
 
 ### Fixes
 - mkdir/rmdir would not work properly with substring paths on non-windows platforms.

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -9984,7 +9984,7 @@ static inline bool sema_expr_analyse_embed(SemaContext *context, Expr *expr, boo
 	const char *string = filename->const_expr.bytes.ptr;
 	char *path;
 	char *name;
-	if (file_namesplit(unit->file->full_path, &name, &path))
+	if (file_path_is_relative(unit->file->full_path) && file_namesplit(unit->file->full_path, &name, &path))
 	{
 		string = file_append_path(path, string);
 	}

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -9979,7 +9979,7 @@ static inline bool sema_expr_analyse_embed(SemaContext *context, Expr *expr, boo
 		}
 	}
 	if (!expr_is_const_string(filename)) RETURN_SEMA_ERROR(filename, "A compile time string was expected.");
-
+	if (!filename->const_expr.bytes.len) RETURN_SEMA_ERROR(filename, "Expected a non-empty string.");
 	CompilationUnit *unit = context->unit;
 	const char *string = filename->const_expr.bytes.ptr;
 	char *path;

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -9984,7 +9984,7 @@ static inline bool sema_expr_analyse_embed(SemaContext *context, Expr *expr, boo
 	const char *string = filename->const_expr.bytes.ptr;
 	char *path;
 	char *name;
-	if (file_path_is_relative(unit->file->full_path) && file_namesplit(unit->file->full_path, &name, &path))
+	if (file_path_is_relative(string) && file_namesplit(unit->file->full_path, &name, &path))
 	{
 		string = file_append_path(path, string);
 	}

--- a/src/utils/file_utils.c
+++ b/src/utils/file_utils.c
@@ -525,11 +525,13 @@ bool file_exists(const char *path)
 
 bool file_path_is_relative(const char *file_name)
 {
-	if (NULL == file_name || !strlen(file_name)) return false;
+	assert(file_name);
+	size_t len = strlen(file_name);
+	if (!len) return false;
 
 	// returns !full_path condition
 #if PLATFORM_WINDOWS
-	return !(file_name[0] == '\\' || (strlen(file_name) >= 2 && char_is_alpha(file_name[0]) && file_name[1] == ':'));
+	return !(file_name[0] == '\\' || (len >= 2 && char_is_letter(file_name[0]) && file_name[1] == ':'));
 #else
 	return file_name[0] != '/';
 #endif

--- a/src/utils/file_utils.c
+++ b/src/utils/file_utils.c
@@ -529,7 +529,7 @@ bool file_path_is_relative(const char *file_name)
 
 	// returns !full_path condition
 #if PLATFORM_WINDOWS
-	return !(file_name[0] == '\\' || (strlen(file_name) >= 3 && char_is_alpha(file_name[0]) && 0 == strncmp(&file_name[1], ":\\", 2)));
+	return !(file_name[0] == '\\' || (strlen(file_name) >= 2 && char_is_alpha(file_name[0]) && file_name[1] == ':'));
 #else
 	return file_name[0] != '/';
 #endif

--- a/src/utils/file_utils.c
+++ b/src/utils/file_utils.c
@@ -523,6 +523,16 @@ bool file_exists(const char *path)
 	return S_ISDIR(st.st_mode) || S_ISREG(st.st_mode) || S_ISREG(st.st_mode);
 }
 
+bool file_path_is_relative(const char *file_name)
+{
+	// returns !full_path condition
+#if PLATFORM_WINDOWS
+	return !(file_name[0] == '\\' || (char_is_alpha(file_name[0]) && 0 == strncmp(&file_name[1], ":\\", 2)));
+#else
+	return file_name[0] != '/';
+#endif
+}
+
 #define PATH_BUFFER_SIZE 16384
 static char path_buffer[PATH_BUFFER_SIZE];
 

--- a/src/utils/file_utils.c
+++ b/src/utils/file_utils.c
@@ -525,9 +525,11 @@ bool file_exists(const char *path)
 
 bool file_path_is_relative(const char *file_name)
 {
+	if (NULL == file_name || !strlen(file_name)) return false;
+
 	// returns !full_path condition
 #if PLATFORM_WINDOWS
-	return !(file_name[0] == '\\' || (char_is_alpha(file_name[0]) && 0 == strncmp(&file_name[1], ":\\", 2)));
+	return !(file_name[0] == '\\' || (strlen(file_name) >= 3 && char_is_alpha(file_name[0]) && 0 == strncmp(&file_name[1], ":\\", 2)));
 #else
 	return file_name[0] != '/';
 #endif

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -497,11 +497,6 @@ static inline bool char_is_digit(char c)
 	return c >= '0' && c <= '9';
 }
 
-static inline bool char_is_alpha(char c)
-{
-	return char_is_lower(c) || char_is_upper(c);
-}
-
 static char hex_conv[256] = {
 		['0'] = 1,
 		['1'] = 2,

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -79,6 +79,7 @@ bool file_delete_file(const char *path);
 void file_delete_dir(const char *path);
 bool file_is_dir(const char *file);
 bool file_exists(const char *path);
+bool file_path_is_relative(const char *file_name);
 FILE *file_open_read(const char *path);
 bool file_touch(const char *path);
 char *file_read_binary(const char *path, size_t *size);
@@ -494,6 +495,11 @@ static inline bool char_is_digit_or_(char c)
 static inline bool char_is_digit(char c)
 {
 	return c >= '0' && c <= '9';
+}
+
+static inline bool char_is_alpha(char c)
+{
+	return char_is_lower(c) || char_is_upper(c);
 }
 
 static char hex_conv[256] = {


### PR DESCRIPTION
_Call for c3c Windows testers_: Please try out both `\path\to\file` and `C:\path\to\file` (and perhaps another drive letter from a different mount), and let me know if it works properly!

-----

Adding support for full-path file inclusion with the `$embed` CT statement. This came up because I had a few paths to well-known test files under my `/tmp/` folder and I got sick of using symlinks and/or `$embed("../../../../../../../../../tmp/file")` as a cheap hack. :)

Test:
```c++
fn void main()
{
    char[] u = $embed("/path/to/test/int/misc/test_input.data");
    char[] v = $embed("lib/std/atomic.c3");

    char[] w = $embed("/path/to/test/int/misc/test_input.data", 456);
    char[] x = $embed("lib/std/atomic.c3", 200);

    io::printfn("Bytes: %d and %d // %d and %d", u.len, v.len, w.len, x.len);
}
```

Result:
```
> c3c compile-run main.c3
Bytes: 270008320 and 19964 // 456 and 200

> ls -al /path/to/test/int/misc/test_input.data lib/std/atomic.c3
-rw-r--r--. 1 zpuhl zpuhl 270008320 Jun 26 22:49 /path/to/test/int/misc/test_input.data
-rw-r--r--. 1 zpuhl zpuhl     19964 Jul 24 17:48 lib/std/atomic.c3
```