### PR TITLE
Fix printf segfaults with unassigned interfaces

### DIFF
--- a/lib/std/io/formatter.c3
+++ b/lib/std/io/formatter.c3
@@ -137,6 +137,7 @@ fn usz? Formatter.out_unknown(&self, String category, any arg) @private
 {
 	return self.out_substr("<") + self.out_substr(category) + self.out_substr(" type:") + self.ntoa((iptr)arg.type, false, 16) + self.out_substr(", addr:") + self.ntoa((iptr)arg.ptr, false, 16) + self.out_substr(">");
 }
+import eee;
 fn usz? Formatter.out_str(&self, any arg) @private
 {
 	switch (arg.type.kindof)
@@ -146,8 +147,10 @@ fn usz? Formatter.out_str(&self, any arg) @private
 		case VOID:
 			return self.out_substr("void");
 		case FAULT:
-			return self.out_substr((*(fault*)arg.ptr).nameof);
+			return self.out_substr((*(fault*)arg.ptr).nameof ?: "<EMPTY-FAULT>");
 		case INTERFACE:
+			if (!*(usz*)arg.ptr) return self.out_substr("<EMPTY-INTERFACE>");
+			nextcase;
 		case ANY:
 			return self.out_str(*(any*)arg);
 		case OPTIONAL:

--- a/lib/std/io/formatter.c3
+++ b/lib/std/io/formatter.c3
@@ -149,7 +149,7 @@ fn usz? Formatter.out_str(&self, any arg) @private
 		case FAULT:
 			return self.out_substr((*(fault*)arg.ptr).nameof ?: "<EMPTY-FAULT>");
 		case INTERFACE:
-			if (!*(usz*)arg.ptr) return self.out_substr("<EMPTY-INTERFACE>");
+			if (!*(uptr*)arg.ptr) return self.out_substr("<EMPTY-INTERFACE>");
 			nextcase;
 		case ANY:
 			return self.out_str(*(any*)arg);


### PR DESCRIPTION
Printing interface-typed variables without an assigned value cause segfaults within the stdlib `std::io::print` functions. Also, empty fault values, while not really something that will occur, should at least output _something_ when encountered.

Feel free to change the text for what's output on empty/null input for these two.

```c++
module eee;
import std::io;

interface Decl
{
}

struct TestS (Decl, Printable)
{
    int a;
}
fn usz? TestS.to_format(&self, Formatter* formatter) @dynamic => formatter.printf("[%d]", self.a);

faultdef DERP;

fn void main()
{
    TestS a = {100};
    Decl z = &a;
    io::printfn("%s", z);   // works fine to print "[100]"

    fault p; fault o = DERP;
    io::printfn("%s|%s", p, o);   // 'p' prints nothing; should at least show a placeholder

    Decl y;
    io::printfn("%s", y);   // stdlib segfault/runtime-error
}
```

Gives:
```
> c3c compile-run main2.c3
Program linked to executable './eee'.
Launching ./eee
[100]
|eee::DERP

ERROR: 'Out of bounds memory access.'
   [backtraces to std.io.Formatter.out_str]
```

After fix:
```
> c3c compile-run main2.c3
Program linked to executable './eee'.
Launching ./eee
[100]
<EMPTY-FAULT>|eee::DERP
<EMPTY-INTERFACE>
Program completed with exit code 0.
```