### PR TITLE
Add `@iter` to provide `.iter()` if it exists

### DIFF
--- a/benchmarks/stdlib/collections/linkedlist.c3
+++ b/benchmarks/stdlib/collections/linkedlist.c3
@@ -1,0 +1,50 @@
+module linkedlist_benchmarks;
+
+import std::collections::linkedlist;
+
+
+LinkedList{int} long_list;
+const HAY = 2;
+const NEEDLE = 1000;
+
+fn void bench_setup() @init
+{
+	set_benchmark_warmup_iterations(3);
+	set_benchmark_max_iterations(4096);
+
+    int[*] haystack = { [0..999] = HAY };
+    long_list = linkedlist::@new{int}(mem, haystack[..]);
+    long_list.push(NEEDLE);
+    long_list.push_all(haystack[..]);
+}
+
+
+// ==============================================================================================
+module linkedlist_benchmarks @benchmark;
+
+String die_str = "Failed to find the value `1`. Is something broken?";
+
+
+fn void foreach_linear()
+{
+    foreach (v : long_list) if (v == NEEDLE) return;
+    runtime::@kill_benchmark(die_str);
+}
+
+fn void foreach_iterator()
+{
+    foreach (v : long_list.iter()) if (v == NEEDLE) return;
+    runtime::@kill_benchmark(die_str);
+}
+
+fn void foreach_r_linear()
+{
+    foreach_r (v : long_list) if (v == NEEDLE) return;
+    runtime::@kill_benchmark(die_str);
+}
+
+fn void foreach_r_iterator()
+{
+    foreach_r (v : long_list.iter()) if (v == NEEDLE) return;
+    runtime::@kill_benchmark(die_str);
+}

--- a/lib/std/collections/linkedlist.c3
+++ b/lib/std/collections/linkedlist.c3
@@ -3,6 +3,8 @@
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::collections::linkedlist{Type};
 
+import std::io;
+
 const ELEMENT_IS_EQUATABLE = types::is_equatable_type(Type);
 
 struct Node @private
@@ -16,8 +18,34 @@ struct LinkedList
 {
 	Allocator allocator;
 	usz size;
-	Node *_first;
-	Node *_last;
+	Node* _first;
+	Node* _last;
+}
+
+fn usz? LinkedList.to_format(&self, Formatter* f) @dynamic
+{
+	usz len;
+	usz list_end = self.len() - 1;
+	len += f.print("{ ")!;
+	foreach (i, e : self.iter()) len += f.printf(i != list_end ? "%s, " : "%s", e)!;
+	len += f.print(" }")!;
+	return len;
+}
+
+macro LinkedList @new(Allocator allocator, Type[] #default_values = {})
+{
+	LinkedList new_list;
+	new_list.init(allocator);
+	new_list.push_all(#default_values);
+	return new_list;
+}
+
+<*
+ @require values::@is_list(#default_values)
+*>
+macro LinkedList @tnew(Type[] #default_values = {})
+{
+	return @new(tmem, #default_values);
 }
 
 <*

--- a/lib/std/collections/linkedlist.c3
+++ b/lib/std/collections/linkedlist.c3
@@ -7,10 +7,10 @@ import std::io;
 
 const ELEMENT_IS_EQUATABLE = types::is_equatable_type(Type);
 
-struct Node @private
+struct Node
 {
-	Node *next;
-	Node *prev;
+	Node* next;
+	Node* prev;
 	Type value;
 }
 
@@ -120,7 +120,7 @@ fn void LinkedList.push(&self, Type value)
 
 fn void LinkedList.push_all(&self, Type[] value)
 {
-	foreach_r (v : value) self.push_front(v);
+	foreach_r (v : value) self.push(v);
 }
 
 fn Type? LinkedList.peek(&self) => self.first() @inline;
@@ -400,4 +400,93 @@ fn void LinkedList.unlink(&self, Node* x) @private
 	}
 	self.free_node(x);
 	self.size--;
+}
+
+
+<*
+ @require values::@is_list(other) &&& $defined(Type z = other[0])
+*>
+fn bool LinkedList.eq(&self, LinkedList other) @operator(==) @if (ELEMENT_IS_EQUATABLE)
+{
+	if (self.len() != values::find_len(other)) return false;
+
+	bool equal = true;
+	foreach (i, v : self.iter()) equal &= v == other[i];
+	return equal;
+}
+
+
+fn LinkedListNodeIterator LinkedList.iter_node(&self)
+{
+	return { .list = self, .current_node = self._first };
+}
+
+fn LinkedListIterator LinkedList.iter(&self)
+{
+	return (LinkedListIterator)self.iter_node();
+}
+
+
+struct LinkedListNodeIterator
+{
+	LinkedList* list;
+	Node* current_node;
+	usz current_index;
+}
+
+fn usz LinkedListNodeIterator.len(&self) @operator(len) => self.list.size;
+
+<*
+ @require index < self.list.size
+*>
+fn Node* LinkedListNodeIterator.get_ref(&self, usz index) @operator(&[])
+{
+	if (index == self.list.size - 1)
+	{
+		self.current_node = self.list._last;
+		self.current_index = index;
+	}
+
+	while (self.current_index != index)
+	{
+		switch
+		{
+			case index < self.current_index:   // reverse iteration
+				self.current_node = self.current_node.prev;
+				self.current_index--;
+			case index > self.current_index:
+				self.current_node = self.current_node.next;
+				self.current_index++;
+		}
+	}
+
+	return self.current_node;
+}
+
+<*
+ @require index < self.list.size
+*>
+fn Node LinkedListNodeIterator.get(&self, usz index) @operator([]) => *(self.get_ref(index));
+
+
+typedef LinkedListIterator = LinkedListNodeIterator;
+
+fn usz LinkedListIterator.len(&self) @operator(len) => self.list.size;
+
+<*
+ @require index < self.list.size
+*>
+fn Type* LinkedListIterator.get_ref(&self, usz index) @operator(&[]) => &((LinkedListNodeIterator*)self).get_ref(index).value;
+
+<*
+ @require index < self.list.size
+*>
+fn Type LinkedListIterator.get(&self, usz index) @operator([]) => ((LinkedListNodeIterator*)self).get(index).value;
+
+<*
+ @require index < self.list.size
+*>
+fn void LinkedListIterator.set(&self, usz index, Type value) @operator([]=)
+{
+	((LinkedListNodeIterator*)self).get_ref(index).value = value;
 }

--- a/lib/std/collections/linkedlist.c3
+++ b/lib/std/collections/linkedlist.c3
@@ -406,13 +406,11 @@ fn void LinkedList.unlink(&self, Node* x) @private
 <*
  @require values::@is_list(other) &&& $defined(Type z = other[0])
 *>
-fn bool LinkedList.eq(&self, LinkedList other) @operator(==) @if (ELEMENT_IS_EQUATABLE)
+macro bool LinkedList.eq(&self, other) @operator(==) @if(ELEMENT_IS_EQUATABLE)
 {
 	if (self.len() != values::find_len(other)) return false;
-
-	bool equal = true;
-	foreach (i, v : self.iter()) equal &= v == other[i];
-	return equal;
+	foreach (i, v : self.iter()) if(v != other[i]) return false;
+	return true;
 }
 
 

--- a/lib/std/collections/linkedlist.c3
+++ b/lib/std/collections/linkedlist.c3
@@ -68,6 +68,11 @@ fn void LinkedList.push_front(&self, Type value)
 	self.size++;
 }
 
+fn void LinkedList.push_front_all(&self, Type[] value)
+{
+	foreach_r (v : value) self.push_front(v);
+}
+
 fn void LinkedList.push(&self, Type value)
 {
 	Node *last = self._last;
@@ -83,6 +88,11 @@ fn void LinkedList.push(&self, Type value)
 		last.next = new_node;
 	}
 	self.size++;
+}
+
+fn void LinkedList.push_all(&self, Type[] value)
+{
+	foreach_r (v : value) self.push_front(v);
 }
 
 fn Type? LinkedList.peek(&self) => self.first() @inline;
@@ -115,7 +125,7 @@ fn void LinkedList.clear(&self)
 	self.size = 0;
 }
 
