### PR TITLE
Fix compilation error - Update sema_decls.c

### DIFF
--- a/src/compiler/sema_decls.c
+++ b/src/compiler/sema_decls.c
@@ -2309,7 +2309,7 @@ INLINE bool sema_analyse_operator_method(SemaContext *context, Type *parent_type
 			{
 				RETURN_SEMA_ERROR(method, "Only regular overloads can have untyped right hand parameters");
 			}
-			is_wildcard = method->func_decl.is_wildcard_overload = true;
+			is_wildcard = (method->func_decl.is_wildcard_overload = true);
 			second_param = type_void;
 		}
 		second_param = second_param->canonical;


### PR DESCRIPTION
Fix compilation error

```
[ 48%] Building C object CMakeFiles/c3c.dir/src/compiler/sema_passes.c.o
/home/mb/.cache/yay/c3c-git/src/c3c/src/compiler/sema_decls.c: In function ‘sema_analyse_operator_method’:
/home/mb/.cache/yay/c3c-git/src/c3c/src/compiler/sema_decls.c:2312:25: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
 2312 |                         is_wildcard = method->func_decl.is_wildcard_overload = true;
      |                         ^~~~~~~~~~~
```