### PR TITLE
Make `enum Cc` `inline` so it can index `Termios.c_cc`

### DIFF
--- a/lib/std/libc/os/posix.c3
+++ b/lib/std/libc/os/posix.c3
@@ -218,7 +218,7 @@ enum Speed : const CUInt
 	MAX_BAUD = B4000000,
 }
 
-enum Cc : const char
+enum Cc : const inline char
 {
 	VINTR = 0,
 	VQUIT = 1,


### PR DESCRIPTION
I forgot to make it inline, so it couldn't be used to index the termux `c_cc`array it was meant to without a cast. This fixes it.