### PR TITLE
add ability for TinyCC to compile c3c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,15 +70,16 @@ else()
 endif()
 
 # Options
-set(C3_LINK_DYNAMIC         OFF      CACHE BOOL   "Link dynamically with LLVM/LLD libs")
-set(C3_WITH_LLVM            ON       CACHE BOOL   "Build with LLVM")
-set(C3_LLVM_VERSION         "auto"   CACHE STRING "Use LLVM version [default: auto]")
-set(C3_USE_MIMALLOC         OFF      CACHE BOOL   "Use built-in mimalloc")
-set(C3_MIMALLOC_TAG         "v1.7.3" CACHE STRING "Used version of mimalloc")
-set(C3_USE_TB               OFF      CACHE BOOL   "Use TB")
-set(C3_LLD_DIR              ""       CACHE STRING "Use custom LLD directory")
-set(C3_ENABLE_CLANGD_LSP    OFF      CACHE BOOL   "Enable/Disable output of compile commands during generation")
-set(LLVM_CRT_LIBRARY_DIR    ""       CACHE STRING "Use custom llvm's compiler-rt directory")
+set(C3_LINK_DYNAMIC         OFF                         CACHE BOOL   "Link dynamically with LLVM/LLD libs")
+set(C3_WITH_LLVM            ON                          CACHE BOOL   "Build with LLVM")
+set(C3_LLVM_VERSION         "auto"                      CACHE STRING "Use LLVM version [default: auto]")
+set(C3_USE_MIMALLOC         OFF                         CACHE BOOL   "Use built-in mimalloc")
+set(C3_MIMALLOC_TAG         "v1.7.3"                    CACHE STRING "Used version of mimalloc")
+set(C3_USE_TB               OFF                         CACHE BOOL   "Use TB")
+set(C3_LLD_DIR              ""                          CACHE STRING "Use custom LLD directory")
+set(C3_ENABLE_CLANGD_LSP    OFF                         CACHE BOOL   "Enable/Disable output of compile commands during generation")
+set(LLVM_CRT_LIBRARY_DIR    ""                          CACHE STRING "Use custom llvm's compiler-rt directory")
+set(TCC_LIB_PATH            "/usr/lib/tcc/libtcc1.a"    CACHE STRING "Use custom libtcc1.a path")
 
 set(C3_OPTIONS
         C3_LINK_DYNAMIC
@@ -573,6 +574,17 @@ else()
         -Wno-unused-parameter
     )
     target_link_options(c3c PRIVATE -pthread)
+endif()
+
+if(CMAKE_C_COMPILER_ID STREQUAL "TinyCC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-eh-frame-hdr -z noexecstack")
+
+    # Link the static tcc runtime archive if it exists
+    if(EXISTS "${TCC_LIB_PATH}")
+        target_link_libraries(c3c "${TCC_LIB_PATH}")
+    else()
+        message(FATAL_ERROR "TCC runtime not found at ${TCC_LIB_PATH}; Ensure the path is correct.")
+    endif()
 endif()
 
 install(TARGETS c3c DESTINATION bin)

--- a/src/build/builder.c
+++ b/src/build/builder.c
@@ -213,7 +213,7 @@ void update_build_target_with_opt_level(BuildTarget *target, OptimizationSetting
 			break;
 		case OPT_SETTING_NOT_SET:
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	COPY_IF_DEFAULT(target->optsize, optsize);
 	COPY_IF_DEFAULT(target->optlevel, optlevel);
@@ -493,7 +493,7 @@ static void update_build_target_from_options(BuildTarget *target, BuildOptions *
 		case SANITIZE_ADDRESS: target->feature.sanitize_address = true; break;
 		case SANITIZE_MEMORY: target->feature.sanitize_memory = true; break;
 		case SANITIZE_THREAD: target->feature.sanitize_thread = true; break;
-		default: UNREACHABLE;
+		default: UNREACHABLE_VOID;
 	}
 
 	if (target->arch_os_target == ARCH_OS_TARGET_DEFAULT) target->arch_os_target = default_target;

--- a/src/build/common_build.c
+++ b/src/build/common_build.c
@@ -149,7 +149,7 @@ int get_valid_string_setting(BuildParseContext context, JSONObject *json, const 
 		error_exit("In file '%s': '%s' had an invalid value for '%s', expected %s", context.file, context.target, key, expected);
 	}
 	error_exit("In file '%s': Invalid value for '%s', expected %s", context.file, key, expected);
-	return 0;
+	UNREACHABLE
 }
 
 int get_valid_enum_from_string(const char *str, const char *target, const char **values, int count, const char *expected)
@@ -161,7 +161,7 @@ int get_valid_enum_from_string(const char *str, const char *target, const char *
 		error_exit("'%s' had an invalid value, expected %s", target, expected);
 	}
 	error_exit("Invalid value, expected %s", expected);
-	return 0;
+	UNREACHABLE
 }
 
 long get_valid_integer(BuildParseContext context, JSONObject *table, const char *key, bool mandatory)

--- a/src/build/common_build.c
+++ b/src/build/common_build.c
@@ -149,6 +149,7 @@ int get_valid_string_setting(BuildParseContext context, JSONObject *json, const 
 		error_exit("In file '%s': '%s' had an invalid value for '%s', expected %s", context.file, context.target, key, expected);
 	}
 	error_exit("In file '%s': Invalid value for '%s', expected %s", context.file, key, expected);
+	return 0;
 }
 
 int get_valid_enum_from_string(const char *str, const char *target, const char **values, int count, const char *expected)
@@ -160,6 +161,7 @@ int get_valid_enum_from_string(const char *str, const char *target, const char *
 		error_exit("'%s' had an invalid value, expected %s", target, expected);
 	}
 	error_exit("Invalid value, expected %s", expected);
+	return 0;
 }
 
 long get_valid_integer(BuildParseContext context, JSONObject *table, const char *key, bool mandatory)

--- a/src/build/libraries.c
+++ b/src/build/libraries.c
@@ -127,6 +127,7 @@ static Library *find_library(Library **libs, size_t lib_count, const char *name)
 		if (str_eq(libs[i]->provides, name)) return libs[i];
 	}
 	error_exit("Required library '%s' could not be found. You can add additional library search paths using '--libdir' in case you forgot one.", name);
+	return 0;
 }
 
 static void add_library_dependency(BuildTarget *build_target, Library *library, Library **library_list, size_t lib_count)

--- a/src/build/libraries.c
+++ b/src/build/libraries.c
@@ -127,7 +127,7 @@ static Library *find_library(Library **libs, size_t lib_count, const char *name)
 		if (str_eq(libs[i]->provides, name)) return libs[i];
 	}
 	error_exit("Required library '%s' could not be found. You can add additional library search paths using '--libdir' in case you forgot one.", name);
-	return 0;
+	UNREACHABLE
 }
 
 static void add_library_dependency(BuildTarget *build_target, Library *library, Library **library_list, size_t lib_count)

--- a/src/build/project.c
+++ b/src/build/project.c
@@ -359,7 +359,7 @@ static void load_into_build_target(BuildParseContext context, JSONObject *json, 
 		case SANITIZE_ADDRESS: target->feature.sanitize_address = true; break;
 		case SANITIZE_MEMORY: target->feature.sanitize_memory = true; break;
 		case SANITIZE_THREAD: target->feature.sanitize_thread = true; break;
-		default: UNREACHABLE;
+		default: UNREACHABLE_VOID;
 	}
 
 	// Cpu
@@ -595,6 +595,7 @@ BuildTarget *project_select_target(const char *filename, Project *project, const
 		if (str_eq(target->name, optional_target)) return target;
 	}
 	error_exit("No build target named '%s' was found in %s. Was it misspelled?", optional_target, filename);
+	return 0;
 }
 
 JSONObject *project_json_load(const char **filename_ref)

--- a/src/build/project.c
+++ b/src/build/project.c
@@ -595,7 +595,7 @@ BuildTarget *project_select_target(const char *filename, Project *project, const
 		if (str_eq(target->name, optional_target)) return target;
 	}
 	error_exit("No build target named '%s' was found in %s. Was it misspelled?", optional_target, filename);
-	return 0;
+	UNREACHABLE
 }
 
 JSONObject *project_json_load(const char **filename_ref)

