### PR TITLE
Add compile-time `@min` and `@max`

### DIFF
--- a/lib/std/core/builtin_comparison.c3
+++ b/lib/std/core/builtin_comparison.c3
@@ -126,3 +126,36 @@ macro max(x, ...) @builtin
 	$endif
 }
 
+
+<*
+ @require types::is_numerical($typeof($a))
+*>
+macro @max($a, ...) @builtin @const
+{
+	$if $vacount == 1:
+		return $a > $vaconst[0] ? $a : $vaconst[0];
+	$else
+		var $result = $a;
+		$for var $x = 0; $x < $vacount; ++$x:
+			$if $vaconst[$x] > $result: $result = $vaconst[$x]; $endif
+		$endfor
+		return $result;
+	$endif
+}
+
+<*
+ @require types::is_numerical($typeof($a))
+*>
+macro @min($a, ...) @builtin @const
+{
+	$if $vacount == 1:
+		return $a < $vaconst[0] ? $a : $vaconst[0];
+	$else
+		var $result = $a;
+		$for var $x = 0; $x < $vacount; ++$x:
+			$if $vaconst[$x] < $result: $result = $vaconst[$x]; $endif
+		$endfor
+		return $result;
+	$endif
+}
+

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -7,6 +7,7 @@
 - Add compile-time `@intlog2` macro to math.
 - Add compile-time `@clz` builtin. #2367
 - Add `bitsizeof` macro builtins. #2376
+- Add compile-time `@min` and `@max` builtins. #2378
 
 ### Fixes
 - List.remove_at would incorrectly trigger ASAN.

--- a/test/unit/stdlib/core/builtintests.c3
+++ b/test/unit/stdlib/core/builtintests.c3
@@ -203,3 +203,12 @@ fn void test_bitsizeof()
 	assert(@bitsizeof(0) == 32);
 	assert(@bitsizeof((char[*])"abcdefghi") == 72);
 }
+
+fn void test_ct_min_max()
+{
+	assert(@min(4, 5) == 4);
+	assert(@max(1.234, 1.2345) == 1.2345);
+	assert(@min(4, 5, 6, 7, 8.90, 3.14) == 3.14);
+	assert(@max(0, 0, 1.234, 1.2345, 0.2) == 1.2345);
+	assert(@max(127.9999999, 45 + 46, bitsizeof(uint128)) == 128);
+}


### PR DESCRIPTION
title

```c
    usz $z = max(127, $vaconst[0], $vaconst[1]);
    io::printfn("%d", $z);
```
`Error: Expected a constant expression assigned to $z.` :-1: 