### PR TITLE
Fix get_config_dir() implementation

### DIFF
--- a/lib/std/os/env.c3
+++ b/lib/std/os/env.c3
@@ -79,7 +79,7 @@ fn String? get_home_dir(Allocator allocator)
 
 
 <*
-Returns the current user's config directory.
+ Returns the current user's config directory.
 *>
 fn Path? get_config_dir(Allocator allocator) => @pool()
 {
@@ -87,20 +87,15 @@ fn Path? get_config_dir(Allocator allocator) => @pool()
 		return path::new(allocator, tget_var("AppData"));
 	$else
 		$if env::DARWIN:
-			String s = tget_var("HOME")!;
+			String home_dir = tget_var("HOME")!;
 			const DIR = "Library/Application Support";
-			return path::temp(s).append(allocator, DIR);
 		$else
 			String? config_path = tget_var("XDG_CONFIG_HOME");
-			if (catch config_path) {
-				String home_dir = tget_var("HOME")!;
-				const DIR = ".config";
-
-				return path::temp(home_dir).append(allocator, DIR);
-			} else {
-				return path::new(allocator, config_path);
-			}
+			if (try config_path && config_path.len > 0) return path::new(allocator, config_path);
+			String home_dir = tget_var("HOME")!;
+			const DIR = ".config";
 		$endif
+		return path::temp(home_dir).append(allocator, DIR);
 	$endif
 }
 

--- a/lib/std/os/env.c3
+++ b/lib/std/os/env.c3
@@ -89,11 +89,18 @@ fn Path? get_config_dir(Allocator allocator) => @pool()
 		$if env::DARWIN:
 			String s = tget_var("HOME")!;
 			const DIR = "Library/Application Support";
+			return path::temp(s).append(allocator, DIR);
 		$else
-			String s = tget_var("XDG_CONFIG_HOME") ?? tget_var("HOME")!;
-			const DIR = ".config";
+			String? config_path = tget_var("XDG_CONFIG_HOME");
+			if (catch config_path) {
+				String home_dir = tget_var("HOME")!;
+				const DIR = ".config";
+
+				return path::temp(home_dir).append(allocator, DIR);
+			} else {
+				return path::new(allocator, config_path);
+			}
 		$endif
-		return path::temp(s).append(allocator, DIR);
 	$endif
 }
 


### PR DESCRIPTION
There is an issue with the current `get_config_home()` implementation, as it puts `".config"` behind `$XDG_CONFIG_HOME`, but that is not needed (see the spec: https://specifications.freedesktop.org/basedir-spec/latest/).

I also noticed that only config-home is implemented, but the spec also defines data-home, state-home, cache-home and runtime-dir (less interesting than the previous). Do I implement those too?