### PR TITLE
string: use correct allocator in `replace`

### DIFF
--- a/lib/std/core/string.c3
+++ b/lib/std/core/string.c3
@@ -187,7 +187,7 @@ fn String String.replace(self, Allocator allocator, String needle, String new_st
 	@pool()
 	{
 		String[] split = self.tsplit(needle);
-		return dstring::join(tmem, split, new_str).copy_str(mem);
+		return dstring::join(tmem, split, new_str).copy_str(allocator);
 	};
 }
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -37,6 +37,7 @@
 - Compile time indexing at compile time in a $typeof was no considered compile time.
 - Slicing a constant array with designated initialization would not update the indexes.
 - Fix for bug when `@format` encountered `*` in some cases.
+- Use correct allocator in `replace`.
 
 ### Stdlib changes
 - Add `==` to `Pair`, `Triple` and TzDateTime. Add print to `Pair` and `Triple`.


### PR DESCRIPTION
`replace` accepts an Allocator but uses `mem` instead.