### PR TITLE
Stdlib: implement SingleSizeObjectPool

### DIFF
--- a/lib/std/core/mem_objectpool.c3
+++ b/lib/std/core/mem_objectpool.c3
@@ -13,8 +13,7 @@ struct SingleSizeObjectPoolNode {
 }
 
 union SingleSizeObjectPoolEntry {
-	SingleSizeObjectPoolEntry *previous;
-	void *data;
+	void *previous;
 }
 
 struct SingleSizeObjectPool {
@@ -23,7 +22,7 @@ struct SingleSizeObjectPool {
 	SingleSizeObjectPoolNode *tail;
 	void *next_free;
 	void *freelist;
-	usz object_size, grow_size;
+	usz object_size, grow_capacity;
 	bool initialized;
 }
 
@@ -40,7 +39,7 @@ macro void SingleSizeObjectPool.init(&self, Allocator alloc, $Type,
 	self.head.capacity = capacity;
 	self.next_free = self.head.buffer;
 	self.freelist = null;
-	self.grow_size = capacity;
+	self.grow_capacity = capacity;
 	self.initialized = true;
 }
 
@@ -102,13 +101,13 @@ fn bool SingleSizeObjectPool.check_ptr(&self, void *ptr) @local
 }
 
 <*
- @require self.grow_size > 0 : "How many objects will it store"
+ @require self.grow_capacity > 0 : "How many objects will it store"
 *>
 fn void SingleSizeObjectPool.new_node(&self) @local
 {
 	SingleSizeObjectPoolNode *node = allocator::new(self.allocator, SingleSizeObjectPoolNode);
-	node.buffer = allocator::calloc(self.allocator, self.grow_size * self.object_size);
-	node.capacity = self.grow_size;
+	node.buffer = allocator::calloc(self.allocator, self.grow_capacity * self.object_size);
+	node.capacity = self.grow_capacity;
 	self.tail.next = node;
 	self.tail = node;
 	self.next_free = node.buffer;

--- a/lib/std/core/mem_objectpool.c3
+++ b/lib/std/core/mem_objectpool.c3
@@ -1,0 +1,115 @@
+module std::core::mem::objectpool;
+
+import libc;
+import std::core::mem::allocator;
+import std::core::mem;
+
+const INITIAL_CAPACITY = 0;
+
+struct SingleSizeObjectPoolNode {
+	void *buffer;
+	SingleSizeObjectPoolNode *next;
+	usz capacity;
+}
+
+union SingleSizeObjectPoolEntry {
+	SingleSizeObjectPoolEntry *previous;
+	void *data;
+}
+
+struct SingleSizeObjectPool {
+	Allocator allocator;
+	SingleSizeObjectPoolNode head;
+	SingleSizeObjectPoolNode *tail;
+	void *next_free;
+	void *freelist;
+	usz object_size, grow_size;
+	bool initialized;
+}
+
+macro void SingleSizeObjectPool.init(&self, Allocator alloc, $Type,
+	usz capacity = INITIAL_CAPACITY)
+{
+	self.allocator = alloc;
+	self.tail = &self.head;
+	self.head.next = null;
+	self.object_size = $Type.sizeof >= (void*).sizeof ? $Type.sizeof : (void*).sizeof;
+
+	capacity = capacity ?: mem::os_pagesize() / self.object_size;
+	self.head.buffer = allocator::calloc(alloc, capacity * self.object_size);
+	self.head.capacity = capacity;
+	self.next_free = self.head.buffer;
+	self.freelist = null;
+	self.grow_size = capacity;
+	self.initialized = true;
+}
+
+macro void SingleSizeObjectPool.tinit(&self, $Type, usz capacity = INITIAL_CAPACITY) => self.init(tmem, $Type, capacity);
+
+<*
+ @require self.initialized : "The object pool must be initialized"
+*>
+fn void SingleSizeObjectPool.free(&self)
+{
+	allocator::free(self.allocator, self.head.buffer);
+	SingleSizeObjectPoolNode *iter = self.head.next;
+
+	while (iter != null) {
+		allocator::free(self.allocator, iter.buffer);
+		SingleSizeObjectPoolNode *current = iter;
+		iter = iter.next;
+		allocator::free(self.allocator, current);
+	}
+}
+
+fn void *SingleSizeObjectPool.alloc(&self)
+{
+	if (self.freelist != null) {
+		SingleSizeObjectPoolEntry *entry = self.freelist;
+		self.freelist = entry.previous;
+		return libc::memset(entry, 0, self.object_size);
+	}
+
+	void *end = self.tail.buffer + (self.tail.capacity * self.object_size);
+	if (self.next_free >= end) self.new_node();
+	void *ptr = self.next_free;
+	self.next_free += self.object_size;
+
+	return ptr;
+}
+
+<*
+ @require self.check_ptr(ptr) : "The pointer should be part of the pool"
+*>
+fn void SingleSizeObjectPool.dealloc(&self, void *ptr)
+{
+	SingleSizeObjectPoolEntry *entry = ptr;
+	entry.previous = self.freelist;
+	self.freelist = entry;
+}
+
+fn bool SingleSizeObjectPool.check_ptr(&self, void *ptr) @local
+{
+	SingleSizeObjectPoolNode *iter = &self.head;
+
+	while (iter != null) {
+		void *end = iter.buffer + (iter.capacity * self.object_size);
+		if (ptr >= iter.buffer && ptr < end) return true;
+		iter = iter.next;
+	}
+
+	return false;
+}
+
+<*
+ @require self.grow_size > 0 : "How many objects will it store"
+*>
+fn void SingleSizeObjectPool.new_node(&self) @local
+{
+	SingleSizeObjectPoolNode *node = allocator::new(self.allocator, SingleSizeObjectPoolNode);
+	node.buffer = allocator::calloc(self.allocator, self.grow_size * self.object_size);
+	node.capacity = self.grow_size;
+	self.tail.next = node;
+	self.tail = node;
+	self.next_free = node.buffer;
+}

--- a/lib/std/core/mem_objectpool.c3
+++ b/lib/std/core/mem_objectpool.c3
@@ -1,22 +1,27 @@
 module std::core::mem::objectpool;
-
 import libc;
-import std::core::mem::allocator;
-import std::core::mem;
+import std::core::mem, std::core::mem::allocator;
 
 const INITIAL_CAPACITY = 0;
 
-struct SingleSizeObjectPoolNode {
+struct SingleSizeObjectPoolNode
+{
 	void *buffer;
 	SingleSizeObjectPoolNode *next;
 	usz capacity;
 }
 
-union SingleSizeObjectPoolEntry {
+union SingleSizeObjectPoolEntry
+{
 	void *previous;
 }
 
-struct SingleSizeObjectPool {
+<*
+ Object pool pre-allocating objects backed by an Allocator which are then reserved for the user,
+ objects deallocated by the user are later re-used by future object allocations
+*>
+struct SingleSizeObjectPool
+{
 	Allocator allocator;
 	SingleSizeObjectPoolNode head;
 	SingleSizeObjectPoolNode *tail;
@@ -26,16 +31,21 @@ struct SingleSizeObjectPool {
 	bool initialized;
 }
 
-macro void SingleSizeObjectPool.init(&self, Allocator alloc, $Type,
-	usz capacity = INITIAL_CAPACITY)
+<*
+ Initialize a object pool
+
+ @param [in] allocator : "The allocator to use"
+ @require !self.initialized : "The object pool must not be initialized"
+*>
+macro void SingleSizeObjectPool.init(&self, Allocator allocator, $Type, usz capacity = INITIAL_CAPACITY)
 {
-	self.allocator = alloc;
+	self.allocator = allocator;
 	self.tail = &self.head;
 	self.head.next = null;
 	self.object_size = $Type.sizeof >= (void*).sizeof ? $Type.sizeof : (void*).sizeof;
 
 	capacity = capacity ?: mem::os_pagesize() / self.object_size;
-	self.head.buffer = allocator::calloc(alloc, capacity * self.object_size);
+	self.head.buffer = allocator::calloc(allocator, capacity * self.object_size);
 	self.head.capacity = capacity;
 	self.next_free = self.head.buffer;
 	self.freelist = null;
@@ -43,6 +53,11 @@ macro void SingleSizeObjectPool.init(&self, Allocator alloc, $Type,
 	self.initialized = true;
 }
 
+<*
+ Initialize a object pool using Temporary allocator
+
+ @require !self.initialized : "The object pool must not be initialized"
+*>
 macro void SingleSizeObjectPool.tinit(&self, $Type, usz capacity = INITIAL_CAPACITY) => self.init(tmem, $Type, capacity);
 
 <*
@@ -53,17 +68,25 @@ fn void SingleSizeObjectPool.free(&self)
 	allocator::free(self.allocator, self.head.buffer);
 	SingleSizeObjectPoolNode *iter = self.head.next;
 
-	while (iter != null) {
+	while (iter != null)
+	{
 		allocator::free(self.allocator, iter.buffer);
 		SingleSizeObjectPoolNode *current = iter;
 		iter = iter.next;
 		allocator::free(self.allocator, current);
 	}
+	self.initialized = false;
 }
 
+<*
+ Allocate an object on the object pool, re-uses previously deallocated objects
+
+ @require self.initialized : "The object pool must be initialized"
+*>
 fn void *SingleSizeObjectPool.alloc(&self)
 {
-	if (self.freelist != null) {
+	if (self.freelist != null)
+	{
 		SingleSizeObjectPoolEntry *entry = self.freelist;
 		self.freelist = entry.previous;
 		return libc::memset(entry, 0, self.object_size);
@@ -78,6 +101,9 @@ fn void *SingleSizeObjectPool.alloc(&self)
 }
 
 <*
+ Deallocate an object from the object pool
+
+ @require self.initialized : "The object pool must be initialized"
  @require self.check_ptr(ptr) : "The pointer should be part of the pool"
 *>
 fn void SingleSizeObjectPool.dealloc(&self, void *ptr)
@@ -87,11 +113,15 @@ fn void SingleSizeObjectPool.dealloc(&self, void *ptr)
 	self.freelist = entry;
 }
 
+<*
+ @require self.initialized : "The object pool must be initialized"
+*>
 fn bool SingleSizeObjectPool.check_ptr(&self, void *ptr) @local
 {
 	SingleSizeObjectPoolNode *iter = &self.head;
 
-	while (iter != null) {
+	while (iter != null)
+	{
 		void *end = iter.buffer + (iter.capacity * self.object_size);
 		if (ptr >= iter.buffer && ptr < end) return true;
 		iter = iter.next;

--- a/lib/std/core/mem_objectpool.c3
+++ b/lib/std/core/mem_objectpool.c3
@@ -19,6 +19,9 @@ union SingleSizeObjectPoolEntry
 <*
  Object pool pre-allocating objects backed by an Allocator which are then reserved for the user,
  objects deallocated by the user are later re-used by future object allocations
+
+ `grow_capacity` can be changed in order to affect how many objects will be allocated by next pool allocation,
+ it has to be greater than 0
 *>
 struct SingleSizeObjectPool
 {

--- a/test/unit/stdlib/core/mem_objectpool.c3
+++ b/test/unit/stdlib/core/mem_objectpool.c3
@@ -1,0 +1,91 @@
+module std::core::objectpool_test;
+
+import std;
+
+struct Foo
+{
+    int a;
+    double b;
+    bool c;
+}
+
+fn void test_basic_allocation() @test
+{
+    SingleSizeObjectPool pool;
+    defer pool.free();
+    pool.init(mem, int);
+
+    int *ptr1 = pool.alloc();
+    int *ptr2 = pool.alloc();
+    assert(((usz) ptr2) - ((usz) ptr1) >= int.sizeof);
+}
+
+fn void test_large_allocation() @test
+{
+    SingleSizeObjectPool pool;
+    defer pool.free();
+    pool.init(mem, Foo);
+
+    Foo *ptr1 = pool.alloc();
+    Foo *ptr2 = pool.alloc();
+    assert(((usz) ptr2) - ((usz) ptr1) >= Foo.sizeof);
+}
+
+fn void test_basic_capacity() @test
+{
+    SingleSizeObjectPool pool;
+    defer pool.free();
+    pool.init(mem, int, 2);
+
+    int *ptr1 = pool.alloc();
+    int *ptr2 = pool.alloc();
+    assert(((usz) ptr2) - ((usz) ptr1) >= int.sizeof);
+}
+
+fn void test_basic_capacity_different_grow_capacity() @test
+{
+    SingleSizeObjectPool pool;
+    defer pool.free();
+    pool.init(mem, int, 1);
+
+    pool.alloc();
+    pool.grow_capacity = 2;
+
+    pool.alloc();
+    pool.alloc();
+    pool.grow_capacity = 1;
+
+    pool.alloc();
+
+    assert(pool.head.buffer != null);
+    assert(pool.head.next.buffer != null);
+    assert(pool.head.next.next.buffer != null);
+    assert(pool.head.next.next.next == null);
+}
+
+fn void test_basic_object_reuse() @test
+{
+    SingleSizeObjectPool pool;
+    defer pool.free();
+    pool.init(mem, int, 1);
+
+    int*[10] objs;
+    for (int i = 0; i < 10; i++) objs[i] = pool.alloc();
+
+    int *obj1 = objs[1];
+    pool.dealloc(obj1);
+
+    int *obj3 = objs[3];
+    pool.dealloc(obj3);
+
+    int *obj7 = objs[7];
+    pool.dealloc(obj7);
+
+    int *obj2 = objs[2];
+    pool.dealloc(obj2);
+
+    assert(obj2 == pool.alloc());
+    assert(obj7 == pool.alloc());
+    assert(obj3 == pool.alloc());
+    assert(obj1 == pool.alloc());
+}

--- a/test/unit/stdlib/core/mem_objectpool.c3
+++ b/test/unit/stdlib/core/mem_objectpool.c3
@@ -4,88 +4,88 @@ import std;
 
 struct Foo
 {
-    int a;
-    double b;
-    bool c;
+	int a;
+	double b;
+	bool c;
 }
 
 fn void test_basic_allocation() @test
 {
-    SingleSizeObjectPool pool;
-    defer pool.free();
-    pool.init(mem, int);
+	SingleSizeObjectPool pool;
+	defer pool.free();
+	pool.init(mem, int);
 
-    int *ptr1 = pool.alloc();
-    int *ptr2 = pool.alloc();
-    assert(((usz) ptr2) - ((usz) ptr1) >= int.sizeof);
+	int *ptr1 = pool.alloc();
+	int *ptr2 = pool.alloc();
+	assert(((usz) ptr2) - ((usz) ptr1) >= int.sizeof);
 }
 
 fn void test_large_allocation() @test
 {
-    SingleSizeObjectPool pool;
-    defer pool.free();
-    pool.init(mem, Foo);
+	SingleSizeObjectPool pool;
+	defer pool.free();
+	pool.init(mem, Foo);
 
-    Foo *ptr1 = pool.alloc();
-    Foo *ptr2 = pool.alloc();
-    assert(((usz) ptr2) - ((usz) ptr1) >= Foo.sizeof);
+	Foo *ptr1 = pool.alloc();
+	Foo *ptr2 = pool.alloc();
+	assert(((usz) ptr2) - ((usz) ptr1) >= Foo.sizeof);
 }
 
 fn void test_basic_capacity() @test
 {
-    SingleSizeObjectPool pool;
-    defer pool.free();
-    pool.init(mem, int, 2);
+	SingleSizeObjectPool pool;
+	defer pool.free();
+	pool.init(mem, int, 2);
 
-    int *ptr1 = pool.alloc();
-    int *ptr2 = pool.alloc();
-    assert(((usz) ptr2) - ((usz) ptr1) >= int.sizeof);
+	int *ptr1 = pool.alloc();
+	int *ptr2 = pool.alloc();
+	assert(((usz) ptr2) - ((usz) ptr1) >= int.sizeof);
 }
 
 fn void test_basic_capacity_different_grow_capacity() @test
 {
-    SingleSizeObjectPool pool;
-    defer pool.free();
-    pool.init(mem, int, 1);
+	SingleSizeObjectPool pool;
+	defer pool.free();
+	pool.init(mem, int, 1);
 
-    pool.alloc();
-    pool.grow_capacity = 2;
+	pool.alloc();
+	pool.grow_capacity = 2;
 
-    pool.alloc();
-    pool.alloc();
-    pool.grow_capacity = 1;
+	pool.alloc();
+	pool.alloc();
+	pool.grow_capacity = 1;
 
-    pool.alloc();
+	pool.alloc();
 
-    assert(pool.head.buffer != null);
-    assert(pool.head.next.buffer != null);
-    assert(pool.head.next.next.buffer != null);
-    assert(pool.head.next.next.next == null);
+	assert(pool.head.buffer != null);
+	assert(pool.head.next.buffer != null);
+	assert(pool.head.next.next.buffer != null);
+	assert(pool.head.next.next.next == null);
 }
 
 fn void test_basic_object_reuse() @test
 {
-    SingleSizeObjectPool pool;
-    defer pool.free();
-    pool.init(mem, int, 1);
+	SingleSizeObjectPool pool;
+	defer pool.free();
+	pool.init(mem, int, 1);
 
-    int*[10] objs;
-    for (int i = 0; i < 10; i++) objs[i] = pool.alloc();
+	int*[10] objs;
+	for (int i = 0; i < 10; i++) objs[i] = pool.alloc();
 
-    int *obj1 = objs[1];
-    pool.dealloc(obj1);
+	int *obj1 = objs[1];
+	pool.dealloc(obj1);
 
-    int *obj3 = objs[3];
-    pool.dealloc(obj3);
+	int *obj3 = objs[3];
+	pool.dealloc(obj3);
 
-    int *obj7 = objs[7];
-    pool.dealloc(obj7);
+	int *obj7 = objs[7];
+	pool.dealloc(obj7);
 
-    int *obj2 = objs[2];
-    pool.dealloc(obj2);
+	int *obj2 = objs[2];
+	pool.dealloc(obj2);
 
-    assert(obj2 == pool.alloc());
-    assert(obj7 == pool.alloc());
-    assert(obj3 == pool.alloc());
-    assert(obj1 == pool.alloc());
+	assert(obj2 == pool.alloc());
+	assert(obj7 == pool.alloc());
+	assert(obj3 == pool.alloc());
+	assert(obj1 == pool.alloc());
 }


### PR DESCRIPTION
Adds Object Pool `SingleSizeObjectPool` to the stdlib, allows users to quickly allocate/reserve objects from the pool and to quickly deallocate/return objects back to the pool, adds module `std::core::mem::objectpool` and tests.

Example usage:
```c
fn int main(String[] args)
{
	SingleSizeObjectPool pool;
	pool.init(mem, int);
	int *obj = pool.alloc();
	// do something with obj
	pool.dealloc(obj);
	return 0;
}
```