### PR TITLE
Add `bitsizeof` to Builtins

### DIFF
--- a/lib/std/core/builtin.c3
+++ b/lib/std/core/builtin.c3
@@ -85,6 +85,10 @@ macro void @swap(#a, #b) @builtin
 	#b = temp;
 }
 
+macro bitsizeof($Type) @builtin @const => $Type.sizeof * 8;
+
+macro @bitsizeof(#expr) @builtin => $sizeof(#expr) * 8;
+
 <*
  Convert an `any` type to a type, returning an failure if there is a type mismatch.
 

--- a/test/unit/stdlib/core/builtintests.c3
+++ b/test/unit/stdlib/core/builtintests.c3
@@ -173,3 +173,20 @@ fn void test_hash_repeat()
 	assert((bool[100]){}.hash() == (bool[100]){}.hash());
 	assert(int.typeid.hash() == int.typeid.hash());
 }
+
+fn void test_bitsizeof()
+{
+	// compile-time
+	assert(bitsizeof(uint128) == 128);
+	assert(bitsizeof(ulong) == 64);
+	assert(bitsizeof(int) == 32);
+	assert(bitsizeof(short) == 16);
+	assert(bitsizeof(char) == 8);
+	assert(bitsizeof(char[200]) == 1600);
+
+	// runtime
+	assert(@bitsizeof((char)0x07) == 8);
+	assert(@bitsizeof(0x1000ul) == 64);
+	assert(@bitsizeof(0) == 32);
+	assert(@bitsizeof((char[*])"abcdefghi") == 72);
+}


### PR DESCRIPTION
There are countless places where the pattern `$sizeof(something) * 8` is used to express the conversion of a type's byte-width to bits.

Most languages usually have a flavor of this macro in order to make conversions readily apparent and readable by maintainers.

More unit tests are welcome for corner cases, but it's rather straightforward.