### PR TITLE
Build linux binaries for releases with proper curl support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,7 +236,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install common deps
         run: |
-          sudo apt-get install zlib1g zlib1g-dev python3 ninja-build curl
+          sudo apt-get install zlib1g zlib1g-dev python3 ninja-build curl libcurl4-openssl-dev
 
       - name: Install Clang ${{matrix.llvm_version}}
         run: |
@@ -292,6 +292,10 @@ jobs:
                 -DLLVM_ENABLE_LIBXML2=OFF \
                 -DC3_LLVM_VERSION=${{matrix.llvm_version}}.1
           cmake --build build
+
+      - name: Vendor-fetch
+        run: |
+          ./build/c3c vendor-fetch raylib55
 
       - name: Compile and run some examples
         run: |
@@ -416,7 +420,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install common deps
         run: |
-          sudo apt-get install zlib1g zlib1g-dev python3 ninja-build curl
+          sudo apt-get install zlib1g zlib1g-dev python3 ninja-build curl libcurl4-openssl-dev
 
       - name: Install Clang ${{matrix.llvm_version}}
         run: |
@@ -460,6 +464,11 @@ jobs:
                 -DLLVM_ENABLE_LIBXML2=OFF \
                 -DC3_LLVM_VERSION=${{matrix.llvm_version}}.1
           cmake --build build
+
+      - name: Vendor-fetch
+        run: |
+          ./build/c3c vendor-fetch raylib55
+
       - name: Compile and run some examples
         run: |
           cd resources

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -293,10 +293,6 @@ jobs:
                 -DC3_LLVM_VERSION=${{matrix.llvm_version}}.1
           cmake --build build
 
-      - name: Vendor-fetch
-        run: |
-          ./build/c3c vendor-fetch raylib55
-
       - name: Compile and run some examples
         run: |
           cd resources
@@ -385,6 +381,10 @@ jobs:
           ./build/c3c init myproject
           ls myproject
 
+      - name: Vendor-fetch
+        run: |
+          ./build/c3c vendor-fetch raylib55
+
       - name: run compiler tests
         run: |
           cd test
@@ -465,10 +465,6 @@ jobs:
                 -DC3_LLVM_VERSION=${{matrix.llvm_version}}.1
           cmake --build build
 
-      - name: Vendor-fetch
-        run: |
-          ./build/c3c vendor-fetch raylib55
-
       - name: Compile and run some examples
         run: |
           cd resources
@@ -514,6 +510,10 @@ jobs:
         run: |
           cd resources/testproject
           ../../build/c3c run -vvv --linker=builtin --trust=full
+
+      - name: Vendor-fetch
+        run: |
+          ./build/c3c vendor-fetch raylib55
 
       - name: run compiler tests
         run: |

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 : ${DOCKER:=docker}
 : ${IMAGE:="c3c-builder"}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ENV LLVM_DEV_VERSION=20
 
 ARG CMAKE_VERSION=3.20
 
-RUN apt-get update && apt-get install -y wget gnupg software-properties-common zlib1g zlib1g-dev python3 ninja-build curl g++ && \
+RUN apt-get update && apt-get install -y wget gnupg software-properties-common zlib1g zlib1g-dev python3 ninja-build curl g++ libcurl4-openssl-dev && \
     wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-$CMAKE_VERSION-linux-x86_64.sh && \
     mkdir -p /opt/cmake && \
     sh cmake-${CMAKE_VERSION}-linux-x86_64.sh --prefix=/opt/cmake --skip-license && \


### PR DESCRIPTION
fixes #2460 and allows the linux binaries in releases to use `vendor-fetch`

I've tested this with the `build-with-docker.sh` script, but it should work the same for the github actions scripts as well