### PR TITLE
Several fixes for Nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,29 +6,27 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, ... } @ inputs: inputs.flake-utils.lib.eachDefaultSystem 
+  outputs = { self, ... }@inputs: inputs.flake-utils.lib.eachDefaultSystem 
   (system: 
     let pkgs = import inputs.nixpkgs { inherit system; }; 
-        call = set: pkgs.callPackage ./nix/default.nix ( 
-          set // { 
-            rev = self.rev or "unknown"; 
-          } 
-        );
+        c3cBuild = set: pkgs.callPackage ./nix/default.nix (set // { 
+          rev = self.rev or "unknown"; 
+        });
     in {
       packages = {
         default = self.packages.${system}.c3c;
 
-        c3c = call {};
+        c3c = c3cBuild {};
         
-        c3c-checks = pkgs.callPackage ./nix/default.nix { 
+        c3c-checks = c3cBuild { 
           checks = true; 
         };
 
-        c3c-debug = pkgs.callPackage ./nix/default.nix { 
+        c3c-debug = c3cBuild { 
           debug = true; 
         };
 
-        c3c-debug-checks = pkgs.callPackage ./nix/default.nix { 
+        c3c-debug-checks = c3cBuild { 
           debug = true; 
           checks = true; 
         };

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -54,7 +54,9 @@ in llvmPackages.stdenv.mkDerivation (finalAttrs: {
     libffi
   ] ++ lib.optionals llvmPackages.stdenv.hostPlatform.isDarwin [ xar ];
 
-  nativeCheckInputs = [ python3 ];
+  nativeCheckInputs = lib.optionals checks [ 
+    python3
+  ];
 
   doCheck = llvmPackages.stdenv.system == "x86_64-linux" && checks;
 


### PR DESCRIPTION
List of improvements:
- Now compiler properly displays it's build date
- `c3c-debug`, `c3c-checks` and `c3c-debug-checks` now properly display git hash
- Got rid of redundant `python3` input
- A bit of cleanup in .nix files