--- a/src/compiler/abi/c_abi_x64.c
+++ b/src/compiler/abi/c_abi_x64.c
@@ -372,7 +372,7 @@ static void x64_classify(Type *type, ByteSize offset_base, X64Class *lo_class, X
 	{
 		case LOWERED_TYPES:
 		case TYPE_FUNC_RAW:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_VOID:
 			*current = CLASS_NO_CLASS;
 			break;
@@ -552,7 +552,7 @@ AbiType x64_get_int_type_at_offset(Type *type, unsigned offset, Type *source_typ
 		case LOWERED_TYPES:
 		case TYPE_VOID:
 		case TYPE_FUNC_RAW:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_U64:
 		case TYPE_I64:
 		case TYPE_POINTER:
@@ -592,7 +592,7 @@ AbiType x64_get_int_type_at_offset(Type *type, unsigned offset, Type *source_typ
 			if (offset < 16) return abi_type_get(type_ulong);
 			break;
 		case TYPE_FLEXIBLE_ARRAY:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_ARRAY:
 		{
 			Type *element = type->array.base;

--- a/src/compiler/abi/c_abi_x86.c
+++ b/src/compiler/abi/c_abi_x86.c
@@ -505,7 +505,7 @@ void c_abi_func_create_x86(FunctionPrototype *prototype)
 			regs.int_regs = compiler.platform.default_number_regs_x86;
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	// 3. Special case for MCU:
 	if (compiler.platform.x86.is_mcu_api)

--- a/src/compiler/asm_target.c
+++ b/src/compiler/asm_target.c
@@ -88,6 +88,7 @@ INLINE AsmArgBits parse_bits(const char **desc)
 		return ARG_BITS_5;
 	}
 	error_exit("Invalid bits: %s.", *desc);
+	return 0;
 }
 
 INLINE AsmArgType decode_arg_type(const char **desc)
@@ -563,7 +564,7 @@ static void init_asm_riscv(PlatformTarget *target)
 			bits = ARG_BITS_32;
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	reg_register_list(target, riscv_gp_integer_regs, 32, ASM_REG_INT, bits, RISCV_X0);
 	reg_register_list(target, riscv_arg_integer_regs, 8, ASM_REG_INT, bits, RISCV_X10);
@@ -892,7 +893,7 @@ static void print_arch_asm(PlatformTarget *target)
 				break;
 			}
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 		if (scratch_buffer.len) scratch_buffer.len -= 2;
 		printf("%-30s | ", scratch_buffer_to_string());
@@ -960,7 +961,7 @@ void init_asm(PlatformTarget *target)
 			error_exit("Xtensa asm support not yet available.");
 		case ARCH_TYPE_UNKNOWN:
 			error_exit("Unknown arch does not support asm.");
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case ARCH_TYPE_PPC:
 		case ARCH_TYPE_PPC64:
 		case ARCH_TYPE_PPC64LE:
@@ -973,5 +974,5 @@ void init_asm(PlatformTarget *target)
 		case ARCH_UNSUPPORTED:
 			error_exit("Arch is unsupported and does not support inline asm.");
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }

--- a/src/compiler/asm_target.c
+++ b/src/compiler/asm_target.c
@@ -88,7 +88,7 @@ INLINE AsmArgBits parse_bits(const char **desc)
 		return ARG_BITS_5;
 	}
 	error_exit("Invalid bits: %s.", *desc);
-	return 0;
+	UNREACHABLE
 }
 
 INLINE AsmArgType decode_arg_type(const char **desc)

--- a/src/compiler/bigint.c
+++ b/src/compiler/bigint.c
@@ -32,6 +32,7 @@ UNUSED static char digit_to_char(uint8_t digit, bool upper)
 		return (char)(digit + (upper ? 'A' : 'a') - 10);
 	}
 	FATAL_ERROR("Can't reach");
+	return 0;
 }
 
 #define HI32(_x) ((_x) >> 32)

--- a/src/compiler/bigint.c
+++ b/src/compiler/bigint.c
@@ -31,8 +31,7 @@ UNUSED static char digit_to_char(uint8_t digit, bool upper)
 	{
 		return (char)(digit + (upper ? 'A' : 'a') - 10);
 	}
-	FATAL_ERROR("Can't reach");
-	return 0;
+	UNREACHABLE
 }
 
 #define HI32(_x) ((_x) >> 32)

--- a/src/compiler/c_codegen.c
+++ b/src/compiler/c_codegen.c
@@ -524,7 +524,7 @@ static void c_emit_jump_to_optional_exit(GenContext *c, int value)
 static int c_emit_load(GenContext *c, VariableId id)
 {
 	TODO
-	return 0;
+	UNREACHABLE
 }
 
 static void c_value_fold_optional(GenContext *c, CValue *value)

--- a/src/compiler/c_codegen.c
+++ b/src/compiler/c_codegen.c
@@ -387,7 +387,7 @@ static void c_emit_const_expr(GenContext *c, CValue *value, Expr *expr)
 			break;
 		case CONST_UNTYPED_LIST:
 		case CONST_MEMBER:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	PRINT("/* CONST EXPR */\n");
 }
@@ -418,7 +418,7 @@ static void c_emit_expr(GenContext *c, CValue *value, Expr *expr)
 			break;
 		case NON_RUNTIME_EXPR:
 		case UNRESOLVED_EXPRS:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case EXPR_ACCESS_RESOLVED:
 			break;
 		case EXPR_ASM:
@@ -524,6 +524,7 @@ static void c_emit_jump_to_optional_exit(GenContext *c, int value)
 static int c_emit_load(GenContext *c, VariableId id)
 {
 	TODO
+	return 0;
 }
 
 static void c_value_fold_optional(GenContext *c, CValue *value)
@@ -582,7 +583,7 @@ static void c_emit_local_decl(GenContext *c, Decl *decl, CValue *value)
 		case VARDECL_GLOBAL:
 		case VARDECL_MEMBER:
 		case VARDECL_BITMEMBER:
-			UNREACHABLE;
+			UNREACHABLE_VOID;
 		case VARDECL_PARAM:
 		case VARDECL_UNWRAPPED:
 		case VARDECL_ERASE:
@@ -590,7 +591,7 @@ static void c_emit_local_decl(GenContext *c, Decl *decl, CValue *value)
 			return;
 		case VARDECL_LOCAL_CT:
 		case VARDECL_LOCAL_CT_TYPE:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 
 	// Get the declaration and the LLVM type.
@@ -661,7 +662,7 @@ static void c_emit_local_decl(GenContext *c, Decl *decl, CValue *value)
 		case TYPE_WILDCARD:
 		case TYPE_TYPEINFO:
 		case TYPE_MEMBER:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_ANY:
 		case TYPE_INTERFACE:
 			PRINTF("___var_%d = (c3_any_t){ NULL, NULL };\n", value->var);
