### PR TITLE
Immediately skip empty tests

### DIFF
--- a/lib/std/core/runtime_test.c3
+++ b/lib/std/core/runtime_test.c3
@@ -171,6 +171,11 @@ fn bool run_tests(String[] args, TestUnit[] tests) @private
 	usz max_name;
 	bool sort_tests = true;
 	bool check_leaks = true;
+	if (!tests.len)
+	{
+		io::printn("There are no test units to run.");
+		return true;   // no tests == technically a pass
+	}
 	foreach (&unit : tests)
 	{
 		if (max_name < unit.name.len) max_name = unit.name.len;
@@ -305,7 +310,7 @@ fn bool run_tests(String[] args, TestUnit[] tests) @private
 		}
 		mem.free();
 	}
-	io::printfn("\n%d test%s run.\n", test_count-tests_skipped, test_count > 1 ? "s" : "");
+	io::printfn("\n%d test%s run.\n", test_count-tests_skipped, test_count != 1 ? "s" : "");
 
 	int n_failed = test_count - tests_passed - tests_skipped;
 	io::printf("Test Result: %s%s%s: ",


### PR DESCRIPTION
Very small change. Noticed there was noise and dummy output when there weren't even any units passed to the tests runtime.

This shouldn't really happen, and only came up because I was individualizing `c3c compile-test` to every unit file one at a time on OpenBSD.

Output was:
```
---- TESTS -----

0 test run.

Test Result: PASSED: 0 passed, 0 failed, 0 skipped.
```

Now the output is just `There are no test units to run.` and the exit code remains success/`true`.