### PR TITLE
Add/Fix OpenBSD `native_cpus`

### DIFF
--- a/lib/std/libc/os/openbsd.c3
+++ b/lib/std/libc/os/openbsd.c3
@@ -56,5 +56,5 @@ struct Stat @if(!env::X86_64)
 
 extern fn CInt stat(ZString path, Stat* stat);
 
-extern fn CInt get_nprocs();
-extern fn CInt get_nprocs_conf();
+extern fn CInt sysctl(CInt *name, CUInt namelen, void *oldp, usz *oldlenp, void *newp, usz newlen);
+

--- a/lib/std/os/openbsd/general.c3
+++ b/lib/std/os/openbsd/general.c3
@@ -1,6 +1,52 @@
 module std::os::openbsd @if(env::OPENBSD);
 import libc, std::os, std::collections::list;
 
+
+// Native `sysctl` identifiers from <sys/sysctl.h>
+const CTL_UNSPEC        =  0;   /* unused */
+const CTL_KERN          =  1;   /* "high kernel": proc, limits */
+const CTL_VM            =  2;   /* virtual memory */
+const CTL_FS            =  3;   /* file system, mount type is next */
+const CTL_NET           =  4;   /* network, see socket.h */
+const CTL_DEBUG         =  5;   /* debugging parameters */
+const CTL_HW            =  6;   /* generic cpu/io */
+const CTL_MACHDEP       =  7;   /* machine dependent */
+const CTL_GAP_UNUSED    =  8;   /* was CTL_USER: removed 2013-04 */
+const CTL_DDB           =  9;   /* DDB user interface, see db_var.h */
+const CTL_VFS           = 10;   /* VFS sysctl's */
+const CTL_MAXID         = 11;   /* number of valid top-level ids */
+
+const HW_MACHINE        =  1;   /* string: machine class */
+const HW_MODEL          =  2;   /* string: specific machine model */
+const HW_NCPU           =  3;   /* int: number of configured cpus */
+const HW_BYTEORDER      =  4;   /* int: machine byte order */
+const HW_PHYSMEM        =  5;   /* int: total memory */
+const HW_USERMEM        =  6;   /* int: non-kernel memory */
+const HW_PAGESIZE       =  7;   /* int: software page size */
+const HW_DISKNAMES      =  8;   /* strings: disk drive names */
+const HW_DISKSTATS      =  9;   /* struct: diskstats[] */
+const HW_DISKCOUNT      = 10;   /* int: number of disks */
+const HW_SENSORS        = 11;   /* node: hardware monitors */
+const HW_CPUSPEED       = 12;   /* get CPU frequency */
+const HW_SETPERF        = 13;   /* set CPU performance % */
+const HW_VENDOR         = 14;   /* string: vendor name */
+const HW_PRODUCT        = 15;   /* string: product name */
+const HW_VERSION        = 16;   /* string: hardware version */
+const HW_SERIALNO       = 17;   /* string: hardware serial number */
+const HW_UUID           = 18;   /* string: universal unique id */
+const HW_PHYSMEM64      = 19;   /* quad: total memory */
+const HW_USERMEM64      = 20;   /* quad: non-kernel memory */
+const HW_NCPUFOUND      = 21;   /* int: number of cpus found */
+const HW_ALLOWPOWERDOWN = 22;   /* allow power button shutdown */
+const HW_PERFPOLICY     = 23;   /* set performance policy */
+const HW_SMT            = 24;   /* int: enable SMT/HT/CMT */
+const HW_NCPUONLINE     = 25;   /* int: number of cpus being used */
+const HW_POWER          = 26;   /* int: machine has wall-power */
+const HW_BATTERY        = 27;   /* node: battery */
+const HW_UCOMNAMES      = 28;   /* strings: ucom names */
+const HW_MAXID          = 29;   /* number of valid hw ids */
+
+
 extern fn ZString* backtrace_symbols_fmt(void **addrlist, usz len, ZString fmt);
 
 fn Backtrace? backtrace_line_parse(Allocator allocator, String obj, String addr2line) @local

--- a/lib/std/threads/os/cpu.c3
+++ b/lib/std/threads/os/cpu.c3
@@ -50,6 +50,21 @@ fn uint native_cpu()
 	return count;
 }
 
+module std::thread::cpu @if(env::OPENBSD);
+import std::os::openbsd;
+import libc;
+
+fn uint native_cpu()
+{
+	uint ncpu;
+	usz len = uint.sizeof;
+	int[2] mib = { openbsd::CTL_HW, openbsd::HW_NCPU };
+
+	libc::sysctl(&mib, 2, &ncpu, &len, null, 0);
+
+	return max(1, ncpu);
+}
+
 module std::thread::cpu @if(env::LINUX);
 import libc;
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -24,6 +24,7 @@
 - Compiler segfault when using bitwise not on number literal cast to bitstruct #2373.
 - Formatter did not properly handle "null" for any, and null for empty faults. #2375
 - Bitstructs no longer overloadable with bitops. #2374
+- Fix `native_cpus` functionality for OpenBSD systems. #2387
 
 ### Stdlib changes
 - Add `==` to `Pair`, `Triple` and TzDateTime. Add print to `Pair` and `Triple`.


### PR DESCRIPTION
Added `sysctl` and related identifiers. Fix `native_cpus` to actually return the right information.

Tested on OpenBSD 7.7.