@@ -785,7 +786,7 @@ static void c_emit_stmt(GenContext *c, Ast *stmt)
 	switch (stmt->ast_kind)
 	{
 		case AST_POISONED:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case AST_ASM_STMT:
 			break;
 		case AST_ASM_BLOCK_STMT:
@@ -817,7 +818,7 @@ static void c_emit_stmt(GenContext *c, Ast *stmt)
 		case AST_CT_IF_STMT:
 		case AST_CT_SWITCH_STMT:
 		case AST_CT_TYPE_ASSIGN_STMT:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case AST_DECLARE_STMT:
 		{
 			CValue value;

--- a/src/compiler/codegen_asm.c
+++ b/src/compiler/codegen_asm.c
@@ -77,7 +77,7 @@ static inline void codegen_create_x86att_arg(AsmInlineBlock *block, unsigned inp
 						scratch_buffer_append_char('8');
 						break;
 					default:
-						UNREACHABLE
+						UNREACHABLE_VOID
 				}
 			}
 			scratch_buffer_append_char(')');
@@ -85,7 +85,7 @@ static inline void codegen_create_x86att_arg(AsmInlineBlock *block, unsigned inp
 		case ASM_ARG_ADDROF:
 			TODO
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static inline void codegen_create_aarch64_arg(AsmInlineBlock *block, unsigned input_offset, Expr *expr)
@@ -120,7 +120,7 @@ static inline void codegen_create_aarch64_arg(AsmInlineBlock *block, unsigned in
 		case ASM_ARG_ADDROF:
 			TODO
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static inline void codegen_create_riscv_arg(AsmInlineBlock *block, unsigned input_offset, Expr *expr)
@@ -171,7 +171,7 @@ static inline void codegen_create_riscv_arg(AsmInlineBlock *block, unsigned inpu
 		case ASM_ARG_ADDROF:
 			TODO
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -164,12 +164,12 @@ void thread_compile_task_tb(void *compile_data)
 const char *tilde_codegen(void *context)
 {
 	error_exit("TB backend not available.");
-	return 0;
+	UNREACHABLE
 }
 void **tilde_gen(Module** modules, unsigned module_count)
 {
 	error_exit("TB backend not available.");
-	return 0;
+	UNREACHABLE
 }
 
 #endif

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -164,10 +164,12 @@ void thread_compile_task_tb(void *compile_data)
 const char *tilde_codegen(void *context)
 {
 	error_exit("TB backend not available.");
+	return 0;
 }
 void **tilde_gen(Module** modules, unsigned module_count)
 {
 	error_exit("TB backend not available.");
+	return 0;
 }
 
 #endif
@@ -538,7 +540,7 @@ void compiler_compile(void)
 			task = &thread_compile_task_tb;
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	compiler_ir_gen_time = bench_mark();
 	const char *output_exe = NULL;
@@ -577,7 +579,7 @@ void compiler_compile(void)
 			case TARGET_TYPE_PREPARE:
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 	}
 	if (compiler.build.emit_llvm)

--- a/src/compiler/compiler_internal.h
+++ b/src/compiler/compiler_internal.h
@@ -3645,7 +3645,7 @@ static inline void const_init_set_span(ConstInitializer *init, SourceSpan loc)
 			const_init_set_span(init->init_array_value.element, loc);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static inline void expr_list_set_span(Expr **expr, SourceSpan loc);

--- a/src/compiler/context.c
+++ b/src/compiler/context.c
@@ -168,7 +168,7 @@ void decl_register(Decl *decl)
 		case DECL_IMPORT:
 		case DECL_LABEL:
 		case DECL_POISONED:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case DECL_ATTRIBUTE:
 		case DECL_BITSTRUCT:
 		case DECL_DISTINCT:
@@ -273,7 +273,7 @@ void unit_register_global_decl(CompilationUnit *unit, Decl *decl)
 		case DECL_GROUP:
 		case DECL_IMPORT:
 		case DECL_LABEL:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case DECL_CT_EXEC:
 		case DECL_CT_INCLUDE:
 			vec_add(unit->ct_includes, decl);

--- a/src/compiler/copying.c
+++ b/src/compiler/copying.c
@@ -197,7 +197,7 @@ void copy_range(CopyStruct *c, Range *range)
 	switch (range->range_type)
 	{
 		case RANGE_SINGLE_ELEMENT:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case RANGE_CONST_LEN:
 		case RANGE_CONST_END:
 			MACRO_COPY_EXPRID(range->start);
@@ -209,7 +209,7 @@ void copy_range(CopyStruct *c, Range *range)
 			MACRO_COPY_EXPRID(range->end);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 INLINE ConstInitializer **copy_const_initializer_list(CopyStruct *c, ConstInitializer **initializer_list)
@@ -253,7 +253,7 @@ static inline void copy_const_initializer(CopyStruct *c, ConstInitializer **init
 			copy_const_initializer(c, &copy->init_array_value.element);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 INLINE Expr *copy_const_expr(CopyStruct *c, Expr *expr)

--- a/src/compiler/diagnostics.c
+++ b/src/compiler/diagnostics.c
@@ -64,7 +64,7 @@ static void print_error_type_at(SourceSpan location, const char *message, PrintT
 				eprintf("warn");
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 		eprintf("|");
 		eprint_escaped_string(file->full_path);
@@ -87,7 +87,7 @@ static void print_error_type_at(SourceSpan location, const char *message, PrintT
 				eprintf("Warning|%s|%d|%d|%s\n", file->full_path, location.row, location.col, message);
 				return;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 	}
 	unsigned max_line_length = (unsigned)round(log10(location.row)) + 1;
@@ -198,7 +198,7 @@ static void print_error_type_at(SourceSpan location, const char *message, PrintT
 				}
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 	}
 	else
@@ -236,7 +236,7 @@ static void print_error_type_at(SourceSpan location, const char *message, PrintT
 				}
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 
 	}

--- a/src/compiler/dwarf.h
+++ b/src/compiler/dwarf.h
@@ -1,6 +1,9 @@
 #pragma once
+
+#ifndef __TINYC__
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "OCUnusedMacroInspection"
+#endif
 
 // Copyright (c) 2019 Christoffer Lerno. All rights reserved.
 // Use of this source code is governed by the GNU LGPLv3.0 license
@@ -285,4 +288,6 @@
 
 #define DWARF_PRODUCER_NAME "c3c"
 
+#ifndef __TINYC__
 #pragma clang diagnostic pop
+#endif

--- a/src/compiler/expr.c
+++ b/src/compiler/expr.c
@@ -649,7 +649,7 @@ void expr_rewrite_to_const_zero(Expr *expr, Type *type)
 		case TYPE_VOID:
 		case TYPE_INFERRED_VECTOR:
 		case TYPE_WILDCARD:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case ALL_INTS:
 			expr_rewrite_const_int(expr, type, 0);
 			return;
@@ -688,7 +688,7 @@ void expr_rewrite_to_const_zero(Expr *expr, Type *type)
 		case TYPE_UNTYPED_LIST:
 		case TYPE_INFERRED_ARRAY:
 		case TYPE_FLEXIBLE_ARRAY:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_SLICE:
 			expr_rewrite_const_empty_slice(expr, type);
 			return;

--- a/src/compiler/headers.c
+++ b/src/compiler/headers.c
@@ -96,7 +96,7 @@ static void header_print_type(HeaderContext *c, Type *type)
 	{
 		case CT_TYPES:
 		case TYPE_OPTIONAL:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_VOID:
 			PRINTF("void");
 			return;
@@ -199,7 +199,7 @@ static void header_print_type(HeaderContext *c, Type *type)
 			header_print_type(c, type->canonical);
 			return;
 		case TYPE_FLEXIBLE_ARRAY:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_ARRAY:
 			PRINTF("struct { ");
 			header_print_type(c, type->array.base);
@@ -225,7 +225,7 @@ static void header_print_type(HeaderContext *c, Type *type)
 					PRINTF("float");
 					break;
 				default:
-					UNREACHABLE;
+					UNREACHABLE_VOID;
 			}
 			PRINTF("%dx%llu", (int)type_bit_size(type->array.base), (unsigned long long)type->array.len);
 			return;
@@ -372,7 +372,7 @@ static void header_gen_members(HeaderContext *c, int indent, Decl **members)
 				PRINTF(" __bits%d;\n", ++i);
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 	}
 }
@@ -482,7 +482,7 @@ static void header_ensure_member_types_exist(HeaderContext *c, Decl **members)
 			case DECL_BITSTRUCT:
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 	}
 }
@@ -500,7 +500,7 @@ RETRY:
 	{
 		case CT_TYPES:
 		case TYPE_OPTIONAL:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_VOID:
 		case TYPE_BOOL:
 		case ALL_FLOATS:
@@ -557,7 +557,7 @@ RETRY:
 			type = type_flatten(type);
 			goto RETRY;
 		case TYPE_FUNC_RAW:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_STRUCT:
 		case TYPE_UNION:
 			header_gen_struct_union_top(c, type->decl, is_pointer ? GEN_POINTER : GEN_FULL);
@@ -664,7 +664,7 @@ static void header_gen_global_var(HeaderContext *c, Decl *decl, bool fn_globals,
 			case CONST_INITIALIZER:
 			case CONST_UNTYPED_LIST:
 			case CONST_BYTES:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 	}
 	if (!fn_globals)
@@ -758,7 +758,7 @@ static void process_queue(HeaderContext *c)
 				header_gen_struct_union_top(c, decl, GEN_DEFINITION);
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 	}
 	vec_resize(c->type_queue, 0);

--- a/src/compiler/json_output.c
+++ b/src/compiler/json_output.c
@@ -124,7 +124,7 @@ void print_type(FILE *file, TypeInfo *type)
 	switch (type->kind)
 	{
 		case TYPE_INFO_POISON:
-			UNREACHABLE;
+			UNREACHABLE_VOID;
 		case TYPE_INFO_IDENTIFIER:
 		case TYPE_INFO_CT_IDENTIFIER:
 			if (type->unresolved.path)
@@ -329,7 +329,7 @@ static inline void emit_param(FILE *file, Decl *decl)
 			PRINT("type");
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	PRINTF("\",\n\t\t\t\t\t\"name\": \"%s\",\n", decl->name ? decl->name : "");
 	PRINTF("\t\t\t\t\t\"type\": \"");

--- a/src/compiler/lexer.c
+++ b/src/compiler/lexer.c
@@ -277,7 +277,7 @@ static void skip_whitespace(Lexer *lexer)
 				break;
 			case '\r':
 				// Already filtered out.
-				UNREACHABLE
+				UNREACHABLE_VOID
 			default:
 				return;
 		}

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -47,6 +47,7 @@ static const char *ld_target(ArchType arch_type)
 		default:
 			error_exit("Architecture currently not available for cross linking.");
 	}
