### PR TITLE
Fix out of bounds access when stdout is empty

### DIFF
--- a/lib/std/os/subprocess.c3
+++ b/lib/std/os/subprocess.c3
@@ -292,6 +292,7 @@ fn String? execute_stdout_to_buffer(char[] buffer, String[] command_line, SubPro
 	SubProcess process = process::create(command_line, options, environment)!;
 	process.join()!;
 	usz len = process.read_stdout(buffer.ptr, buffer.len)!;
+	if (len == 0) return "";
 	return (String)buffer[:len - 1];
 }
 


### PR DESCRIPTION
In execute_stdout_to_buffer() when the process exits without printing to stdout the function would access the buffer to index -1