### PR TITLE
Add compile-time `@range` and runtime `range`/`trange`

### DIFF
--- a/lib/std/core/array.c3
+++ b/lib/std/core/array.c3
@@ -121,7 +121,7 @@ macro tconcat(arr1, arr2) @nodiscard => concat(tmem, arr1, arr2);
  @require @is_empty_macro_slot(stop) ||| (types::is_int($typeof(stop)) && stop <= isz.max && stop >= isz.min)
  @require @is_empty_macro_slot(step) ||| types::is_int($typeof(step))
 *>
-macro isz[] range(Allocator allocator, isz start_stop, stop = EMPTY_MACRO_SLOT, step = EMPTY_MACRO_SLOT, bool inclusive = false)
+macro isz[] range(Allocator allocator, isz start_stop = 0, stop = EMPTY_MACRO_SLOT, step = EMPTY_MACRO_SLOT, bool inclusive = false)
 {
 	// when no stop is provided, the range is expected to be 0..start_stop
 	isz real_start = @is_valid_macro_slot(stop) ? start_stop : 0;
@@ -154,7 +154,7 @@ macro isz[] range(Allocator allocator, isz start_stop, stop = EMPTY_MACRO_SLOT, 
  @require @is_empty_macro_slot(stop) ||| (types::is_int($typeof(stop)) && stop <= isz.max && stop >= isz.min)
  @require @is_empty_macro_slot(step) ||| types::is_int($typeof(step))
 *>
-macro isz[] trange(isz start_stop, stop = EMPTY_MACRO_SLOT, step = EMPTY_MACRO_SLOT, bool inclusive = false)
+macro isz[] trange(isz start_stop = 0, stop = EMPTY_MACRO_SLOT, step = EMPTY_MACRO_SLOT, bool inclusive = false)
 {
 	return range(tmem, start_stop, stop, step, inclusive);
 }

--- a/lib/std/core/array.c3
+++ b/lib/std/core/array.c3
@@ -1,5 +1,8 @@
 module std::core::array;
+
 import std::core::array::slice;
+import std::math;
+
 
 <*
  Returns true if the array contains at least one element, else false
@@ -111,3 +114,47 @@ macro concat(Allocator allocator, arr1, arr2) @nodiscard
  @ensure return.len == arr1.len + arr2.len
 *>
 macro tconcat(arr1, arr2) @nodiscard => concat(tmem, arr1, arr2);
+
+
+<*
+ @param[&inout] allocator
+ @require @is_empty_macro_slot(stop) ||| (types::is_int($typeof(stop)) && stop <= isz.max && stop >= isz.min)
+ @require @is_empty_macro_slot(step) ||| types::is_int($typeof(step))
+*>
+macro isz[] range(Allocator allocator, isz start_stop, stop = EMPTY_MACRO_SLOT, step = EMPTY_MACRO_SLOT, bool inclusive = false)
+{
+	// when no stop is provided, the range is expected to be 0..start_stop
+	isz real_start = @is_valid_macro_slot(stop) ? start_stop : 0;
+	isz real_stop = @is_valid_macro_slot(stop) ? (isz)stop : start_stop;
+	isz real_step = @is_valid_macro_slot(step) ? (isz)step : 1;
+
+	if (!real_step) real_step = 1;   // no zero-step values; force a 1
+
+	if ((real_start > real_stop && real_step > 0) || (real_start < real_stop && real_step < 0)) real_step *= -1;
+
+	isz final_length = (isz)math::ceil((float)math::abs((float)(real_start - real_stop) / real_step));
+	if (inclusive && !((real_start - real_stop) % real_step)) ++final_length;
+
+	if (!final_length) return {};
+
+	isz[] result = allocator::new_array(allocator, isz, final_length);
+
+	for (
+		usz j = 0, isz i = real_start;
+		real_stop > real_start
+			? (inclusive ? i <= real_stop : i < real_stop)
+			: (inclusive ? i >= real_stop : i > real_stop);
+		i += real_step, ++j
+	) result[j] = i;
+
+	return result;
+}
+
+<*
+ @require @is_empty_macro_slot(stop) ||| (types::is_int($typeof(stop)) && stop <= isz.max && stop >= isz.min)
+ @require @is_empty_macro_slot(step) ||| types::is_int($typeof(step))
+*>
+macro isz[] trange(isz start_stop, stop = EMPTY_MACRO_SLOT, step = EMPTY_MACRO_SLOT, bool inclusive = false)
+{
+	return range(tmem, start_stop, stop, step, inclusive);
+}

--- a/lib/std/core/builtin.c3
+++ b/lib/std/core/builtin.c3
@@ -538,20 +538,18 @@ macro bool? @try_catch(#v, #expr, fault expected_fault) @builtin
 
 <*
  @require types::is_int($typeof($start_stop))
- @require @is_empty_macro_slot($stop) ||| types::is_int($typeof($stop))
- @require @is_empty_macro_slot($step) ||| types::is_int($typeof($step))
+ @require @is_empty_macro_slot($stop) ||| (types::is_int($typeof($stop)) &&& $stop <= isz.max &&& $stop >= isz.min)
+ @require @is_empty_macro_slot($step) ||| (types::is_int($typeof($step)) &&& $step != 0)
 *>
 macro isz[*] @range(isz $start_stop, $stop = EMPTY_MACRO_SLOT, $step = EMPTY_MACRO_SLOT, bool $inclusive = false) @builtin @const
 {
 	isz $real_start = @is_valid_macro_slot($stop) ? $start_stop : 0;
-	isz $real_stop = @is_valid_macro_slot($stop) ? (isz)$stop : $start_stop;
-	isz $real_step = @is_valid_macro_slot($step) ? (isz)$step : 1;
+	isz $real_stop  = @is_valid_macro_slot($stop) ? (isz)$stop : $start_stop;
+	isz $real_step  = @is_valid_macro_slot($step) ? (isz)$step : 1;
 
 	$if ($real_start > $real_stop &&& $real_step > 0) ||| ($real_start < $real_stop &&& $real_step < 0):
 		$real_step *= -1;   // flip the sign of 'step' automatically if necessary
 	$endif
-
-	$assert $real_step != 0 : "A compile-time range cannot use a zero 'step' value.";
 
 	// a poor man's CT absolute value |max - min| ensures a positive length integer
 	var $interval = @max($real_start, $real_stop) - @min($real_start, $real_stop);
@@ -578,45 +576,6 @@ macro isz[*] @range(isz $start_stop, $stop = EMPTY_MACRO_SLOT, $step = EMPTY_MAC
 	$endfor
 
 	return $result;
-}
-
-<*
- @param[&inout] allocator
- @require @is_empty_macro_slot(stop) ||| types::is_int($typeof(stop))
- @require @is_empty_macro_slot(step) ||| types::is_int($typeof(step))
-*>
-macro isz[] range(Allocator allocator, isz start_stop, stop = EMPTY_MACRO_SLOT, step = EMPTY_MACRO_SLOT, bool inclusive = false) @builtin
-{
-	// when no stop is provided, the range is expected to be 0..start_stop
-	isz real_start = @is_valid_macro_slot(stop) ? start_stop : 0;
-	isz real_stop = @is_valid_macro_slot(stop) ? (isz)stop : start_stop;
-	isz real_step = @is_valid_macro_slot(step) ? (isz)step : 1;
-
-	if (!real_step) real_step = 1;   // no zero-step values; force a 1
-
-	if ((real_start > real_stop && real_step > 0) || (real_start < real_stop && real_step < 0)) real_step *= -1;
-
-	isz final_length = (isz)math::ceil((float)math::abs((float)(real_start - real_stop) / real_step));
-	if (inclusive && !((real_start - real_stop) % real_step)) ++final_length;
-
-	if (!final_length) return {};
-
-	isz[] result = allocator::new_array(allocator, isz, final_length);
-
-	for (
-		usz j = 0, isz i = real_start;
-		real_stop > real_start
-			? (inclusive ? i <= real_stop : i < real_stop)
-			: (inclusive ? i >= real_stop : i > real_stop);
-		i += real_step, ++j
-	) result[j] = i;
-
-	return result;
-}
-
-macro isz[] trange(isz start_stop, stop = EMPTY_MACRO_SLOT, step = EMPTY_MACRO_SLOT) @builtin
-{
-	return range(tmem, start_stop, stop, step);
 }
 
 

--- a/lib/std/core/builtin.c3
+++ b/lib/std/core/builtin.c3
@@ -541,7 +541,7 @@ macro bool? @try_catch(#v, #expr, fault expected_fault) @builtin
  @require @is_empty_macro_slot($stop) ||| (types::is_int($typeof($stop)) &&& $stop <= isz.max &&& $stop >= isz.min)
  @require @is_empty_macro_slot($step) ||| (types::is_int($typeof($step)) &&& $step != 0)
 *>
-macro isz[*] @range(isz $start_stop, $stop = EMPTY_MACRO_SLOT, $step = EMPTY_MACRO_SLOT, bool $inclusive = false) @builtin @const
+macro isz[*] @range(isz $start_stop = 0, $stop = EMPTY_MACRO_SLOT, $step = EMPTY_MACRO_SLOT, bool $inclusive = false) @builtin @const
 {
 	isz $real_start = @is_valid_macro_slot($stop) ? $start_stop : 0;
 	isz $real_stop  = @is_valid_macro_slot($stop) ? (isz)$stop : $start_stop;

--- a/lib/std/core/builtin.c3
+++ b/lib/std/core/builtin.c3
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::core::builtin;
-import libc, std::hash, std::io, std::os::backtrace;
+import libc, std::hash, std::io, std::os::backtrace, std::math;
 
 
 <*
@@ -534,6 +534,91 @@ macro bool? @try_catch(#v, #expr, fault expected_fault) @builtin
 	#v = res;
 	return false;
 }
+
+
+<*
+ @require types::is_int($typeof($start_stop))
+ @require @is_empty_macro_slot($stop) ||| types::is_int($typeof($stop))
+ @require @is_empty_macro_slot($step) ||| types::is_int($typeof($step))
+*>
+macro isz[*] @range(isz $start_stop, $stop = EMPTY_MACRO_SLOT, $step = EMPTY_MACRO_SLOT, bool $inclusive = false) @builtin @const
+{
+	isz $real_start = @is_valid_macro_slot($stop) ? $start_stop : 0;
+	isz $real_stop = @is_valid_macro_slot($stop) ? (isz)$stop : $start_stop;
+	isz $real_step = @is_valid_macro_slot($step) ? (isz)$step : 1;
+
+	$if ($real_start > $real_stop &&& $real_step > 0) ||| ($real_start < $real_stop &&& $real_step < 0):
+		$real_step *= -1;   // flip the sign of 'step' automatically if necessary
+	$endif
+
+	$assert $real_step != 0 : "A compile-time range cannot use a zero 'step' value.";
+
+	// a poor man's CT absolute value |max - min| ensures a positive length integer
+	var $interval = @max($real_start, $real_stop) - @min($real_start, $real_stop);
+	var $abs_step = ($real_step < 0) ? -$real_step : $real_step;
+
+	isz $final_length = (isz)($interval / (float)$abs_step) + ($interval % $abs_step ? 1 : 0);
+	$if $final_length < 0: $final_length = -$final_length; $endif
+
+	// only add the extra slot if the end value is a multiple of the step
+	$if $inclusive && !($interval % $abs_step): ++$final_length; $endif
+
+	$assert $final_length != 0
+		: "A compile-time range cannot return a zero-length array (start %s, stop %s, step %s).", $real_start, $real_stop, $real_step;
+
+	isz[$final_length] $result;
+
+	$for
+		var $j = 0, var $i = $real_start;
+		$real_stop > $real_start
+			? ($inclusive ? $i <= $real_stop : $i < $real_stop)
+			: ($inclusive ? $i >= $real_stop : $i > $real_stop);
+		++$j, $i += $real_step :
+			$result[$j] = $i;
+	$endfor
+
+	return $result;
+}
+
+<*
+ @param[&inout] allocator
+ @require @is_empty_macro_slot(stop) ||| types::is_int($typeof(stop))
+ @require @is_empty_macro_slot(step) ||| types::is_int($typeof(step))
+*>
+macro isz[] range(Allocator allocator, isz start_stop, stop = EMPTY_MACRO_SLOT, step = EMPTY_MACRO_SLOT, bool inclusive = false) @builtin
+{
+	// when no stop is provided, the range is expected to be 0..start_stop
+	isz real_start = @is_valid_macro_slot(stop) ? start_stop : 0;
+	isz real_stop = @is_valid_macro_slot(stop) ? (isz)stop : start_stop;
+	isz real_step = @is_valid_macro_slot(step) ? (isz)step : 1;
+
+	if (!real_step) real_step = 1;   // no zero-step values; force a 1
+
+	if ((real_start > real_stop && real_step > 0) || (real_start < real_stop && real_step < 0)) real_step *= -1;
+
+	isz final_length = (isz)math::ceil((float)math::abs((float)(real_start - real_stop) / real_step));
+	if (inclusive && !((real_start - real_stop) % real_step)) ++final_length;
+
+	if (!final_length) return {};
+
+	isz[] result = allocator::new_array(allocator, isz, final_length);
+
+	for (
+		usz j = 0, isz i = real_start;
+		real_stop > real_start
+			? (inclusive ? i <= real_stop : i < real_stop)
+			: (inclusive ? i >= real_stop : i > real_stop);
+		i += real_step, ++j
+	) result[j] = i;
+
+	return result;
+}
+
+macro isz[] trange(isz start_stop, stop = EMPTY_MACRO_SLOT, step = EMPTY_MACRO_SLOT) @builtin
+{
+	return range(tmem, start_stop, stop, step);
+}
+
 
 <*
  @require $defined(&#value, (char*)&#value) : "This must be a value that can be viewed as a char array"

--- a/lib/std/core/builtin_comparison.c3
+++ b/lib/std/core/builtin_comparison.c3
@@ -126,3 +126,36 @@ macro max(x, ...) @builtin
 	$endif
 }
 
+
+<*
+ @require types::is_numerical($typeof($a))
+*>
+macro @max($a, ...) @builtin @const
+{
+	$if $vacount == 1:
+		return $a > $vaconst[0] ? $a : $vaconst[0];
+	$else
+		var $result = $a;
+		$for var $x = 0; $x < $vacount; ++$x:
+			$if $vaconst[$x] > $result: $result = $vaconst[$x]; $endif
+		$endfor
+		return $result;
+	$endif
+}
+
+<*
+ @require types::is_numerical($typeof($a))
+*>
+macro @min($a, ...) @builtin @const
+{
+	$if $vacount == 1:
+		return $a < $vaconst[0] ? $a : $vaconst[0];
+	$else
+		var $result = $a;
+		$for var $x = 0; $x < $vacount; ++$x:
+			$if $vaconst[$x] < $result: $result = $vaconst[$x]; $endif
+		$endfor
+		return $result;
+	$endif
+}
+

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -34,6 +34,7 @@
 - Updated hash functions in default hash methods.
 - Added `FixedBlockPool` which is a memory pool for fixed size blocks.
 - Added the experimental `std::core::log` for logging.
+- Added `array::range` and compile-time `@range` builtins.
 
 ## 0.7.4 Change list
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -7,6 +7,7 @@
 - Add compile-time `@intlog2` macro to math.
 - Add compile-time `@clz` builtin. #2367
 - Add `bitsizeof` macro builtins. #2376
+- Add compile-time `@min` and `@max` builtins. #2378
 
 ### Fixes
 - List.remove_at would incorrectly trigger ASAN.

--- a/test/unit/stdlib/core/array.c3
+++ b/test/unit/stdlib/core/array.c3
@@ -37,3 +37,42 @@ fn void concat()
 	defer free(c);
 	assert (c == (int[]){ 2, 3, 1, 2, 3 });
 }
+
+fn void range() => @pool()
+{
+	// quick alloc/free
+	isz[] t = array::range(mem, 3);
+	assert(t.len == 3);
+	mem::free(t.ptr);
+
+	// empty
+	assert({} == array::trange(0));
+	assert({} == array::trange(-10_000, -10_000));
+
+	// ascending
+	assert({0, 1, 2, 3, 4} == array::trange(5));
+	assert({0, 1, 2, 3, 4, 5} == array::trange(5, inclusive: true));
+	assert({0, 2, 4} == array::trange(5, step: 2));
+	assert({0, 2, 4} == array::trange(5, step: 2, inclusive: true));
+	assert({2, 3, 4, 5} == array::trange(2, 5, inclusive: true));
+
+	// descending
+	assert({2, 1, 0, -1, -2, -3, -4} == array::trange(2, -5));
+	assert({0, -1, -2, -3, -4, -5} == array::trange(-5, inclusive: true));
+	assert({-2, -3, -4, -5} == array::trange(-2, -5, inclusive: true));
+	// -- purposefully using the wrong sign for 'step' here to show it will work regardless
+	assert({0, -2, -4} == array::trange(-5, step: 2));
+	assert({0, -2, -4} == array::trange(-5, step: 2, inclusive: true));
+
+	// misc
+	assert({-2, -1, 0, 1} == array::trange(-2, 2));
+	assert({-2, -1, 0, 1, 2} == array::trange(-2, 2, inclusive: true));
+	assert({-18, -8, 2, 12, 22} == array::trange(-18, 25, 10));
+	assert({-18, -8, 2, 12, 22} == array::trange(-18, 25, 10, inclusive: true));
+	assert({2, 4} == array::trange(2, 6, 2));
+
+	// iterate
+	isz z;
+	foreach (i : array::trange(200, step: 25, inclusive: true)) z += i;
+	assert(z == 0 + 25 + 50 + 75 + 100 + 125 + 150 + 175 + 200);
+}

--- a/test/unit/stdlib/core/array.c3
+++ b/test/unit/stdlib/core/array.c3
@@ -47,6 +47,7 @@ fn void range() => @pool()
 
 	// empty
 	assert({} == array::trange(0));
+	assert({} == array::trange());
 	assert({} == array::trange(-10_000, -10_000));
 
 	// ascending
@@ -65,6 +66,8 @@ fn void range() => @pool()
 	assert({0, -2, -4} == array::trange(-5, step: 2, inclusive: true));
 
 	// misc
+	assert({0, 1, 2} == array::trange(stop: 3));
+	assert({0, 1, 2, 3} == array::trange(stop: 3, inclusive: true));
 	assert({-2, -1, 0, 1} == array::trange(-2, 2));
 	assert({-2, -1, 0, 1, 2} == array::trange(-2, 2, inclusive: true));
 	assert({-18, -8, 2, 12, 22} == array::trange(-18, 25, 10));

--- a/test/unit/stdlib/core/builtintests.c3
+++ b/test/unit/stdlib/core/builtintests.c3
@@ -203,3 +203,12 @@ fn void test_bitsizeof()
 	assert(@bitsizeof(0) == 32);
 	assert(@bitsizeof((char[*])"abcdefghi") == 72);
 }
+
+fn void test_ct_min_max()
+{
+	assert(@min(4, 5) == 4);
+	assert(@max(1.234, 1.2345) == 1.2345);
+	assert(@min(4, 5, 6, 7, 8.90, 3.14) == 3.14);
+	assert(@max(0, 0, 1.234, 1.2345, 0.2) == 1.2345);
+	assert(@max(127.9999999, 45 + 46, bitsizeof(uint128)) == 128);
+}

--- a/test/unit/stdlib/core/builtintests.c3
+++ b/test/unit/stdlib/core/builtintests.c3
@@ -231,6 +231,8 @@ fn void range()
 	assert({0, -2, -4} == @range(-5, $step: 2, $inclusive: true));
 
 	// misc
+	assert({0, 1, 2} == @range($stop: 3));
+	assert({0, 1, 2, 3} == @range($stop: 3, $inclusive: true));
 	assert({-2, -1, 0, 1} == @range(-2, 2));
 	assert({-2, -1, 0, 1, 2} == @range(-2, 2, $inclusive: true));
 	assert({-18, -8, 2, 12, 22} == @range(-18, 25, 10));

--- a/test/unit/stdlib/core/builtintests.c3
+++ b/test/unit/stdlib/core/builtintests.c3
@@ -212,3 +212,33 @@ fn void test_ct_min_max()
 	assert(@max(0, 0, 1.234, 1.2345, 0.2) == 1.2345);
 	assert(@max(127.9999999, 45 + 46, bitsizeof(uint128)) == 128);
 }
+
+fn void range()
+{
+	// ascending
+	assert({0, 1, 2, 3, 4} == @range(5));
+	assert({0, 1, 2, 3, 4, 5} == @range(5, $inclusive: true));
+	assert({0, 2, 4} == @range(5, $step: 2));
+	assert({0, 2, 4} == @range(5, $step: 2, $inclusive: true));
+	assert({2, 3, 4, 5} == @range(2, 5, $inclusive: true));
+
+	// descending
+	assert({2, 1, 0, -1, -2, -3, -4} == @range(2, -5));
+	assert({0, -1, -2, -3, -4, -5} == @range(-5, $inclusive: true));
+	assert({-2, -3, -4, -5} == @range(-2, -5, $inclusive: true));
+	// -- purposefully using the wrong sign for 'step' here to show it will work regardless
+	assert({0, -2, -4} == @range(-5, $step: 2));
+	assert({0, -2, -4} == @range(-5, $step: 2, $inclusive: true));
+
+	// misc
+	assert({-2, -1, 0, 1} == @range(-2, 2));
+	assert({-2, -1, 0, 1, 2} == @range(-2, 2, $inclusive: true));
+	assert({-18, -8, 2, 12, 22} == @range(-18, 25, 10));
+	assert({-18, -8, 2, 12, 22} == @range(-18, 25, 10, $inclusive: true));
+	assert({2, 4} == @range(2, 6, 2));
+
+	// iterate
+	isz z;
+	foreach (i : @range(200, $step: 25, $inclusive: true)) z += i;
+	assert(z == 0 + 25 + 50 + 75 + 100 + 125 + 150 + 175 + 200);
+}


### PR DESCRIPTION
This pull request depends on changes from #2378 -- that PR should be merged before this one. I will fix merge conflicts.

-----

Adds a compile-time and runtime `range` functionality, similar to python's [range function](https://docs.python.org/3/library/stdtypes.html#typesseq-range).

```c++
    // compile-time ranging
    $foreach $sample : @range(17):
        $echo @sprintf("SAMPLE: %s", $sample);   // prints "SAMPLE: 0" -> "SAMPLE: 16"
    $endforeach

    // runtime ranging - prints "[0, 2, 4, 6]"
    io::printfn("%s", array::trange(stop: 6, step: 2, inclusive: true));
    // below prints "[-2, 0, 2, 4, 6]"
    io::printfn("%s", array::trange(-2, 6, 2, true));
```

Compile-time ranges are fun to splat with:
```
    isz[] some_sequence = { 1, 2, 3, ...@range(4, 150, $inclusive: true) });
```