+	return 0;
 }
 
 static void linker_setup_windows(const char ***args_ref, Linker linker_type, const char *output_file)
@@ -69,7 +70,7 @@ static void linker_setup_windows(const char ***args_ref, Linker linker_type, con
 			is_debug = true;
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	if (!link_libc()) return;
 	bool link_with_dynamic_debug_libc = true;
@@ -111,7 +112,7 @@ static void linker_setup_windows(const char ***args_ref, Linker linker_type, con
 					scratch_buffer_append("/x86");
 					break;
 				default:
-					UNREACHABLE
+					UNREACHABLE_VOID
 			}
 			if (file_exists(scratch_buffer_to_string()))
 			{
@@ -761,7 +762,7 @@ static void append_fpie_pic_options(RelocModel reloc, const char ***args_ref)
 	switch (reloc)
 	{
 		case RELOC_DEFAULT:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case RELOC_NONE:
 			add_plain_arg("-fno-pic");
 			break;

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -47,7 +47,7 @@ static const char *ld_target(ArchType arch_type)
 		default:
 			error_exit("Architecture currently not available for cross linking.");
 	}
-	return 0;
+	UNREACHABLE
 }
 
 static void linker_setup_windows(const char ***args_ref, Linker linker_type, const char *output_file)

--- a/src/compiler/llvm_codegen.c
+++ b/src/compiler/llvm_codegen.c
@@ -447,7 +447,7 @@ void llvm_emit_ptr_from_array(GenContext *c, BEValue *value)
 			return;
 		}
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 }
 
@@ -988,7 +988,7 @@ static void llvm_emit_type_decls(GenContext *context, Decl *decl)
 		case NON_TYPE_DECLS:
 		case DECL_ERASED:
 		case DECL_FNTYPE:
-			UNREACHABLE;
+			UNREACHABLE_VOID;
 		case DECL_TYPEDEF:
 			if (decl->type_alias_decl.is_func)
 			{
@@ -997,7 +997,7 @@ static void llvm_emit_type_decls(GenContext *context, Decl *decl)
 			break;
 		case DECL_FUNC:
 			// Never directly invoked.
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case DECL_INTERFACE:
 			break;
 		case DECL_DISTINCT:

--- a/src/compiler/llvm_codegen_builtins.c
+++ b/src/compiler/llvm_codegen_builtins.c
@@ -223,7 +223,7 @@ INLINE void llvm_emit_atomic_fetch(GenContext *c, BuiltinFunction func, BEValue 
 			op = LLVMAtomicRMWBinOpUDecWrap;
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	LLVMValueRef res = LLVMBuildAtomicRMW(c->builder, op, val, llvm_load_value_store(c, result_value),
 	                   llvm_atomic_ordering(expr->call_expr.arguments[3]->const_expr.ixx.i.low),
@@ -342,7 +342,7 @@ static inline void llvm_emit_syscall(GenContext *c, BEValue *be_value, Expr *exp
 			break;
 		case ARCH_UNSUPPORTED:
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	LLVMValueRef result = LLVMBuildCall2(c->builder, func_type, inline_asm, arg_results, arguments, "syscall");
 	llvm_value_set(be_value, result, type_uptr);
@@ -718,7 +718,7 @@ static void llvm_emit_wrap_builtin(GenContext *c, BEValue *result_value, Expr *e
 			}
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	llvm_value_set(result_value, res, expr->type);
 }
@@ -731,7 +731,7 @@ void llvm_emit_builtin_call(GenContext *c, BEValue *result_value, Expr *expr)
 	{
 		case BUILTIN_ANY_MAKE:
 			// Folded in the frontend.
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case BUILTIN_UNREACHABLE:
 			llvm_emit_unreachable_stmt(c, result_value);
 			return;
@@ -769,7 +769,7 @@ void llvm_emit_builtin_call(GenContext *c, BEValue *result_value, Expr *expr)
 		case BUILTIN_VECCOMPEQ:
 		case BUILTIN_VECCOMPGT:
 		case BUILTIN_VECCOMPGE:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case BUILTIN_REVERSE:
 			llvm_emit_reverse(c, result_value, expr);
 			return;
@@ -1106,9 +1106,9 @@ void llvm_emit_builtin_call(GenContext *c, BEValue *result_value, Expr *expr)
 		case BUILTIN_WIDESTRING_32:
 		case BUILTIN_RND:
 		case BUILTIN_SPRINTF:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case BUILTIN_NONE:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }

--- a/src/compiler/llvm_codegen_expr.c
+++ b/src/compiler/llvm_codegen_expr.c
@@ -678,7 +678,7 @@ static inline void llvm_emit_subscript_addr_with_base(GenContext *c, BEValue *re
 			}
 			return;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 
 	}
 }
@@ -867,7 +867,7 @@ static void llvm_emit_member_addr(GenContext *c, BEValue *value, Decl *parent, D
 				llvm_value_struct_gep(c, value, value, (unsigned)index);
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 		parent = found;
 	} while (found != member);
@@ -1508,7 +1508,7 @@ static void llvm_emit_const_init_ref(GenContext *c, BEValue *ref, ConstInitializ
 			llvm_store_zero(c, ref);
 			return;
 		case CONST_INIT_ARRAY_VALUE:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case CONST_INIT_ARRAY_FULL:
 		{
 			LLVMValueRef array_ref = ref->value;
@@ -1580,7 +1580,7 @@ static void llvm_emit_const_init_ref(GenContext *c, BEValue *ref, ConstInitializ
 			return;
 		}
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static inline void llvm_emit_initialize_reference_vector(GenContext *c, BEValue *ref, Type *real_type, Expr **elements)
@@ -1817,7 +1817,7 @@ static void llvm_emit_initialize_designated_element(GenContext *c, BEValue *ref,
 			llvm_emit_initialize_designated_const_range(c, ref, offset, current, last, expr, emitted_value);
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 }
 
@@ -2070,7 +2070,7 @@ static inline void llvm_emit_initialize_reference(GenContext *c, BEValue *ref, E
 			llvm_emit_initialize_reference_designated(c, ref, expr);
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 }
 
@@ -2187,7 +2187,7 @@ static void llvm_emit_vec_comp(GenContext *c, BEValue *result, BEValue *lhs, BEV
 				res = LLVMBuildFCmp(c->builder, LLVMRealOLT, lhs->value, rhs->value, "lt");
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 	}
 	else
@@ -2216,7 +2216,7 @@ static void llvm_emit_vec_comp(GenContext *c, BEValue *result, BEValue *lhs, BEV
 				res = LLVMBuildICmp(c->builder, is_signed ? LLVMIntSLT : LLVMIntULT, lhs->value, rhs->value, "lt");
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 	}
 	llvm_value_set(result, res, type);
@@ -2462,7 +2462,7 @@ static void llvm_emit_unary_expr(GenContext *c, BEValue *value, Expr *expr)
 			FATAL_ERROR("Illegal unary op %s", expr->unary_expr.operator);
 		case UNARYOP_PLUS:
 			// Folded
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case UNARYOP_NOT:
 			llvm_emit_expr(c, value, inner);
 			if (type_flat_is_vector(type))
@@ -2550,7 +2550,7 @@ static void llvm_emit_unary_expr(GenContext *c, BEValue *value, Expr *expr)
 			llvm_emit_pre_inc_dec(c, value, inner, -1, !expr->unary_expr.no_wrap);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 
@@ -2677,7 +2677,7 @@ static void llvm_emit_slice_values(GenContext *c, Expr *slice, BEValue *parent_r
 			parent_base = parent_addr;
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 
 	// Emit the start and end
@@ -2688,7 +2688,7 @@ static void llvm_emit_slice_values(GenContext *c, Expr *slice, BEValue *parent_r
 	switch (range.range_type)
 	{
 		case RANGE_SINGLE_ELEMENT:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case RANGE_DYNAMIC:
 		case RANGE_CONST_LEN:
 		case RANGE_CONST_END:
@@ -2725,7 +2725,7 @@ static void llvm_emit_slice_values(GenContext *c, Expr *slice, BEValue *parent_r
 				llvm_value_set_int(c, &len, start_type, parent_type->array.len);
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 	}
 
@@ -2759,7 +2759,7 @@ static void llvm_emit_slice_values(GenContext *c, Expr *slice, BEValue *parent_r
 		switch (range.range_type)
 		{
 			case RANGE_SINGLE_ELEMENT:
-				UNREACHABLE
+				UNREACHABLE_VOID
 			case RANGE_DYNAMIC:
 				llvm_emit_exprid(c, &end_index, range.end);
 				llvm_value_rvalue(c, &end_index);
@@ -2877,7 +2877,7 @@ static void gencontext_emit_slice(GenContext *c, BEValue *be_value, Expr *expr)
 			start_pointer = llvm_emit_pointer_inbounds_gep_raw(c, llvm_get_pointee_type(c, parent.type), parent.value, start.value);
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 
 	// Create a new slice type
@@ -3178,7 +3178,7 @@ void llvm_emit_int_comp_raw(GenContext *c, BEValue *result, Type *lhs_type, Type
 					llvm_value_set(result, llvm_const_int(c, type_bool, 1), type_bool);
 					return;
 				default:
-					UNREACHABLE
+					UNREACHABLE_VOID
 			}
 		}
 		lhs_signed = false;
@@ -3210,7 +3210,7 @@ void llvm_emit_int_comp_raw(GenContext *c, BEValue *result, Type *lhs_type, Type
 				value = LLVMBuildICmp(c->builder, LLVMIntULT, lhs_value, rhs_value, "lt");
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 		if (vector_type)
 		{
@@ -3247,7 +3247,7 @@ void llvm_emit_int_comp_raw(GenContext *c, BEValue *result, Type *lhs_type, Type
 			comp_value = LLVMBuildICmp(c->builder, LLVMIntSLT, lhs_value, rhs_value, "lt");
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 
 	// If right side is also signed then this is fine.
@@ -3297,7 +3297,7 @@ void llvm_emit_int_comp_raw(GenContext *c, BEValue *result, Type *lhs_type, Type
 			comp_value = LLVMBuildOr(c->builder, check_value, comp_value, "siui-lt");
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	if (vector_type)
 	{
@@ -3335,7 +3335,7 @@ static void llvm_emit_ptr_comparison(GenContext *c, BEValue *result, BEValue *lh
 			val = LLVMBuildICmp(c->builder, LLVMIntULT, lhs_value, rhs_value, "lt");
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	llvm_value_set(result, val, type_bool);
 }
@@ -3369,7 +3369,7 @@ static void llvm_emit_any_comparison(GenContext *c, BEValue *result, BEValue *lh
 			res = LLVMBuildOr(c->builder, val, val2, "any_ne");
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	llvm_value_set(result, res, type_bool);
 }
@@ -3604,7 +3604,7 @@ MEMCMP:
 		case TYPE_WILDCARD:
 		case TYPE_TYPEINFO:
 		case TYPE_MEMBER:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_BOOL:
 		case ALL_FLOATS:
 		case TYPE_SLICE:
@@ -3737,7 +3737,7 @@ static void llvm_emit_float_comp(GenContext *c, BEValue *be_value, BEValue *lhs,
 			val = LLVMBuildFCmp(c->builder, LLVMRealOLT, lhs_value, rhs_value, "lt");
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	if (vector_type)
 	{
@@ -3783,7 +3783,7 @@ void llvm_emit_comp(GenContext *c, BEValue *result, BEValue *lhs, BEValue *rhs, 
 	switch (lhs->type->type_kind)
 	{
 		case TYPE_VOID:
-			UNREACHABLE;
+			UNREACHABLE_VOID;
 		case TYPE_BOOL:
 		case ALL_INTS:
 			llvm_value_rvalue(c, lhs);
@@ -3807,7 +3807,7 @@ void llvm_emit_comp(GenContext *c, BEValue *result, BEValue *lhs, BEValue *rhs, 
 			return;
 		case LOWERED_TYPES:
 		case TYPE_FLEXIBLE_ARRAY:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_STRUCT:
 		case TYPE_UNION:
 			llvm_emit_struct_comparison(c, result, lhs, rhs, binary_op);
@@ -4039,7 +4039,7 @@ void llvm_emit_bitstruct_binary_op(GenContext *c, BEValue *be_value, BEValue *lh
 			val = LLVMBuildXor(c->builder, l, r, "xor");
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	LLVMValueRef store = llvm_emit_alloca(c, big_int, lhs->alignment, "");
 	llvm_store_to_ptr_raw_aligned(c, store, val, lhs->alignment);
@@ -4119,7 +4119,7 @@ void llvm_emit_binary(GenContext *c, BEValue *be_value, Expr *expr, BEValue *lhs
 	switch (binary_op)
 	{
 		case BINARYOP_ERROR:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case BINARYOP_MULT:
 			if (is_float)
 			{
@@ -4277,7 +4277,7 @@ void llvm_emit_binary(GenContext *c, BEValue *be_value, Expr *expr, BEValue *lhs
 		case BINARYOP_CT_OR:
 		case BINARYOP_CT_CONCAT:
 			// Handled elsewhere.
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	ASSERT(val);
 	llvm_value_set(be_value, val, expr->type);
@@ -4881,7 +4881,7 @@ static void llvm_emit_const_expr(GenContext *c, BEValue *be_value, Expr *expr)
 			llvm_value_set(be_value, NULL, type_void);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 
@@ -4922,7 +4922,7 @@ static void llvm_expand_type_to_args(GenContext *context, Type *param_type, LLVM
 		case TYPE_VOID:
 		case TYPE_FUNC_RAW:
 		case TYPE_FLEXIBLE_ARRAY:
-			UNREACHABLE
+			UNREACHABLE_VOID
 			break;
 		case TYPE_BOOL:
 		case ALL_INTS:
@@ -5371,7 +5371,7 @@ void llvm_emit_raw_call(GenContext *c, BEValue *result_value, FunctionPrototype 
 	{
 		case ABI_ARG_EXPAND:
 		case ABI_ARG_DIRECT_SPLIT_STRUCT_I32:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case ABI_ARG_IGNORE:
 			// 12. Basically void returns or empty structs.
 			//     Here we know we don't have an optional or any return value that can be used.
@@ -5744,7 +5744,7 @@ INLINE void llvm_emit_call_invocation(GenContext *c, BEValue *result_value,
 			break;
 		case ABI_ARG_EXPAND:
 		case ABI_ARG_DIRECT_SPLIT_STRUCT_I32:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case ABI_ARG_DIRECT_PAIR:
 		case ABI_ARG_IGNORE:
 		case ABI_ARG_DIRECT_COERCE_INT:
@@ -5867,7 +5867,7 @@ INLINE void llvm_emit_vasplat_expr(GenContext *c, BEValue *value_ref, Expr *vasp
 		case TYPE_SLICE:
 			return;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 
 }
@@ -6246,7 +6246,7 @@ static inline void llvm_emit_macro_block(GenContext *c, BEValue *be_value, Expr 
 			case VARDECL_REWRAPPED:
 			case VARDECL_ERASE:
 			case VARDECL_BITMEMBER:
-				UNREACHABLE
+				UNREACHABLE_VOID
 			case VARDECL_PARAM_CT:
 			case VARDECL_PARAM_CT_TYPE:
 			case VARDECL_PARAM_EXPR:
@@ -6375,7 +6375,7 @@ static inline void llvm_emit_vector_initializer_list(GenContext *c, BEValue *val
 					break;
 				case DESIGNATOR_FIELD:
 				default:
-					UNREACHABLE
+					UNREACHABLE_VOID
 			}
 		}
 	}
@@ -6638,9 +6638,9 @@ static inline void llvm_emit_typeid_info(GenContext *c, BEValue *value, Expr *ex
 				return;
 			}
 		case TYPEID_INFO_PARENTOF:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 void llvm_emit_try_unwrap_chain(GenContext *c, BEValue *value, Expr *expr)
@@ -6779,7 +6779,7 @@ static inline void llvm_emit_builtin_access(GenContext *c, BEValue *be_value, Ex
 			llvm_emit_type_from_any(c, be_value);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static LLVMValueRef llvm_get_benchmark_hook_global(GenContext *c, Expr *expr)
@@ -7109,7 +7109,7 @@ void llvm_emit_expr(GenContext *c, BEValue *value, Expr *expr)
 		case UNRESOLVED_EXPRS:
 		case EXPR_SUBSCRIPT_ASSIGN:
 			// These are folded in the semantic analysis step.
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case EXPR_LAMBDA:
 		case EXPR_COND:
 		case EXPR_ASM:
@@ -7119,7 +7119,7 @@ void llvm_emit_expr(GenContext *c, BEValue *value, Expr *expr)
 		case EXPR_NAMED_ARGUMENT:
 		case EXPR_BUILTIN:
 		case EXPR_OPERATOR_CHARS:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case EXPR_TWO:
 			llvm_emit_expr(c, value, expr->two_expr.first);
 			llvm_emit_expr(c, value, expr->two_expr.last);
@@ -7322,7 +7322,7 @@ void llvm_emit_expr(GenContext *c, BEValue *value, Expr *expr)
 			llvm_emit_bitaccess(c, value, expr);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 

--- a/src/compiler/llvm_codegen_function.c
+++ b/src/compiler/llvm_codegen_function.c
@@ -334,7 +334,7 @@ void llvm_emit_return_abi(GenContext *c, BEValue *return_value, BEValue *optiona
 		case ABI_ARG_EXPAND:
 			// Expands to multiple slots -
 			// Not applicable to return values.
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case ABI_ARG_EXPAND_COERCE:
 		{
 			// Pick the return as an address.
@@ -382,7 +382,7 @@ DIRECT_RETURN:
 			return;
 		}
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 void llvm_emit_return_implicit(GenContext *c)

--- a/src/compiler/llvm_codegen_stmt.c
+++ b/src/compiler/llvm_codegen_stmt.c
@@ -82,7 +82,7 @@ void llvm_emit_local_decl(GenContext *c, Decl *decl, BEValue *value)
 		case VARDECL_GLOBAL:
 		case VARDECL_MEMBER:
 		case VARDECL_BITMEMBER:
-			UNREACHABLE;
+			UNREACHABLE_VOID;
 		case VARDECL_PARAM:
 		{
 			Expr *init_expr = decl->var.init_expr;
@@ -104,7 +104,7 @@ void llvm_emit_local_decl(GenContext *c, Decl *decl, BEValue *value)
 			return;
 		case VARDECL_LOCAL_CT:
 		case VARDECL_LOCAL_CT_TYPE:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 
 	// Get the declaration and the LLVM type.
@@ -603,7 +603,7 @@ void llvm_emit_for_stmt(GenContext *c, Ast *ast)
 			llvm_emit_br(c, loop_start_block);
 			break;
 		case LOOP_NONE:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 
 	ASSERT(inc_block || body_block || cond_block);
@@ -1090,7 +1090,7 @@ void llvm_emit_break(GenContext *c, Ast *ast)
 			break;
 		case AST_FOREACH_STMT:
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	llvm_emit_jmp(c, jump);
 }
@@ -1106,13 +1106,13 @@ void llvm_emit_continue(GenContext *c, Ast *ast)
 		case AST_IF_STMT:
 		case AST_SWITCH_STMT:
 		case AST_FOREACH_STMT:
-			UNREACHABLE
+			UNREACHABLE_VOID
 			break;
 		case AST_FOR_STMT:
 			jump = jump_target->for_stmt.codegen.continue_block;
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	llvm_emit_jmp(c, jump);
 }
@@ -1644,7 +1644,7 @@ void llvm_emit_stmt(GenContext *c, Ast *ast)
 		case AST_CASE_STMT:
 		case AST_DEFAULT_STMT:
 		case CT_AST:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case AST_EXPR_STMT:
 			llvm_emit_expr_stmt(c, ast);
 			break;

--- a/src/compiler/llvm_codegen_type.c
+++ b/src/compiler/llvm_codegen_type.c
@@ -18,11 +18,11 @@ static inline LLVMTypeRef llvm_type_from_decl(GenContext *c, Decl *decl)
 		case NON_TYPE_DECLS:
 		case DECL_FNTYPE:
 		case DECL_INTERFACE:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case DECL_BITSTRUCT:
 			return llvm_get_type(c, decl->strukt.container_type->type);
 		case DECL_FUNC:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case DECL_TYPEDEF:
 			return llvm_get_type(c, decl->type);
 		case DECL_CONST_ENUM:
@@ -101,7 +101,7 @@ static void param_expand(GenContext *context, LLVMTypeRef** params_ref, Type *ty
 	switch (type->type_kind)
 	{
 		case TYPE_TYPEDEF:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_ARRAY:
 			for (ArraySize i = type->array.len; i > 0; i--)
 			{
@@ -144,7 +144,7 @@ static void param_expand(GenContext *context, LLVMTypeRef** params_ref, Type *ty
 			vec_add(*params_ref, llvm_get_type(context, type));
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static inline void add_func_type_param(GenContext *c, Type *param_type, ABIArgInfo *arg_info, LLVMTypeRef **params)
@@ -211,7 +211,7 @@ LLVMTypeRef llvm_update_prototype_abi(GenContext *c, FunctionPrototype *prototyp
 	switch (ret_arg_info->kind)
 	{
 		case ABI_ARG_EXPAND:
-			UNREACHABLE;
+			UNREACHABLE_VOID;
 		case ABI_ARG_INDIRECT:
 			vec_add(*params, c->ptr_type);
 			retval = llvm_get_type(c, type_void);
@@ -237,7 +237,7 @@ LLVMTypeRef llvm_update_prototype_abi(GenContext *c, FunctionPrototype *prototyp
 			retval = llvm_get_type(c, call_return_type);
 			break;
 		case ABI_ARG_DIRECT_SPLIT_STRUCT_I32:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case ABI_ARG_DIRECT_COERCE_INT:
 			retval = LLVMIntTypeInContext(c->context, type_size(call_return_type) * 8);
 			break;
@@ -311,7 +311,7 @@ LLVMTypeRef llvm_get_type(GenContext *c, Type *any_type)
 	{
 		case LOWERED_TYPES:
 			// If this is reachable, then we're not doing the proper lowering.
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_STRUCT:
 		case TYPE_UNION:
 			return any_type->backend_type = llvm_type_from_decl(c, any_type->decl);
@@ -647,7 +647,7 @@ LLVMValueRef llvm_get_typeid(GenContext *c, Type *type)
 		case TYPE_TYPEDEF:
 			return llvm_get_typeid(c, type->canonical);
 		case CT_TYPES:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_VOID:
 			return llvm_get_introspection_for_builtin_type(c, type, INTROSPECT_TYPE_VOID, 0);
 		case TYPE_BOOL:

--- a/src/compiler/number.c
+++ b/src/compiler/number.c
@@ -73,7 +73,7 @@ void expr_contract_array(ExprConst *expr_const, ConstKind contract_type)
 		case CONST_INIT_UNION:
 		case CONST_INIT_VALUE:
 		case CONST_INIT_ARRAY_VALUE:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case CONST_INIT_ARRAY:
 		{
 			FOREACH(ConstInitializer *, init, initializer->init_array.elements)
@@ -455,7 +455,7 @@ void const_init_to_scratch_buffer(ConstInitializer *init)
 			const_init_to_scratch_buffer(init->init_array_value.element);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 void expr_const_to_scratch_buffer(const ExprConst *expr)
 {
@@ -529,7 +529,7 @@ void expr_const_to_scratch_buffer(const ExprConst *expr)
 			return;
 		}
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 const char *expr_const_to_error_string(const ExprConst *expr)
 {

--- a/src/compiler/sema_asm.c
+++ b/src/compiler/sema_asm.c
@@ -521,6 +521,7 @@ static inline bool sema_check_asm_arg_value(SemaContext *context, AsmInlineBlock
 		return true;
 	}
 	TODO
+	return 0;
 }
 static inline bool sema_check_asm_arg(SemaContext *context, AsmInlineBlock *block, AsmInstruction *instr, AsmArgType arg_type, Expr *expr)
 {

--- a/src/compiler/sema_asm.c
+++ b/src/compiler/sema_asm.c
@@ -521,7 +521,7 @@ static inline bool sema_check_asm_arg_value(SemaContext *context, AsmInlineBlock
 		return true;
 	}
 	TODO
-	return 0;
+	UNREACHABLE
 }
 static inline bool sema_check_asm_arg(SemaContext *context, AsmInlineBlock *block, AsmInstruction *instr, AsmArgType arg_type, Expr *expr)
 {

--- a/src/compiler/sema_casts.c
+++ b/src/compiler/sema_casts.c
@@ -639,7 +639,7 @@ static void expr_recursively_rewrite_untyped_list(Expr *expr, Type *to_type)
 		case TYPE_STRUCT:
 			break;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 	Decl *decl = flat->decl;
 	Decl **members = decl->strukt.members;
@@ -1717,7 +1717,7 @@ static void vector_const_initializer_convert_to_type(ConstInitializer *initializ
 			break;
 		case CONST_INIT_UNION:
 		case CONST_INIT_STRUCT:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case CONST_INIT_ARRAY_VALUE:
 			vector_const_initializer_convert_to_type(initializer->init_array_value.element, to_type);
 			break;
@@ -1973,7 +1973,7 @@ static void cast_vec_to_vec(Expr *expr, Type *to_type)
 					expr_rewrite_to_float_to_int(expr, to_type);
 					return;
 				default:
-					UNREACHABLE;
+					UNREACHABLE_VOID;
 			}
 		}
 
@@ -1991,7 +1991,7 @@ static void cast_vec_to_vec(Expr *expr, Type *to_type)
 				expr_rewrite_to_int_to_float(expr, to_type);
 				return;
 			}
-			UNREACHABLE;
+			UNREACHABLE_VOID;
 		}
 
 		if (type_is_integer(from_element))
@@ -2019,14 +2019,14 @@ static void cast_vec_to_vec(Expr *expr, Type *to_type)
 				case TYPE_ANYFAULT:
 					expr_rewrite_to_int_to_ptr(expr, to_type);
 				default:
-					UNREACHABLE;
+					UNREACHABLE_VOID;
 			}
 		}
 		// The rest will be different pointer types
 		switch (to_element->type_kind)
 		{
 			case ALL_FLOATS:
-				UNREACHABLE
+				UNREACHABLE_VOID
 				return;
 			case TYPE_BOOL:
 			{
@@ -2046,7 +2046,7 @@ static void cast_vec_to_vec(Expr *expr, Type *to_type)
 				expr_rewrite_rvalue(expr, to_type);
 				return;
 			default:
-				UNREACHABLE;
+				UNREACHABLE_VOID;
 		}
 	}
 
@@ -2252,7 +2252,7 @@ static void cast_vecarr_to_slice(Expr *expr, Type *to_type)
 {
 	if (!sema_cast_const(expr))
 	{
-		UNREACHABLE
+		UNREACHABLE_VOID
 	}
 	ASSERT(expr_is_const(expr));
 	switch (expr->const_expr.const_kind)
@@ -2268,7 +2268,7 @@ static void cast_vecarr_to_slice(Expr *expr, Type *to_type)
 		case CONST_UNTYPED_LIST:
 		case CONST_REF:
 		case CONST_MEMBER:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case CONST_BYTES:
 		case CONST_STRING:
 			expr->type = to_type;
@@ -2280,7 +2280,7 @@ static void cast_vecarr_to_slice(Expr *expr, Type *to_type)
 			return;
 		}
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 static void cast_slice_to_vecarr(Expr *expr, Type *to_type)
 {
@@ -2297,7 +2297,7 @@ static void cast_slice_to_vecarr(Expr *expr, Type *to_type)
 				return;
 			}
 			default:
-				UNREACHABLE;
+				UNREACHABLE_VOID;
 		}
 	}
 	if (expr_is_const_slice(expr))

--- a/src/compiler/sema_decls.c
+++ b/src/compiler/sema_decls.c
@@ -2217,7 +2217,7 @@ static inline void sema_get_overload_arguments(Decl *method, Type **value_ref, T
 	switch (method->func_decl.operator)
 	{
 		case OVERLOAD_LEN:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case OVERLOAD_ELEMENT_AT:
 			*value_ref = type_no_optional(typeget(method->func_decl.signature.rtype)->canonical);
 			*index_ref = method->func_decl.signature.params[1]->type->canonical;
@@ -2231,7 +2231,7 @@ static inline void sema_get_overload_arguments(Decl *method, Type **value_ref, T
 			*index_ref = method->func_decl.signature.params[1]->type->canonical;
 			return;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 }
 

--- a/src/compiler/sema_initializers.c
+++ b/src/compiler/sema_initializers.c
@@ -1202,7 +1202,7 @@ static inline void sema_update_const_initializer_with_designator(
 			sema_update_const_initializer_with_designator_array(const_init, curr, end, value);
 			return;
 		default:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 }
 

--- a/src/compiler/sema_liveness.c
+++ b/src/compiler/sema_liveness.c
@@ -88,7 +88,7 @@ static void sema_trace_asm_arg_list(ExprAsmArg **list)
 				sema_trace_exprid_liveness(asm_arg->expr_id);
 				continue;
 		}
-		UNREACHABLE
+		UNREACHABLE_VOID
 	}
 }
 
@@ -102,7 +102,7 @@ static void sema_trace_stmt_liveness(Ast *ast)
 		case AST_CONTRACT:
 		case AST_FOREACH_STMT:
 		case AST_CONTRACT_FAULT:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case AST_ASM_STMT:
 			sema_trace_expr_list_liveness(ast->asm_stmt.args);
 			return;
@@ -196,7 +196,7 @@ static void sema_trace_stmt_liveness(Ast *ast)
 			sema_trace_stmt_chain_liveness(ast->contbreak_stmt.defers);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static void sema_trace_const_initializer_liveness(ConstInitializer *const_init)
@@ -245,7 +245,7 @@ static void sema_trace_const_initializer_liveness(ConstInitializer *const_init)
 			sema_trace_expr_liveness(const_init->init_value);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 
@@ -263,7 +263,7 @@ RETRY:
 		case EXPR_MEMBER_SET:
 		case EXPR_NAMED_ARGUMENT:
 		case UNRESOLVED_EXPRS:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case EXPR_TWO:
 			sema_trace_expr_liveness(expr->two_expr.first);
 			sema_trace_expr_liveness(expr->two_expr.last);
@@ -299,7 +299,7 @@ RETRY:
 					sema_trace_expr_liveness(exprptr(expr->expr_asm_arg.expr_id));
 					return;
 			}
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case EXPR_BINARY:
 		case EXPR_BITASSIGN:
 			sema_trace_expr_liveness(exprptr(expr->binary_expr.left));
@@ -418,7 +418,7 @@ RETRY:
 			return;
 		}
 		case EXPR_LAMBDA:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case EXPR_MACRO_BLOCK:
 		{
 			FOREACH(Decl *, val, expr->macro_block.params) sema_trace_decl_liveness(val);
@@ -454,7 +454,7 @@ RETRY:
 			switch (expr->slice_expr.range.range_type)
 			{
 				case RANGE_SINGLE_ELEMENT:
-					UNREACHABLE
+					UNREACHABLE_VOID
 				case RANGE_CONST_RANGE:
 					return;
 				case RANGE_DYNAMIC:
@@ -466,7 +466,7 @@ RETRY:
 					sema_trace_expr_liveness(exprptr(expr->slice_expr.range.start));
 					return;
 			}
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case EXPR_SUBSCRIPT:
 		case EXPR_SUBSCRIPT_ADDR:
 			sema_trace_expr_liveness(exprptr(expr->subscript_expr.expr));
@@ -512,7 +512,7 @@ RETRY:
 		case EXPR_LAST_FAULT:
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 void sema_trace_liveness(void)
@@ -639,7 +639,7 @@ RETRY:
 		case DECL_IMPORT:
 		case DECL_LABEL:
 		case DECL_MACRO:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case DECL_FNTYPE:
 			sema_trace_func_liveness(&decl->fntype_decl);
 			return;
@@ -673,6 +673,6 @@ RETRY:
 			}
 			return;
 		case DECL_DECLARRAY:
-			UNREACHABLE
+			UNREACHABLE_VOID
 	}
 }

--- a/src/compiler/sema_passes.c
+++ b/src/compiler/sema_passes.c
@@ -355,7 +355,7 @@ INLINE void register_includes(CompilationUnit *unit, Decl **decls)
 				include_decls = sema_load_include(unit, include);
 				break;
 			default:
-				UNREACHABLE
+				UNREACHABLE_VOID
 		}
 		FOREACH(Decl *, decl, include_decls)
 		{

--- a/src/compiler/semantic_analyser.c
+++ b/src/compiler/semantic_analyser.c
@@ -174,7 +174,7 @@ void sema_analyze_stage(Module *module, AnalysisStage stage)
 		switch (module->stage)
 		{
 			case ANALYSIS_NOT_BEGUN:
-				UNREACHABLE
+				UNREACHABLE_VOID
 			case ANALYSIS_MODULE_HIERARCHY:
 				sema_analyse_pass_module_hierarchy(module);
 				break;
@@ -264,7 +264,7 @@ static void register_generic_decls(CompilationUnit *unit, Decl **decls)
 			case DECL_ERASED:
 			case DECL_GROUP:
 			case DECL_LABEL:
-				UNREACHABLE
+				UNREACHABLE_VOID
 			case DECL_ALIAS:
 			case DECL_ATTRIBUTE:
 			case DECL_BITSTRUCT:

--- a/src/compiler/target.c
+++ b/src/compiler/target.c
@@ -1656,7 +1656,7 @@ static AlignData os_target_alignment_of_float(OsType os, ArchType arch, uint32_t
 		case ARCH_TYPE_UNKNOWN:
 		case ARCH_UNSUPPORTED:
 			UNREACHABLE_VOID;
-			return (AlignData) { 0, 0 };
+			break;
 		case ARCH_TYPE_X86:
 			if (os == OS_TYPE_ELFIAMCU && bits >= 32) return (AlignData) { 32, 32 };
 			if (os == OS_TYPE_WIN32 || os == OS_TYPE_NACL)

--- a/src/compiler/target.c
+++ b/src/compiler/target.c
@@ -251,7 +251,7 @@ static inline void target_setup_arm_abi(void)
 			compiler.platform.arm.abi_variant = ARM_ABI_AAPCS;
 			break;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static inline void target_setup_x86_abi(BuildTarget *target)
@@ -731,7 +731,7 @@ static void x86_features_add_feature(X86Features *cpu_features, X86Feature featu
 			x86_features_add_feature(cpu_features, X86_FEAT_AVX512FP16);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 
@@ -961,7 +961,7 @@ static void x86features_from_cpu(X86Features *cpu_features, X86CpuSet cpu_set)
 			x86_features_from_host(cpu_features);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static inline bool x86_has_all_features(X86Features *feature_to_test, X86Features *features_to_match)
@@ -1578,7 +1578,8 @@ static AlignData os_target_alignment_of_int(OsType os, ArchType arch, uint32_t b
 	{
 		case ARCH_TYPE_UNKNOWN:
 		case ARCH_UNSUPPORTED:
-			UNREACHABLE
+			UNREACHABLE_VOID;
+			return (AlignData) { 0, 0 };
 		case ARCH_TYPE_ARM:
 		case ARCH_TYPE_THUMB:
 		case ARCH_TYPE_ARMB:
@@ -1614,7 +1615,8 @@ static AlignData os_target_alignment_of_int(OsType os, ArchType arch, uint32_t b
 			if (os == OS_TYPE_WIN32 || os == OS_TYPE_NACL) return (AlignData) { 64, 64 };
 			return (AlignData) { 32, 64 };
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID;
+	return (AlignData) { 0, 0 };
 }
 
 static unsigned arch_big_endian(ArchType arch)
@@ -1653,7 +1655,8 @@ static AlignData os_target_alignment_of_float(OsType os, ArchType arch, uint32_t
 	{
 		case ARCH_TYPE_UNKNOWN:
 		case ARCH_UNSUPPORTED:
-			UNREACHABLE
+			UNREACHABLE_VOID;
+			return (AlignData) { 0, 0 };
 		case ARCH_TYPE_X86:
 			if (os == OS_TYPE_ELFIAMCU && bits >= 32) return (AlignData) { 32, 32 };
 			if (os == OS_TYPE_WIN32 || os == OS_TYPE_NACL)
@@ -1685,7 +1688,8 @@ static AlignData os_target_alignment_of_float(OsType os, ArchType arch, uint32_t
 			if (bits == 128 && os == OS_TYPE_ELFIAMCU) return (AlignData) { 32, 32 };
 			return (AlignData) { bits , bits };
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID;
+	return (AlignData) { 0, 0 };
 }
 
 static const char *os_dynamic_library_suffix(OsType os)
@@ -1924,7 +1928,7 @@ void target_setup(BuildTarget *target)
 	switch (target->optlevel)
 	{
 		case OPTIMIZATION_NOT_SET:
-			UNREACHABLE;
+			UNREACHABLE_VOID;
 		case OPTIMIZATION_AGGRESSIVE:
 			level = LLVMCodeGenLevelAggressive;
 			break;
@@ -1938,7 +1942,7 @@ void target_setup(BuildTarget *target)
 			level = LLVMCodeGenLevelNone;
 			break;
 		default:
-			UNREACHABLE;
+			UNREACHABLE_VOID;
 	}
 
 	compiler.platform.llvm_opt_level = (int)level;
@@ -2013,7 +2017,7 @@ void target_setup(BuildTarget *target)
 	switch (compiler.platform.arch)
 	{
 		case ARCH_UNSUPPORTED:
-			UNREACHABLE
+			UNREACHABLE_VOID
 			break;
 		case ARCH_TYPE_AARCH64:
 		case ARCH_TYPE_AARCH64_BE:

--- a/src/compiler/types.c
+++ b/src/compiler/types.c
@@ -86,6 +86,7 @@ Type *type_int_signed_by_bitsize(BitSize bitsize)
 		case 128: return type_i128;
 		default: FATAL_ERROR("Illegal bitsize %d", bitsize);
 	}
+	return 0;
 }
 Type *type_int_unsigned_by_bitsize(BitSize bit_size)
 {
@@ -98,6 +99,7 @@ Type *type_int_unsigned_by_bitsize(BitSize bit_size)
 		case 128: return type_u128;
 		default: FATAL_ERROR("Illegal bitsize");
 	}
+	return 0;
 }
 
 const char *type_quoted_error_string_maybe_with_path(Type *type, Type *other_type)
@@ -137,7 +139,7 @@ void type_append_name_to_scratch(Type *type)
 	{
 		case TYPE_POISONED:
 		case TYPE_TYPEDEF:
-			UNREACHABLE;
+			UNREACHABLE_VOID;
 		case TYPE_ENUM:
 		case TYPE_CONST_ENUM:
 		case TYPE_STRUCT:
@@ -186,7 +188,7 @@ void type_append_name_to_scratch(Type *type)
 		case TYPE_TYPEINFO:
 		case TYPE_MEMBER:
 		case TYPE_WILDCARD:
-			UNREACHABLE
+			UNREACHABLE_VOID
 			break;
 		case TYPE_FUNC_PTR:
 			type = type->pointer;
@@ -654,7 +656,7 @@ void type_mangle_introspect_name_to_buffer(Type *type)
 	switch (type->type_kind)
 	{
 		case CT_TYPES:
-			UNREACHABLE
+			UNREACHABLE_VOID
 		case TYPE_ANY:
 			scratch_buffer_append("any$");
 			return;
@@ -741,7 +743,7 @@ void type_mangle_introspect_name_to_buffer(Type *type)
 			type_mangle_introspect_name_to_buffer(type->canonical);
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 bool type_func_match(Type *fn_type, Type *rtype, unsigned arg_count, ...)

--- a/src/compiler/types.c
+++ b/src/compiler/types.c
@@ -86,7 +86,7 @@ Type *type_int_signed_by_bitsize(BitSize bitsize)
 		case 128: return type_i128;
 		default: FATAL_ERROR("Illegal bitsize %d", bitsize);
 	}
-	return 0;
+	UNREACHABLE
 }
 Type *type_int_unsigned_by_bitsize(BitSize bit_size)
 {
@@ -99,7 +99,7 @@ Type *type_int_unsigned_by_bitsize(BitSize bit_size)
 		case 128: return type_u128;
 		default: FATAL_ERROR("Illegal bitsize");
 	}
-	return 0;
+	UNREACHABLE
 }
 
 const char *type_quoted_error_string_maybe_with_path(Type *type, Type *other_type)

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -134,4 +134,4 @@
 
 void evprintf(const char *format, va_list list);
 void eprintf(const char *format, ...);
-NORETURN void error_exit(const char *format, ...) ;
+NORETURN void error_exit(const char *format, ...);

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -119,7 +119,8 @@
 
 #define ASSERT(_condition) do { if (!(_condition)) { FATAL_ERROR("Violated assert: " #_condition); } } while (0)
 #define WARNING(_string, ...) do { eprintf("WARNING: "); eprintf(_string, ##__VA_ARGS__); eprintf("\n"); } while(0)
-#define UNREACHABLE FATAL_ERROR("Should be unreachable");
+#define UNREACHABLE_VOID FATAL_ERROR("Should be unreachable");
+#define UNREACHABLE UNREACHABLE_VOID; return 0;
 
 #define TODO FATAL_ERROR("TODO reached");
 #define UNSUPPORTED do { error_exit("Unsupported functionality"); } while (0)

--- a/src/utils/json.c
+++ b/src/utils/json.c
@@ -174,7 +174,7 @@ static void json_parse_string(JsonParser *parser)
 	}
 
 
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static inline void json_lexer_advance(JsonParser *parser)
@@ -256,7 +256,7 @@ static inline void json_lexer_advance(JsonParser *parser)
 			json_error(parser, "Unexpected symbol found.");
 			return;
 	}
-	UNREACHABLE
+	UNREACHABLE_VOID
 }
 
 static inline bool consume(JsonParser *parser, JSONTokenType token)


### PR DESCRIPTION
This PR adds the ability for TinyCC to compile C3C.

Changes:
- `UNREACHABLE` -> `UNREACHABLE_VOID`
- `UNREACHABLE` now returns value `0` in order to satisfy error "function might return no value"
- `cmake` now has option called `TCC_LIB_PATH` which is a full path to `libtcc1.a` as C++ compiler is used for linking final executable

This PR should not break compiling using other compilers, hopefully.

TinyCC version used:
`tcc version 0.9.28rc 2025-09-04 mob@03072a30 (x86_64 Linux)`