-fn usz LinkedList.len(&self) @inline => self.size;
+fn usz LinkedList.len(&self) @operator(len) @inline => self.size;
 
 <*
  @require index < self.size
@@ -133,10 +143,11 @@ macro Node* LinkedList.node_at_index(&self, usz index)
 	while (index--) node = node.next;
 	return node;
 }
+
 <*
  @require index < self.size
 *>
-fn Type LinkedList.get(&self, usz index)
+fn Type LinkedList.get(&self, usz index) @operator([])
 {
 	return self.node_at_index(index).value;
 }
@@ -144,10 +155,38 @@ fn Type LinkedList.get(&self, usz index)
 <*
  @require index < self.size
 *>
-fn void LinkedList.set(&self, usz index, Type element)
+fn Type* LinkedList.get_ref(&self, usz index) @operator(&[])
+{
+	return &self.node_at_index(index).value;
+}
+
+<*
+ @require index < self.size
+*>
+fn void LinkedList.set(&self, usz index, Type element) @operator([]=)
 {
 	self.node_at_index(index).value = element;
 }
+
+fn usz? LinkedList.index_of(&self, Type t) @if(ELEMENT_IS_EQUATABLE)
+{
+	for (Node* node = self._first, usz i = 0; node != null; node = node.next, ++i)
+	{
+		if (node.value == t) return i;
+	}
+	return NOT_FOUND?;
+}
+
+fn usz? LinkedList.rindex_of(&self, Type t) @if(ELEMENT_IS_EQUATABLE)
+{
+	for (Node* node = self._last, usz i = self.size - 1; node != null; node = node.prev, --i)
+	{
+		if (node.value == t) return i;
+		if (i == 0) break;
+	}
+	return NOT_FOUND?;
+}
+
 
 <*
  @require index < self.size

--- a/lib/std/collections/linkedlist.c3
+++ b/lib/std/collections/linkedlist.c3
@@ -120,7 +120,7 @@ fn void LinkedList.push(&self, Type value)
 
 fn void LinkedList.push_all(&self, Type[] value)
 {
-	foreach_r (v : value) self.push(v);
+	foreach (v : value) self.push(v);
 }
 
 fn Type? LinkedList.peek(&self) => self.first() @inline;

--- a/lib/std/core/array.c3
+++ b/lib/std/core/array.c3
@@ -216,7 +216,7 @@ macro @product(array, identity_value = 1)
 *>
 macro usz[] @indices_of(Allocator allocator, array, #predicate)
 {
-	usz[] results = allocator::new_array(allocator, usz, find_len(array));
+	usz[] results = allocator::new_array(allocator, usz, values::find_len(array));
 	usz matches;
 
 	$typefrom(@predicate_fn(array)) $predicate = #predicate;
@@ -400,8 +400,8 @@ macro @zip(Allocator allocator, left, right, #operation = EMPTY_MACRO_SLOT, fill
 		$Type = $typeof(#operation).returns;
 	$endif
 
-	usz left_len = find_len(left);
-	usz right_len = find_len(right);
+	usz left_len = values::find_len(left);
+	usz right_len = values::find_len(right);
 
 	$LeftType left_fill;
 	$RightType right_fill;
@@ -496,7 +496,7 @@ macro @tzip(left, right, #operation = EMPTY_MACRO_SLOT, fill_with = EMPTY_MACRO_
 
  @require values::@is_list(left) : "Expected a valid list"
  @require values::@is_list(right) : "Expected a valid list"
- @require find_len(right) >= find_len(left) : `Right side length must be >= the destination (left) side length; consider using a sub-array of data for the assignment.`
+ @require values::find_len(right) >= values::find_len(left) : `Right side length must be >= the destination (left) side length; consider using a sub-array of data for the assignment.`
  @require $defined($typefrom(@zip_into_fn(left, right)) x = #operation) : "The functor must use the same types as the `left` and `right` inputs, and return a value of the `left` type."
 *>
 macro @zip_into(left, right, #operation)

--- a/lib/std/core/array.c3
+++ b/lib/std/core/array.c3
@@ -120,6 +120,17 @@ macro tconcat(arr1, arr2) @nodiscard => concat(tmem, arr1, arr2);
 
 
 <*
+ If the given list object has an iterator method, return the iterator. If not, just return the list.
+
+ @require values::@is_list(list)
+*>
+macro @iter(list)
+{
+	return $defined(list.iter) ??? list.iter() : list;
+}
+
+
+<*
  Apply a reduction/folding operation to an iterable type. This walks along the input array
  and applies an `#operation` to each value, returning it to the `identity` (or "accumulator")
  base value.
@@ -150,7 +161,7 @@ macro tconcat(arr1, arr2) @nodiscard => concat(tmem, arr1, arr2);
 macro @reduce(array, identity, #operation)
 {
 	$typefrom(@reduce_fn(array, identity)) $func = #operation;
-	foreach (index, element : array) identity = $func(identity, element, index);
+	foreach (index, element : @iter(array)) identity = $func(identity, element, index);
 	return identity;
 }
 
@@ -220,7 +231,7 @@ macro usz[] @indices_of(Allocator allocator, array, #predicate)
 	usz matches;
 
 	$typefrom(@predicate_fn(array)) $predicate = #predicate;
-	foreach (index, element : array)
+	foreach (index, element : @iter(array))
 	{
 		if ($predicate(element, index)) results[matches++] = index;
 	}
@@ -306,7 +317,7 @@ macro @tfilter(array, #predicate) @nodiscard
 macro bool @any(array, #predicate)
 {
 	$typefrom(@predicate_fn(array)) $predicate = #predicate;
-	foreach (index, element : array) if ($predicate(element, index)) return true;
+	foreach (index, element : @iter(array)) if ($predicate(element, index)) return true;
 	return false;
 }
 
@@ -324,7 +335,7 @@ macro bool @any(array, #predicate)
 macro bool @all(array, #predicate)
 {
 	$typefrom(@predicate_fn(array)) $predicate = #predicate;
-	foreach (index, element : array) if (!$predicate(element, index)) return false;
+	foreach (index, element : @iter(array)) if (!$predicate(element, index)) return false;
 	return true;
 }
 
@@ -500,7 +511,7 @@ macro @zip_into(left, right, #operation)
 {
 	$typefrom(@zip_into_fn(left, right)) $operation = #operation;
 
-	foreach (i, &v : left) *v = $operation(left[i], right[i]);
+	foreach (i, &v : @iter(left)) *v = $operation(left[i], right[i]);
 }
 
 

--- a/lib/std/core/array.c3
+++ b/lib/std/core/array.c3
@@ -144,7 +144,7 @@ macro tconcat(arr1, arr2) @nodiscard => concat(tmem, arr1, arr2);
  @param identity
  @param #operation : "The reduction/folding labmda function or function pointer to apply."
 
- @require @is_valid_list(array) : "Expected a valid list"
+ @require values::@is_list(array) : "Expected a valid list"
  @require $defined($typefrom(@reduce_fn(array, identity)) $func = #operation) : "Invalid lambda or function pointer type"
 *>
 macro @reduce(array, identity, #operation)
@@ -163,7 +163,7 @@ macro @reduce(array, identity, #operation)
  @param [in] array
  @param identity_value : "The base accumulator value to use for the sum"
 
- @require @is_valid_list(array) : "Expected a valid list"
+ @require values::@is_list(array) : "Expected a valid list"
  @require $defined(array[0] + array[0]) : "Array element type must implement the '+' operator"
  @require $defined($typeof(array[0]) t = identity_value) : "The identity type must be assignable to the array element type"
 *>
@@ -181,7 +181,7 @@ macro @sum(array, identity_value = 0)
  @param [in] array
  @param identity_value : "The base accumulator value to use for the product"
 
- @require @is_valid_list(array) : "Expected a valid list"
+ @require values::@is_list(array) : "Expected a valid list"
  @require $defined(array[0] * array[0]) : "Array element type must implement the '*' operator"
  @require $defined($typeof(array[0]) t = identity_value) : "The identity type must be assignable to the array element type"
 *>
@@ -211,7 +211,7 @@ macro @product(array, identity_value = 1)
  @param [in] array
  @param #predicate
 
- @require @is_valid_list(array) : "Expected a valid list"
+ @require values::@is_list(array) : "Expected a valid list"
  @require $defined($typefrom(@predicate_fn(array)) p = #predicate)
 *>
 macro usz[] @indices_of(Allocator allocator, array, #predicate)
@@ -234,7 +234,7 @@ macro usz[] @indices_of(Allocator allocator, array, #predicate)
  @param [in] array
  @param #predicate
 
- @require @is_valid_list(array) : "Expected a valid list"
+ @require values::@is_list(array) : "Expected a valid list"
  @require $defined($typefrom(@predicate_fn(array)) p = #predicate)
 *>
 macro usz[] @tindices_of(array, #predicate)
@@ -259,7 +259,7 @@ macro usz[] @tindices_of(array, #predicate)
  @param [in] array
  @param #predicate
 
- @require @is_valid_list(array) : "Expected a valid list"
+ @require values::@is_list(array) : "Expected a valid list"
  @require $defined($typefrom(@predicate_fn(array)) p = #predicate)
 *>
 macro @filter(Allocator allocator, array, #predicate) @nodiscard
@@ -284,7 +284,7 @@ macro @filter(Allocator allocator, array, #predicate) @nodiscard
  @param [in] array
  @param #predicate
 
- @require @is_valid_list(array) : "Expected a valid list"
+ @require values::@is_list(array) : "Expected a valid list"
  @require $defined($typefrom(@predicate_fn(array)) p = #predicate)
 *>
 macro @tfilter(array, #predicate) @nodiscard
@@ -300,7 +300,7 @@ macro @tfilter(array, #predicate) @nodiscard
  @param [in] array
  @param #predicate
 
- @require @is_valid_list(array) : "Expected a valid list"
+ @require values::@is_list(array) : "Expected a valid list"
  @require $defined($typefrom(@predicate_fn(array)) p = #predicate)
 *>
 macro bool @any(array, #predicate)
@@ -318,7 +318,7 @@ macro bool @any(array, #predicate)
  @param [in] array
  @param #predicate
 
- @require @is_valid_list(array) : "Expected a valid list"
+ @require values::@is_list(array) : "Expected a valid list"
  @require $defined($typefrom(@predicate_fn(array)) p = #predicate)
 *>
 macro bool @all(array, #predicate)
@@ -384,7 +384,7 @@ macro bool @all(array, #predicate)
  @param #operation : "The function to apply. Must have a signature of `$typeof(a) (a, b)`, where the type of 'a' and 'b' is the element type of left/right respectively."
  @param fill_with : "The value used to fill or pad the shorter iterable to the length of the longer one while zipping."
 
- @require @is_valid_list(left) &&& @is_valid_list(right) : "Left and right sides must be integer indexable"
+ @require values::@is_list(left) &&& values::@is_list(right) : "Left and right sides must be integer indexable"
  @require @is_valid_operation(#operation, left, right) : "The operator must take two parameters matching the elements of the left and right side"
  @require @is_valid_fill(left, right, fill_with) : "The specified fill value does not match either the left or the right array's underlying type."
 
@@ -458,7 +458,7 @@ macro @zip(Allocator allocator, left, right, #operation = EMPTY_MACRO_SLOT, fill
  @param #operation : "The function to apply. Must have a signature of `$typeof(a) (a, b)`, where the type of 'a' and 'b' is the element type of left/right respectively."
  @param fill_with : "The value used to fill or pad the shorter iterable to the length of the longer one while zipping."
 
- @require @is_valid_list(left) &&& @is_valid_list(right) : "Left and right sides must be integer indexable"
+ @require values::@is_list(left) &&& values::@is_list(right) : "Left and right sides must be integer indexable"
  @require @is_valid_operation(#operation, left, right) : "The operator must take two parameters matching the elements of the left and right side"
  @require @is_valid_fill(left, right, fill_with) : "The specified fill value does not match either the left or the right array's underlying type."
 
@@ -494,8 +494,8 @@ macro @tzip(left, right, #operation = EMPTY_MACRO_SLOT, fill_with = EMPTY_MACRO_
  @param [in] right : `Slice to apply in the functor/operation.`
  @param #operation : "The function to apply. Must have a signature of `$typeof(a) (a, b)`, where the type of 'a' and 'b' is the element type of left/right respectively."
 
- @require @is_valid_list(left) : "Expected a valid list"
- @require @is_valid_list(right) : "Expected a valid list"
+ @require values::@is_list(left) : "Expected a valid list"
+ @require values::@is_list(right) : "Expected a valid list"
  @require find_len(right) >= find_len(left) : `Right side length must be >= the destination (left) side length; consider using a sub-array of data for the assignment.`
  @require $defined($typefrom(@zip_into_fn(left, right)) x = #operation) : "The functor must use the same types as the `left` and `right` inputs, and return a value of the `left` type."
 *>
@@ -538,11 +538,6 @@ macro bool @is_valid_operation(#operation, #left, #right) @const
 	$endswitch
 }
 
-macro bool @is_valid_list(#expr) @const
-{
-	return $defined(#expr[0]) &&& ($defined(#expr.len) ||| $defined(#expr.len()));
-}
-
 macro bool @is_valid_fill(left, right, fill_with)
 {
 	if (@is_empty_macro_slot(fill_with)) return true;
@@ -551,5 +546,3 @@ macro bool @is_valid_fill(left, right, fill_with)
 	if (left_len == right_len) return true;
 	return left_len > right_len ? $defined(($typeof(right[0]))fill_with) : $defined(($typeof(left[0]))fill_with);
 }
-
-macro usz find_len(list) => $defined(list.len()) ??? list.len() : list.len;

--- a/lib/std/core/runtime_benchmark.c3
+++ b/lib/std/core/runtime_benchmark.c3
@@ -1,5 +1,5 @@
 module std::core::runtime;
-import libc, std::time, std::io, std::sort, std::math, std::collections::map;
+import libc, std::time, std::io, std::sort, std::math, std::collections::map, std::os;
 
 alias BenchmarkFn = fn void ();
 
@@ -56,6 +56,7 @@ long cycle_stop @local;
 DString benchmark_log @local;
 bool benchmark_warming @local;
 uint this_iteration @local;
+bool benchmark_stop @local;
 
 macro @start_benchmark()
 {
@@ -67,6 +68,12 @@ macro @end_benchmark()
 {
 	benchmark_nano_seconds = benchmark_clock.mark();
 	cycle_stop = $$sysclock();
+}
+
+macro @kill_benchmark(String format, ...)
+{
+	@log_benchmark(format, $vasplat);
+	benchmark_stop = true;
 }
 
 macro @log_benchmark(msg, args...) => @pool()
@@ -133,6 +140,7 @@ fn bool run_benchmarks(BenchmarkUnit[] benchmarks)
 			@start_benchmark();   // can be overridden by calls inside the unit's func
 
 			unit.func() @inline;
+			if (benchmark_stop) return false;
 
 			if (benchmark_nano_seconds == (NanoDuration){}) @end_benchmark();   // only mark when it wasn't already by the unit.func
 

--- a/lib/std/core/runtime_benchmark.c3
+++ b/lib/std/core/runtime_benchmark.c3
@@ -1,5 +1,5 @@
 module std::core::runtime;
-import libc, std::time, std::io, std::sort, std::math, std::collections::map, std::os;
+import libc, std::time, std::io, std::sort, std::math, std::collections::map;
 
 alias BenchmarkFn = fn void ();
 

--- a/lib/std/core/values.c3
+++ b/lib/std/core/values.c3
@@ -22,6 +22,10 @@ macro bool @is_const(#foo) @const @builtin @deprecated("use '$defined(var $v = e
 {
 	return $defined(var $v = #foo);
 }
+macro bool @is_list(#expr) @const
+{
+	return $defined(#expr[0]) &&& ($defined(#expr.len) ||| $defined(#expr.len()));
+}
 
 macro promote_int(x)
 {
@@ -31,6 +35,8 @@ macro promote_int(x)
 		return x;
 	$endif
 }
+
+macro usz find_len(list) => $defined(list.len()) ??? list.len() : list.len;
 
 <*
  Select between two values at compile time,

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -107,7 +107,10 @@
 - Added array `@reduce`, `@filter`, `@any`, `@all`, `@sum`, `@product`, and `@indices_of` macros.
 - `String.bformat` has reduced overhead.
 - Supplemental `roundeven` has a normal implementation.
-- Add operators to `LinkedList` to support `[]` indexing and `foreach`/`foreach_r`.
+- Add `LinkedList` iterator to support `[]` and `foreach`/`foreach_r`. #2438
+- Make `LinkedList` printable and add `==` operator. #2438
+- Add `values::@is_list` to ensure an expression is indexable. #2438
+- Add `values::find_len` to get an object's length with `.len` or `.len()` dynamically. #2438
 
 ## 0.7.4 Change list
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -107,6 +107,7 @@
 - Added array `@reduce`, `@filter`, `@any`, `@all`, `@sum`, `@product`, and `@indices_of` macros.
 - `String.bformat` has reduced overhead.
 - Supplemental `roundeven` has a normal implementation.
+- Add operators to `LinkedList` to support `[]` indexing and `foreach`/`foreach_r`.
 
 ## 0.7.4 Change list
 

--- a/test/unit/stdlib/collections/linkedlist.c3
+++ b/test/unit/stdlib/collections/linkedlist.c3
@@ -5,11 +5,10 @@ alias IntList = LinkedList{int};
 
 fn void test_is_initialized()
 {
-	IntList test;
-	
-	assert(!test.is_initialized());
+	IntList test;	
+	test::@check(!test.is_initialized());
 	test.init(mem);
-	assert(test.is_initialized());
+	test::@check(test.is_initialized());
 	test.free();
 }
 
@@ -18,13 +17,13 @@ fn void test_push_front()
 	IntList list;
 	defer list.free();
 	list.push_front(23);
-	assert(list.len() == 1);
-	assert(list.first()!! == 23);
-	assert(list.last()!! == 23);
+	test::eq(list.len(), 1);
+	test::eq(list.first()!!, 23);
+	test::eq(list.last()!!, 23);
 	list.push_front(55);
-	assert(list.len() == 2);
-	assert(list.last()!! == 23);
-	assert(list.first()!! == 55);
+	test::eq(list.len(), 2);
+	test::eq(list.last()!!, 23);
+	test::eq(list.first()!!, 55);
 
 }
 
@@ -33,58 +32,53 @@ fn void test_push()
 	IntList list;
 	defer list.free();
 	list.push(23);
-	assert(list.len() == 1);
-	assert(list.first()!! == 23);
-	assert(list.last()!! == 23);
+	test::eq(list.len(), 1);
+	test::eq(list.first()!!, 23);
+	test::eq(list.last()!!, 23);
 	list.push(55);
-	assert(list.len() == 2);
-	assert(list.last()!! == 55);
-	assert(list.first()!! == 23);
+	test::eq(list.len(), 2);
+	test::eq(list.last()!!, 55);
+	test::eq(list.first()!!, 23);
 }
 
 fn void test_get()
 {
 	IntList list;
 	defer list.free();
-	list.push(23);
-	list.push(55);
-	list.push(-3);
-	assert(list.get(2) == -3);
-	assert(list.get(1) == 55);
-	assert(list.get(0) == 23);
+	list.push_all({ 23, 55, -3 });
+	test::eq(list.get(2), -3);
+	test::eq(list.get(1), 55);
+	test::eq(list.get(0), 23);
+	test::eq(list[0], 23);
 }
 
 fn void test_insert()
 {
 	IntList list;
 	defer list.free();
-	list.push(-3);
-	list.push(55);
-	list.push(23);
+	list.push_all({ -3, 55, 23 });
 	list.insert_at(0, 1);
 	list.insert_at(2, 11);
 	list.insert_at(4, 111);
 	list.insert_at(6, 1111);
-	assert(list.get(0) == 1);
-	assert(list.get(1) == -3);
-	assert(list.get(2) == 11);
-	assert(list.get(3) == 55);
-	assert(list.get(4) == 111);
-	assert(list.get(5) == 23);
-	assert(list.get(6) == 1111);
+	test::eq(list.get(0), 1);
+	test::eq(list.get(1), -3);
+	test::eq(list.get(2), 11);
+	test::eq(list.get(3), 55);
+	test::eq(list.get(4), 111);
+	test::eq(list.get(5), 23);
+	test::eq(list.get(6), 1111);
 }
 
 fn void test_set()
 {
 	IntList list;
 	defer list.free();
-    list.push(-3);
-	list.push(55);
-	list.push(23);
+	list.push_all({ -3, 55, 23 });
 	for (int i = 0; i < 3; i++) list.set(i, list.get(i) + 1);
-	assert(list.get(0) == -2);
-	assert(list.get(1) == 56);
-	assert(list.get(2) == 24);
+	test::eq(list.get(0), -2);
+	test::eq(list.get(1), 56);
+	test::eq(list.get(2), 24);
 }
 
 fn void test_remove_at()
@@ -96,10 +90,10 @@ fn void test_remove_at()
 	list.remove_at(1);
 	list.remove_at(7);
 	list.remove_at(5);
-	assert(list.get(0) == 1);
-	assert(list.get(1) == 3);
-	assert(list.get(5) == 8);
-	assert(list.get(4) == 6);
+	test::eq(list.get(0), 1);
+	test::eq(list.get(1), 3);
+	test::eq(list.get(5), 8);
+	test::eq(list.get(4), 6);
 }
 
 fn void test_remove()
@@ -110,138 +104,162 @@ fn void test_remove()
 	for (int i = 0; i < 10; i++) list.push(5);
 	list.push(2);
 	list.remove(5);
-	assert(list.len() == 2);
+	test::eq(list.len(), 2);
 }
 
 fn void test_remove_first_match()
 {
 	IntList list;
 	defer list.free();
-	list.push(23);
-	list.push(55);
-	list.push(-3);
-	assert(list.remove_first_match(23));
-	assert(list.pop()!! == -3);
-	assert(list.pop()!! == 55);
-	assert(!list.len());
+	list.push_all({ 23, 55, -3 });
+	test::@check(list.remove_first_match(23));
+	test::eq(list.pop()!!, -3);
+	test::eq(list.pop()!!, 55);
+	test::@check(!list.len());
 
-	list.push(23);
-	list.push(55);
-	list.push(-3);
-	assert(list.remove_first_match(55));
-	assert(list.pop()!! == -3);
-	assert(list.pop()!! == 23);
-	assert(!list.len());
+	list.push_all({ 23, 55, -3 });
+	test::@check(list.remove_first_match(55));
+	test::eq(list.pop()!!, -3);
+	test::eq(list.pop()!!, 23);
+	test::@check(!list.len());
 
-	list.push(23);
-	list.push(55);
-	list.push(-3);
-	assert(list.remove_first_match(-3));
-	assert(list.pop()!! == 55);
-	assert(list.pop()!! == 23);
-	assert(!list.len());
+	list.push_all({ 23, 55, -3 });
+	test::@check(list.remove_first_match(-3));
+	test::eq(list.pop()!!, 55);
+	test::eq(list.pop()!!, 23);
+	test::@check(!list.len());
 }
 
 fn void test_remove_last_match()
 {
 	IntList list;
 	defer list.free();
-	list.push(23);
-	list.push(55);
-	list.push(-3);
-	assert(list.remove_last_match(23));
-	assert(list.pop()!! == -3);
-	assert(list.pop()!! == 55);
-	assert(!list.len());
+	list.push_all({ 23, 55, -3 });
+	test::@check(list.remove_last_match(23));
+	test::eq(list.pop()!!, -3);
+	test::eq(list.pop()!!, 55);
+	test::@check(!list.len());
 
-	list.push(23);
-	list.push(55);
-	list.push(-3);
-	assert(list.remove_last_match(55));
-	assert(list.pop()!! == -3);
-	assert(list.pop()!! == 23);
-	assert(!list.len());
+	list.push_all({ 23, 55, -3 });
+	test::@check(list.remove_last_match(55));
+	test::eq(list.pop()!!, -3);
+	test::eq(list.pop()!!, 23);
+	test::@check(!list.len());
 
-	list.push(23);
-	list.push(55);
-	list.push(-3);
-	assert(list.remove_last_match(-3));
-	assert(list.pop()!! == 55);
-	assert(list.pop()!! == 23);
-	assert(!list.len());
+	list.push_all({ 23, 55, -3 });
+	test::@check(list.remove_last_match(-3));
+	test::eq(list.pop()!!, 55);
+	test::eq(list.pop()!!, 23);
+	test::@check(!list.len());
 }
 
 fn void test_pop()
 {
 	IntList list;
 	defer list.free();
-	list.push(23);
+	list.push_all({ 23, 55, -3 });
+	test::eq(list.len(), 3);
+	test::eq(list.first()!!, 23);
+	test::eq(list.last()!!, -3);
+	test::eq(list.pop()!!, -3);
+	test::eq(list.len(), 2);
+	test::eq(list.first()!!, 23);
+	test::eq(list.last()!!, 55);
+	test::eq(list.pop()!!, 55);
+	test::eq(list.first()!!, 23);
+	test::eq(list.last()!!, 23);
+	test::eq(list.pop()!!, 23);
+	test::eq(list.len(), 0);
+	test::@check(@catch(list.pop()));
+	test::eq(list.len(), 0);
 	list.push(55);
-	list.push(-3);
-	assert(list.len() == 3);
-	assert(list.first()!! == 23);
-	assert(list.last()!! == -3);
-	assert(list.pop()!! == -3);
-	assert(list.len() == 2);
-	assert(list.first()!! == 23);
-	assert(list.last()!! == 55);
-	assert(list.pop()!! == 55);
-	assert(list.first()!! == 23);
-	assert(list.last()!! == 23);
-	assert(list.pop()!! == 23);
-	assert(list.len() == 0);
-	assert(@catch(list.pop()));
-	assert(list.len() == 0);
-	list.push(55);
-	assert(list.len() == 1);
+	test::eq(list.len(), 1);
 }
 
 fn void test_remove_last()
 {
 	IntList list;
 	defer list.free();
-	list.push(23);
+	list.push_all({ 23, 55, -3 });
+	test::eq(list.len(), 3);
+	test::eq(list.first()!!, 23);
+	test::eq(list.last()!!, -3);
+	test::@check(@ok(list.remove_last()));
+	test::eq(list.len(), 2);
+	test::eq(list.first()!!, 23);
+	test::eq(list.last()!!, 55);
+	test::@check(@ok(list.remove_last()));
+	test::eq(list.first()!!, 23);
+	test::eq(list.last()!!, 23);
+	test::@check(@ok(list.remove_last()));
+	test::eq(list.len(), 0);
+	test::@check(@catch(list.pop()));
+	test::eq(list.len(), 0);
 	list.push(55);
-	list.push(-3);
-	assert(list.len() == 3);
-	assert(list.first()!! == 23);
-	assert(list.last()!! == -3);
-	assert(@ok(list.remove_last()));
-	assert(list.len() == 2);
-	assert(list.first()!! == 23);
-	assert(list.last()!! == 55);
-	assert(@ok(list.remove_last()));
-	assert(list.first()!! == 23);
-	assert(list.last()!! == 23);
-	assert(@ok(list.remove_last()));
-	assert(list.len() == 0);
-	assert(@catch(list.pop()));
-	assert(list.len() == 0);
-	list.push(55);
-	assert(list.len() == 1);
+	test::eq(list.len(), 1);
 }
 
 fn void test_remove_first()
 {
 	IntList list;
 	defer list.free();
-	list.push(23);
+	list.push_all({ 23, 55, -3 });
+	test::eq(list.len(), 3);
+	test::eq(list.first()!!, 23);
+	test::eq(list.last()!!, -3);
+	test::@check(@ok(list.remove_first()));
+	test::eq(list.len(), 2);
+	test::eq(list.last()!!, -3);
+	test::eq(list.first()!!, 55);
+	test::@check(@ok(list.remove_first()));
+	test::eq(list.last()!!, -3);
+	test::eq(list.first()!!, -3);
+	test::@check(@ok(list.remove_first()));
+	test::eq(list.len(), 0);
+	test::@check(@catch(list.remove_first()));
+	test::eq(list.len(), 0);
 	list.push(55);
-	list.push(-3);
-	assert(list.len() == 3);
-	assert(list.first()!! == 23);
-	assert(list.last()!! == -3);
-	assert(@ok(list.remove_first()));
-	assert(list.len() == 2);
-	assert(list.last()!! == -3);
-	assert(list.first()!! == 55);
-	assert(@ok(list.remove_first()));
-	assert(list.last()!! == -3);
-	assert(list.first()!! == -3);
-	assert(@ok(list.remove_first()));
-	assert(list.len() == 0);
-	assert(@catch(list.remove_first()));
-	assert(list.len() == 0);
-	list.push(55);
-	assert(list.len() == 1);
+	test::eq(list.len(), 1);
+}
+
+fn void test_push_all_ordering()
+{
+	IntList l;
+	defer l.free();
+	l.push_all({ 23, 45, 66 });
+	test::eq(l[0], 23);
+	test::eq(l[1], 45);
+	test::eq(l[2], 66);
+
+	IntList l2;
+	defer l2.free();
+	l2.push_all({ 23, 45, 66 });
+	l2.push_front_all({ 3, 6 });
+	test::eq(l2[0], 3);
+	test::eq(l2[1], 6);
+	test::eq(l2[2], 23);
+	test::eq(l2[3], 45);
+	test::eq(l2[4], 66);
+}
+
+fn void test_index_of()
+{
+	IntList list;
+	defer list.free();
+	list.push_all({ 23, 55, 55, -3 });
+	test::@error(list.index_of(20), NOT_FOUND);
+	test::eq(list.index_of(55)!!, 1);
+	test::eq(list.rindex_of(55)!!, 2);
+}
+
+fn void test_operators()
+{
+	IntList list;
+	defer list.free();
+	list.push_all({ 17, 109, 2, 8 });
+	foreach (i, &e : list) *e += 2;
+	test::eq(list[0], 19);
+	test::eq(list[1], 111);
+	test::eq(list[2], 4);
+	test::eq(list[3], 10);
 }

--- a/test/unit/stdlib/collections/linkedlist.c3
+++ b/test/unit/stdlib/collections/linkedlist.c3
@@ -12,10 +12,9 @@ fn void test_is_initialized()
 	test.free();
 }
 
-fn void test_push_front()
+fn void test_push_front() => @pool()
 {
-	IntList list;
-	defer list.free();
+	IntList list = linkedlist::@tnew{int}();
 	list.push_front(23);
 	test::eq(list.len(), 1);
 	test::eq(list.first()!!, 23);
@@ -27,10 +26,9 @@ fn void test_push_front()
 
 }
 
-fn void test_push()
+fn void test_push() => @pool()
 {
-	IntList list;
-	defer list.free();
+	IntList list = linkedlist::@tnew{int}();
 	list.push(23);
 	test::eq(list.len(), 1);
 	test::eq(list.first()!!, 23);
@@ -41,22 +39,18 @@ fn void test_push()
 	test::eq(list.first()!!, 23);
 }
 
-fn void test_get()
+fn void test_get() => @pool()
 {
-	IntList list;
-	defer list.free();
-	list.push_all({ 23, 55, -3 });
+	IntList list = linkedlist::@tnew{int}({ 23, 55, -3 });
 	test::eq(list.get(2), -3);
 	test::eq(list.get(1), 55);
 	test::eq(list.get(0), 23);
 	test::eq(list[0], 23);
 }
 
-fn void test_insert()
+fn void test_insert() => @pool()
 {
-	IntList list;
-	defer list.free();
-	list.push_all({ -3, 55, 23 });
+	IntList list = linkedlist::@tnew{int}({ -3, 55, 23 });
 	list.insert_at(0, 1);
 	list.insert_at(2, 11);
 	list.insert_at(4, 111);
@@ -70,21 +64,18 @@ fn void test_insert()
 	test::eq(list.get(6), 1111);
 }
 
-fn void test_set()
+fn void test_set() => @pool()
 {
-	IntList list;
-	defer list.free();
-	list.push_all({ -3, 55, 23 });
+	IntList list = linkedlist::@tnew{int}({ -3, 55, 23 });
 	for (int i = 0; i < 3; i++) list.set(i, list.get(i) + 1);
 	test::eq(list.get(0), -2);
 	test::eq(list.get(1), 56);
 	test::eq(list.get(2), 24);
 }
 
-fn void test_remove_at()
+fn void test_remove_at() => @pool()
 {
-	IntList list;
-	defer list.free();
+	IntList list = linkedlist::@tnew{int}();
 	for (int i = 0; i < 10; i++) list.push(i);
 	list.remove_at(0);
 	list.remove_at(1);
@@ -96,10 +87,9 @@ fn void test_remove_at()
 	test::eq(list.get(4), 6);
 }
 
-fn void test_remove()
+fn void test_remove() => @pool()
 {
-	IntList list;
-	defer list.free();
+	IntList list = linkedlist::@tnew{int}();
 	list.push(2);
 	for (int i = 0; i < 10; i++) list.push(5);
 	list.push(2);
@@ -107,10 +97,10 @@ fn void test_remove()
 	test::eq(list.len(), 2);
 }
 
-fn void test_remove_first_match()
+fn void test_remove_first_match()   // no @pool
 {
 	IntList list;
-	defer list.free();
+	defer list.free();   // left this to ensure .free() remains valid and functional
 	list.push_all({ 23, 55, -3 });
 	test::@check(list.remove_first_match(23));
 	test::eq(list.pop()!!, -3);
@@ -130,11 +120,9 @@ fn void test_remove_first_match()
 	test::@check(!list.len());
 }
 
-fn void test_remove_last_match()
+fn void test_remove_last_match() => @pool()
 {
-	IntList list;
-	defer list.free();
-	list.push_all({ 23, 55, -3 });
+	IntList list = linkedlist::@tnew{int}({ 23, 55, -3 });
 	test::@check(list.remove_last_match(23));
 	test::eq(list.pop()!!, -3);
 	test::eq(list.pop()!!, 55);
@@ -153,11 +141,9 @@ fn void test_remove_last_match()
 	test::@check(!list.len());
 }
 
-fn void test_pop()
+fn void test_pop() => @pool()
 {
-	IntList list;
-	defer list.free();
-	list.push_all({ 23, 55, -3 });
+	IntList list = linkedlist::@tnew{int}({ 23, 55, -3 });
 	test::eq(list.len(), 3);
 	test::eq(list.first()!!, 23);
 	test::eq(list.last()!!, -3);
@@ -176,11 +162,9 @@ fn void test_pop()
 	test::eq(list.len(), 1);
 }
 
-fn void test_remove_last()
+fn void test_remove_last() => @pool()
 {
-	IntList list;
-	defer list.free();
-	list.push_all({ 23, 55, -3 });
+	IntList list = linkedlist::@tnew{int}({ 23, 55, -3 });
 	test::eq(list.len(), 3);
 	test::eq(list.first()!!, 23);
 	test::eq(list.last()!!, -3);
@@ -199,11 +183,9 @@ fn void test_remove_last()
 	test::eq(list.len(), 1);
 }
 
-fn void test_remove_first()
+fn void test_remove_first() => @pool()
 {
-	IntList list;
-	defer list.free();
-	list.push_all({ 23, 55, -3 });
+	IntList list = linkedlist::@tnew{int}({ 23, 55, -3 });
 	test::eq(list.len(), 3);
 	test::eq(list.first()!!, 23);
 	test::eq(list.last()!!, -3);
@@ -222,18 +204,14 @@ fn void test_remove_first()
 	test::eq(list.len(), 1);
 }
 
-fn void test_push_all_ordering()
+fn void test_push_all_ordering() => @pool()
 {
-	IntList l;
-	defer l.free();
-	l.push_all({ 23, 45, 66 });
+	IntList l = linkedlist::@tnew{int}({ 23, 45, 66 });
 	test::eq(l[0], 23);
 	test::eq(l[1], 45);
 	test::eq(l[2], 66);
 
-	IntList l2;
-	defer l2.free();
-	l2.push_all({ 23, 45, 66 });
+	IntList l2 = linkedlist::@tnew{int}({ 23, 45, 66 });
 	l2.push_front_all({ 3, 6 });
 	test::eq(l2[0], 3);
 	test::eq(l2[1], 6);
@@ -242,24 +220,37 @@ fn void test_push_all_ordering()
 	test::eq(l2[4], 66);
 }
 
-fn void test_index_of()
+fn void test_index_of() => @pool()
 {
-	IntList list;
-	defer list.free();
-	list.push_all({ 23, 55, 55, -3 });
+	IntList list = linkedlist::@tnew{int}({ 23, 55, 55, -3 });
 	test::@error(list.index_of(20), NOT_FOUND);
 	test::eq(list.index_of(55)!!, 1);
 	test::eq(list.rindex_of(55)!!, 2);
 }
 
-fn void test_operators()
+fn void test_operators() => @pool()
 {
-	IntList list;
-	defer list.free();
-	list.push_all({ 17, 109, 2, 8 });
+	IntList list = linkedlist::@tnew{int}({ 17, 109, 2, 8 });
 	foreach (i, &e : list) *e += 2;
 	test::eq(list[0], 19);
 	test::eq(list[1], 111);
 	test::eq(list[2], 4);
 	test::eq(list[3], 10);
+}
+
+fn void test_iterator_set() => @pool()
+{
+	IntList list = linkedlist::@tnew{int}({ 17, 109, 2, 8 });
+	IntList expected = linkedlist::@tnew{int}({1, 2, 3, 4});
+	foreach (int i, &v : list.iter()) *v = i + 1;
+	test::eq(list, expected);
+}
+
+fn void test_iterator_reverse_set() => @pool()
+{
+	IntList list = linkedlist::@tnew{int}({ 17, 109, 2, 8 });
+	IntList pushed = linkedlist::@tnew{int}();
+	IntList expected = linkedlist::@tnew{int}({8, 2, 109, 17});
+	foreach_r (int i, v : list.iter()) pushed.push(v);
+	test::eq(pushed, expected);
 }

--- a/test/unit/stdlib/core/array.c3
+++ b/test/unit/stdlib/core/array.c3
@@ -32,7 +32,7 @@ fn usz? ArrTestStruct.to_format(&self, Formatter* f) @dynamic
 }
 
 module array_test @test;
-import std::collections::pair, std::collections::list;
+import std::collections::pair, std::collections::list, std::collections::linkedlist;
 
 
 fn void contains()
@@ -86,6 +86,10 @@ fn void reduce() => @pool()
 	List {String} l;
 	l.push_all({ "abc", "adef", "ghi", "a12345" });
 	test::eq(array::@reduce(l, (usz)0, fn (acc, e, u) => acc + e.len + u), 0 + (3 + 0) + (4 + 1) + (3 + 2) + (6 + 3));
+
+	LinkedList {String} ll;
+	ll.push_all({ "abc", "adef", "ghi", "a12345" });
+	test::eq(array::@reduce(ll, (usz)0, fn (acc, e, u) => acc + e.len + u), 0 + (3 + 0) + (4 + 1) + (3 + 2) + (6 + 3));
 }
 
 fn void sum()
@@ -127,6 +131,10 @@ fn void indices_of() => @pool()
 	List {String} l;
 	l.push_all({ "abc", "adef", "ghi", "a12345" });
 	test::eq(array::@tindices_of(l, fn (e, u) => e.len <= 3), (usz[]){0, 2});
+
+	LinkedList {String} ll;
+	ll.push_all({ "abc", "adef", "ghi", "a12345" });
+	test::eq(array::@tindices_of(ll, fn (e, u) => e.len <= 3), (usz[]){0, 2});
 }
 
 fn void filter() => @pool()
@@ -143,6 +151,10 @@ fn void filter() => @pool()
 	List {String} l;
 	l.push_all({ "abc", "adef", "ghi", "a12345" });
 	test::eq(array::@tfilter(l, fn (e, u) => e.len <= 3), (String[]){ "abc", "ghi" });
+
+	LinkedList {String} ll;
+	ll.push_all({ "abc", "adef", "ghi", "a12345" });
+	test::eq(array::@tfilter(ll, fn (e, u) => e.len <= 3), (String[]){ "abc", "ghi" });
 }
 
 fn void any_true() => @pool()
@@ -159,6 +171,11 @@ fn void any_true() => @pool()
 	l.push_all({ "abc", "adef", "ghi", "a12345" });
 	test::@check(array::@any(l, fn (e, u) => e.len > 5));
 	test::@check(!array::@any(l, fn (e, u) => e == "hi"));
+
+	LinkedList {String} ll;
+	ll.push_all({ "abc", "adef", "ghi", "a12345" });
+	test::@check(array::@any(ll, fn (e, u) => e.len > 5));
+	test::@check(!array::@any(ll, fn (e, u) => e == "hi"));
 }
 
 fn void all_true() => @pool()
@@ -175,6 +192,11 @@ fn void all_true() => @pool()
 	l.push_all({ "abc", "adef", "ghi", "a12345" });
 	test::@check(array::@all(l, fn (e, u) => e.len > 1));
 	test::@check(!array::@all(l, fn (e, u) => e.len > 3));
+
+	LinkedList {String} ll;
+	ll.push_all({ "abc", "adef", "ghi", "a12345" });
+	test::@check(array::@all(ll, fn (e, u) => e.len > 1));
+	test::@check(!array::@all(ll, fn (e, u) => e.len > 3));
 }
 
 
@@ -355,6 +377,20 @@ fn void zip_into()
 fn void zip_into_list() => @pool()
 {
 	List{char} l;
+	l.push_all({ '1', '2', '3', '4' });
+	String[6] right = { "one", "two", "three", "four", "five", "six" };
+
+	char[] expected = { '4', '5', '8', '8' };
+
+	array::@zip_into(l, right, fn (a, b) => a + (char)b.len);
+
+	test::eq(l.len(), 4);
+	foreach (i, c : l) test::@check(c == expected[i], "Mismatch on index %d: %s (actual) != %s (expected)", i, c, expected[i]);
+}
+
+fn void zip_into_linked_list() => @pool()
+{
+	LinkedList{char} l;
 	l.push_all({ '1', '2', '3', '4' });
 	String[6] right = { "one", "two", "three", "four", "five", "six" };
 


### PR DESCRIPTION
This change depends on #2438 and will stay in Draft until that request has been reviewed.

Adds an `@iter` macro to array to provide the proper iterable type at compile-time based on whether the passed list has an `.iter()` method attached to it.