### PR TITLE
Find cl and set INCLUDE env var outside of a visual studio command promt 

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1754,7 +1754,7 @@ const char *default_c_compiler(void)
 		return cc;
 	}
 #if PLATFORM_WINDOWS
-	return cc = windows_get_cl();
+	return cc = windows_get_sdk()->cl_path;
 #else
 	return cc = "cc";
 #endif

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1754,7 +1754,7 @@ const char *default_c_compiler(void)
 		return cc;
 	}
 #if PLATFORM_WINDOWS
-	return cc = "cl.exe";
+	return cc = windows_get_cl();
 #else
 	return cc = "cc";
 #endif

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1756,11 +1756,11 @@ const char *default_c_compiler(void)
 #if PLATFORM_WINDOWS
 	WindowsSDK *sdk = windows_get_sdk();
 
-	if (sdk != NULL && sdk->cl_path != NULL) {
-		return sdk->cl_path;
-	} else {
-		return cc = "cl.exe";
+	if (sdk && sdk->cl_path)
+	{
+		return cc = sdk->cl_path;
 	}
+	return cc = "cl.exe";
 #else
 	return cc = "cc";
 #endif

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1754,7 +1754,13 @@ const char *default_c_compiler(void)
 		return cc;
 	}
 #if PLATFORM_WINDOWS
-	return cc = windows_get_sdk()->cl_path;
+	WindowsSDK *sdk = windows_get_sdk();
+
+	if (sdk != NULL && sdk->cl_path != NULL) {
+		return sdk->cl_path;
+	} else {
+		return cc = "cl.exe";
+	}
 #else
 	return cc = "cc";
 #endif

--- a/src/compiler/compiler_internal.h
+++ b/src/compiler/compiler_internal.h
@@ -2524,6 +2524,7 @@ bool arch_is_wasm(ArchType type);
 const char *macos_sysroot(void);
 MacSDK *macos_sysroot_sdk_information(const char *sdk_path);
 WindowsSDK *windows_get_sdk(void);
+const char *windows_get_cl(void);
 const char *windows_cross_compile_library(void);
 
 void c_abi_func_create(FunctionPrototype *proto);

--- a/src/compiler/compiler_internal.h
+++ b/src/compiler/compiler_internal.h
@@ -2524,7 +2524,6 @@ bool arch_is_wasm(ArchType type);
 const char *macos_sysroot(void);
 MacSDK *macos_sysroot_sdk_information(const char *sdk_path);
 WindowsSDK *windows_get_sdk(void);
-const char *windows_get_cl(void);
 const char *windows_cross_compile_library(void);
 
 void c_abi_func_create(FunctionPrototype *proto);

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -1031,6 +1031,10 @@ const char *cc_compiler(const char *cc, const char *file, const char *flags, con
 	const char ***args_ref = &parts;
 	add_quote_arg(cc);
 
+	if (is_cl_exe) {
+		add_plain_arg("/nologo");
+	}
+
 	FOREACH(const char *, include_dir, include_dirs)
 	{
 		add_concat_quote_arg(is_cl_exe ? "/I" : "-I ", include_dir);
@@ -1059,6 +1063,12 @@ const char *cc_compiler(const char *cc, const char *file, const char *flags, con
 		add_plain_arg("-o");
 		add_quote_arg(out_name);
 	}
+
+#if PLATFORM_WINDOWS
+	if (is_cl_exe) {
+		_putenv_s("INCLUDE", windows_get_sdk()->cl_include_env);
+	}
+#endif
 
 	const char *output = assemble_linker_command(parts, PLATFORM_WINDOWS);
 	DEBUG_LOG("Compiling c sources using '%s'", output);

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -1066,7 +1066,10 @@ const char *cc_compiler(const char *cc, const char *file, const char *flags, con
 
 #if PLATFORM_WINDOWS
 	if (is_cl_exe) {
-		_putenv_s("INCLUDE", windows_get_sdk()->cl_include_env);
+		WindowsSDK * sdk = windows_get_sdk();
+		if (sdk != NULL && sdk->cl_include_env != NULL) {
+			_putenv_s("INCLUDE", sdk->cl_include_env);
+		}
 	}
 #endif
 

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -1008,7 +1008,7 @@ const char *cc_compiler(const char *cc, const char *file, const char *flags, con
 	if (!dir) dir = compiler.build.build_dir;
 	if (output_subdir) dir = dir ? file_append_path(dir, output_subdir) : output_subdir;
 	if (dir) dir_make(dir);
-	bool is_cl_exe = str_ends_with(cc, "cl.exe");
+	bool is_cl_exe = str_has_suffix(cc, "cl.exe");
 	char *filename = NULL;
 	bool split_worked = file_namesplit(file, &filename, NULL);
 	if (!split_worked) error_exit("Cannot compile '%s'", file);
@@ -1031,9 +1031,7 @@ const char *cc_compiler(const char *cc, const char *file, const char *flags, con
 	const char ***args_ref = &parts;
 	add_quote_arg(cc);
 
-	if (is_cl_exe) {
-		add_plain_arg("/nologo");
-	}
+	if (is_cl_exe) add_plain_arg("/nologo");
 
 	FOREACH(const char *, include_dir, include_dirs)
 	{
@@ -1065,9 +1063,11 @@ const char *cc_compiler(const char *cc, const char *file, const char *flags, con
 	}
 
 #if PLATFORM_WINDOWS
-	if (is_cl_exe) {
-		WindowsSDK * sdk = windows_get_sdk();
-		if (sdk != NULL && sdk->cl_include_env != NULL) {
+	if (is_cl_exe)
+	{
+		WindowsSDK *sdk = windows_get_sdk();
+		if (sdk && sdk->cl_include_env)
+		{
 			_putenv_s("INCLUDE", sdk->cl_include_env);
 		}
 	}

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -1008,7 +1008,7 @@ const char *cc_compiler(const char *cc, const char *file, const char *flags, con
 	if (!dir) dir = compiler.build.build_dir;
 	if (output_subdir) dir = dir ? file_append_path(dir, output_subdir) : output_subdir;
 	if (dir) dir_make(dir);
-	bool is_cl_exe = str_has_suffix(cc, "cl.exe");
+	bool is_cl_exe = str_ends_with(cc, "cl.exe");
 	char *filename = NULL;
 	bool split_worked = file_namesplit(file, &filename, NULL);
 	if (!split_worked) error_exit("Cannot compile '%s'", file);

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -1008,7 +1008,7 @@ const char *cc_compiler(const char *cc, const char *file, const char *flags, con
 	if (!dir) dir = compiler.build.build_dir;
 	if (output_subdir) dir = dir ? file_append_path(dir, output_subdir) : output_subdir;
 	if (dir) dir_make(dir);
-	bool is_cl_exe = str_eq(cc, "cl.exe");
+	bool is_cl_exe = str_ends_with(cc, "cl.exe");
 	char *filename = NULL;
 	bool split_worked = file_namesplit(file, &filename, NULL);
 	if (!split_worked) error_exit("Cannot compile '%s'", file);

--- a/src/compiler/windows_support.c
+++ b/src/compiler/windows_support.c
@@ -16,32 +16,23 @@ static WindowsSDK *sdk = NULL;
 
 #if PLATFORM_WINDOWS
 
-WindowsSDK get_windows_link_paths(void);
-const char *get_windows_cl_path(void);
+WindowsSDK get_windows_paths(void);
 
 static WindowsSDK loaded;
 WindowsSDK *windows_get_sdk(void)
 {
 	if (!sdk)
 	{
-		loaded = get_windows_link_paths();
+		loaded = get_windows_paths();
 		sdk = &loaded;
 	}
 	return sdk;
-}
-
-const char * windows_get_cl(void) {
-	return get_windows_cl_path();
 }
 
 #else
 
 WindowsSDK *windows_get_sdk(void)
 {
-	return NULL;
-}
-
-const char * windows_get_cl(void) {
 	return NULL;
 }
 

--- a/src/compiler/windows_support.c
+++ b/src/compiler/windows_support.c
@@ -17,6 +17,7 @@ static WindowsSDK *sdk = NULL;
 #if PLATFORM_WINDOWS
 
 WindowsSDK get_windows_link_paths(void);
+const char *get_windows_cl_path(void);
 
 static WindowsSDK loaded;
 WindowsSDK *windows_get_sdk(void)
@@ -29,10 +30,18 @@ WindowsSDK *windows_get_sdk(void)
 	return sdk;
 }
 
+const char * windows_get_cl(void) {
+	return get_windows_cl_path();
+}
+
 #else
 
 WindowsSDK *windows_get_sdk(void)
 {
+	return NULL;
+}
+
+const char * windows_get_cl(void) {
 	return NULL;
 }
 

--- a/src/utils/find_msvc.c
+++ b/src/utils/find_msvc.c
@@ -2,8 +2,6 @@
 
 #if PLATFORM_WINDOWS
 
-#include "vmem.h"
-
 #include <windows.h>
 #include <string.h>
 #include <stdio.h>
@@ -38,7 +36,6 @@ WindowsSDK get_windows_paths()
 	if (!windows_sdk_include_root)
 	{
 		free(root);
-		vmem_free(out.windows_sdk_path);
 		error_exit("Failed to find Include dir in windows kit root.");
 	}
 
@@ -67,8 +64,6 @@ WindowsSDK get_windows_paths()
 	}
 
 	free(root);
-	vmem_free(vs_path);
-	vmem_free(windows_sdk_include_root);
 	return out;
 }
 

--- a/src/utils/find_msvc.c
+++ b/src/utils/find_msvc.c
@@ -45,8 +45,8 @@ WindowsSDK get_windows_paths()
 	scratch_buffer_printf("%s\\lib\\x64", vs_path);
 	out.vs_library_path = scratch_buffer_copy();
 
-	if (getenv("INCLUDE") == NULL) {
-
+	if (!getenv("INCLUDE"))
+	{
 		scratch_buffer_clear();
 		scratch_buffer_printf("%s\\bin\\Hostx64\\x64\\cl.exe", vs_path);
 		out.cl_path = scratch_buffer_copy();

--- a/src/utils/find_msvc.c
+++ b/src/utils/find_msvc.c
@@ -57,7 +57,7 @@ const char *get_windows_cl_path(void)
 
 	// We have the version, so we're done with the path:
 	scratch_buffer_clear();
-	scratch_buffer_printf("%s\\VC\\Tools\\MSVC\\%s\\bin\\Hostx64\\x64\\", install_path, version);
+	scratch_buffer_printf("%s\\VC\\Tools\\MSVC\\%s\\bin\\Hostx64\\x64\\cl.exe", install_path, version);
 	return scratch_buffer_copy();
 }
 

--- a/src/utils/find_msvc.c
+++ b/src/utils/find_msvc.c
@@ -10,19 +10,35 @@
 
 static char *find_visual_studio(void);
 static char *find_windows_kit_root(void);
+static char *find_best_version(const char *root, const char *subdir);
 
 WindowsSDK get_windows_paths()
 {
 	WindowsSDK out = {0};
 
-	char *path = find_windows_kit_root();
+	char *root = find_windows_kit_root();
 
-	if (!path)
+	if (!root)
 	{
 		error_exit("Failed to find windows kit root.");
 	}
 
-	out.windows_sdk_path = path;
+	out.windows_sdk_path = find_best_version(root, "Lib");
+
+	if (!out.windows_sdk_path)
+	{	
+		free(root);
+		error_exit("Failed to find Lib dir in windows kit root.");
+	}
+
+	char *windows_sdk_include_root = find_best_version(root, "Include");
+
+	if (!windows_sdk_include_root)
+	{
+		free(root);
+		vmem_free(out.windows_sdk_path);
+		error_exit("Failed to find Include dir in windows kit root.");
+	}
 
 	char *vs_path = find_visual_studio();
 
@@ -35,11 +51,19 @@ WindowsSDK get_windows_paths()
 	out.cl_path = scratch_buffer_copy();
 
 	scratch_buffer_clear();
-	scratch_buffer_printf("%s\\include", vs_path);
-	out.cl_include = scratch_buffer_copy();
+	scratch_buffer_printf("%s\\include;", vs_path);
+	scratch_buffer_printf("%s\\cppwinrt;", windows_sdk_include_root);
+	scratch_buffer_printf("%s\\cppwinrt;", windows_sdk_include_root);
+	scratch_buffer_printf("%s\\shared;", windows_sdk_include_root);
+	scratch_buffer_printf("%s\\ucrt;", windows_sdk_include_root);
+	scratch_buffer_printf("%s\\um;", windows_sdk_include_root);
+	scratch_buffer_printf("%s\\winrt;", windows_sdk_include_root);
 
+	out.cl_include_env = scratch_buffer_copy();
+
+	free(root);
 	vmem_free(vs_path);
-
+	vmem_free(windows_sdk_include_root);
 	return out;
 }
 
@@ -76,7 +100,6 @@ static char *find_visual_studio(void)
 	return scratch_buffer_copy();
 }
 
-
 static char *find_windows_kit_root(void)
 {
 	HKEY main_key;
@@ -105,9 +128,15 @@ static char *find_windows_kit_root(void)
 	char *root = win_utf16to8(value);
 	free(value);
 
+	return root;
+}
+
+static char *find_best_version(const char *root, const char *subdir)
+{
 	scratch_buffer_clear();
 	scratch_buffer_append(root);
-	scratch_buffer_append("Lib\\*");
+	scratch_buffer_append(subdir);
+	scratch_buffer_append("\\*");
 
 	WIN32_FIND_DATAW find_data;
 	uint16_t *wildcard_name = win_utf8to16(scratch_buffer_to_string());
@@ -140,19 +169,18 @@ static char *find_windows_kit_root(void)
 	while (FindNextFileW(handle, &find_data));
 	FindClose(handle);
 
-	if (!best_file) goto SEARCH_FAILED;;
+	if (!best_file) goto SEARCH_FAILED;
 
 	scratch_buffer_clear();
 	scratch_buffer_append(root);
-	scratch_buffer_append("Lib\\");
+	scratch_buffer_append(subdir);
+	scratch_buffer_append("\\");
 	scratch_buffer_append(best_file);
 
-	free(root);
 	free(best_file);
 	return scratch_buffer_copy();
 
 SEARCH_FAILED:
-	free(root);
 	return NULL;
 }
 

--- a/src/utils/find_msvc.c
+++ b/src/utils/find_msvc.c
@@ -28,6 +28,38 @@ WindowsSDK get_windows_link_paths()
 	return out;
 }
 
+const char *get_windows_cl_path(void)
+{
+	// Let's locate vswhere.exe
+	char *path = win_utf16to8(_wgetenv(L"ProgramFiles(x86)"));
+	scratch_buffer_clear();
+	scratch_buffer_printf("\"%s\\Microsoft Visual Studio\\Installer\\vswhere.exe\" -latest -prerelease -property installationPath -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -products *", path);
+	char *install_path = NULL;
+
+	// Call vswhere.exe
+	if (!execute_cmd_failable(scratch_buffer_to_string(), &install_path, NULL, 0))
+	{
+		error_exit("Failed to find vswhere.exe to detect MSVC.");
+	}
+
+	// Find and read the version file.
+	scratch_buffer_clear();
+	scratch_buffer_printf("%s\\VC\\Auxiliary\\Build\\Microsoft.VCToolsVersion.default.txt", install_path);
+	const char *version_file = scratch_buffer_to_string();
+	DEBUG_LOG("MSVC version file: %s", version_file);
+	size_t size;
+	char *version = file_read_all(scratch_buffer_to_string(), &size);
+	if (version) version = str_trim(version);
+	if (!version || strlen(version) == 0)
+	{
+		error_exit("Failed to detect MSVC, could not read %s.", scratch_buffer_to_string());
+	}
+
+	// We have the version, so we're done with the path:
+	scratch_buffer_clear();
+	scratch_buffer_printf("%s\\VC\\Tools\\MSVC\\%s\\bin\\Hostx64\\x64\\", install_path, version);
+	return scratch_buffer_copy();
+}
 
 static char *find_visual_studio(void)
 {

--- a/src/utils/find_msvc.c
+++ b/src/utils/find_msvc.c
@@ -2,6 +2,8 @@
 
 #if PLATFORM_WINDOWS
 
+#include "vmem.h"
+
 #include <windows.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/utils/find_msvc.c
+++ b/src/utils/find_msvc.c
@@ -46,20 +46,23 @@ WindowsSDK get_windows_paths()
 	scratch_buffer_printf("%s\\lib\\x64", vs_path);
 	out.vs_library_path = scratch_buffer_copy();
 
-	scratch_buffer_clear();
-	scratch_buffer_printf("%s\\bin\\Hostx64\\x64\\cl.exe", vs_path);
-	out.cl_path = scratch_buffer_copy();
+	if (getenv("INCLUDE") == NULL) {
 
-	scratch_buffer_clear();
-	scratch_buffer_printf("%s\\include;", vs_path);
-	scratch_buffer_printf("%s\\cppwinrt;", windows_sdk_include_root);
-	scratch_buffer_printf("%s\\cppwinrt;", windows_sdk_include_root);
-	scratch_buffer_printf("%s\\shared;", windows_sdk_include_root);
-	scratch_buffer_printf("%s\\ucrt;", windows_sdk_include_root);
-	scratch_buffer_printf("%s\\um;", windows_sdk_include_root);
-	scratch_buffer_printf("%s\\winrt;", windows_sdk_include_root);
+		scratch_buffer_clear();
+		scratch_buffer_printf("%s\\bin\\Hostx64\\x64\\cl.exe", vs_path);
+		out.cl_path = scratch_buffer_copy();
 
-	out.cl_include_env = scratch_buffer_copy();
+		scratch_buffer_clear();
+		scratch_buffer_printf("%s\\include;", vs_path);
+		scratch_buffer_printf("%s\\cppwinrt;", windows_sdk_include_root);
+		scratch_buffer_printf("%s\\cppwinrt;", windows_sdk_include_root);
+		scratch_buffer_printf("%s\\shared;", windows_sdk_include_root);
+		scratch_buffer_printf("%s\\ucrt;", windows_sdk_include_root);
+		scratch_buffer_printf("%s\\um;", windows_sdk_include_root);
+		scratch_buffer_printf("%s\\winrt;", windows_sdk_include_root);
+
+		out.cl_include_env = scratch_buffer_copy();
+	}
 
 	free(root);
 	vmem_free(vs_path);

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -155,6 +155,7 @@ bool str_is_valid_constant(const char *string);
 const char *str_unescape(char *string);
 bool str_is_identifier(const char *string);
 bool str_eq(const char *str1, const char *str2);
+bool str_ends_with(const char *str1, const char *str2);
 bool str_is_type(const char *string);
 bool slice_is_type(const char *string, size_t);
 bool str_is_integer(const char *string);

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -40,6 +40,8 @@ typedef struct
 typedef struct {
 	char* windows_sdk_path;
 	char* vs_library_path;
+	char* cl_path;
+	char* cl_include;
 } WindowsSDK;
 
 #define MAX_STRING_BUFFER 0x10000

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -155,7 +155,7 @@ bool str_is_valid_constant(const char *string);
 const char *str_unescape(char *string);
 bool str_is_identifier(const char *string);
 bool str_eq(const char *str1, const char *str2);
-bool str_ends_with(const char *str1, const char *str2);
+bool str_ends_with(const char *str, const char *end);
 bool str_is_type(const char *string);
 bool slice_is_type(const char *string, size_t);
 bool str_is_integer(const char *string);

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -153,6 +153,7 @@ bool str_is_valid_constant(const char *string);
 const char *str_unescape(char *string);
 bool str_is_identifier(const char *string);
 bool str_eq(const char *str1, const char *str2);
+bool str_ends_with(const char *str1, const char *str2);
 bool str_is_type(const char *string);
 bool slice_is_type(const char *string, size_t);
 bool str_is_integer(const char *string);

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -41,7 +41,7 @@ typedef struct {
 	char* windows_sdk_path;
 	char* vs_library_path;
 	char* cl_path;
-	char* cl_include;
+	char* cl_include_env;
 } WindowsSDK;
 
 #define MAX_STRING_BUFFER 0x10000

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -155,7 +155,6 @@ bool str_is_valid_constant(const char *string);
 const char *str_unescape(char *string);
 bool str_is_identifier(const char *string);
 bool str_eq(const char *str1, const char *str2);
-bool str_ends_with(const char *str1, const char *str2);
 bool str_is_type(const char *string);
 bool slice_is_type(const char *string, size_t);
 bool str_is_integer(const char *string);

--- a/src/utils/stringutils.c
+++ b/src/utils/stringutils.c
@@ -143,6 +143,14 @@ bool str_eq(const char *str1, const char *str2)
 	return str1 == str2 || (str1 && str2 && strcmp(str1, str2) == 0);
 }
 
+bool str_ends_with(const char *str1, const char *str2)
+{
+	size_t len1 = strlen(str1);
+	size_t len2 = strlen(str2);
+	if (len2 > len1) return false;
+	return memcmp(str1 + len1 - len2, str2, len2) == 0;
+}
+
 bool str_is_integer(const char *string)
 {
 	if (string[0] == '-') string++;

--- a/src/utils/stringutils.c
+++ b/src/utils/stringutils.c
@@ -234,14 +234,6 @@ bool str_has_suffix(const char *name, const char *suffix)
 	return memcmp(name + name_len - suffix_len, suffix, suffix_len) == 0;
 }
 
-bool str_ends_with(const char *str1, const char *str2)
-{
-	size_t len1 = strlen(str1);
-	size_t len2 = strlen(str2);
-	if (len2 > len1) return false;
-	return memcmp(str1 + len1 - len2, str2, len2) == 0;
-}
-
 bool str_start_with(const char *name, const char *prefix)
 {
 	size_t suffix_len = strlen(prefix);

--- a/src/utils/stringutils.c
+++ b/src/utils/stringutils.c
@@ -143,14 +143,6 @@ bool str_eq(const char *str1, const char *str2)
 	return str1 == str2 || (str1 && str2 && strcmp(str1, str2) == 0);
 }
 
-bool str_ends_with(const char *str1, const char *str2)
-{
-	size_t len1 = strlen(str1);
-	size_t len2 = strlen(str2);
-	if (len2 > len1) return false;
-	return memcmp(str1 + len1 - len2, str2, len2) == 0;
-}
-
 bool str_is_integer(const char *string)
 {
 	if (string[0] == '-') string++;

--- a/src/utils/stringutils.c
+++ b/src/utils/stringutils.c
@@ -143,6 +143,14 @@ bool str_eq(const char *str1, const char *str2)
 	return str1 == str2 || (str1 && str2 && strcmp(str1, str2) == 0);
 }
 
+bool str_ends_with(const char *str, const char *end)
+{
+	size_t str_len = strlen(str);
+	size_t end_len = strlen(end);
+	if (end_len > str_len) return false;
+	return memcmp(str + str_len - end_len, end, end_len) == 0;
+}
+
 bool str_is_integer(const char *string)
 {
 	if (string[0] == '-') string++;
@@ -224,6 +232,14 @@ bool str_has_suffix(const char *name, const char *suffix)
 	size_t suffix_len = strlen(suffix);
 	if (name_len <= suffix_len) return false;
 	return memcmp(name + name_len - suffix_len, suffix, suffix_len) == 0;
+}
+
+bool str_ends_with(const char *str1, const char *str2)
+{
+	size_t len1 = strlen(str1);
+	size_t len2 = strlen(str2);
+	if (len2 > len1) return false;
+	return memcmp(str1 + len1 - len2, str2, len2) == 0;
 }
 
 bool str_start_with(const char *name, const char *prefix)


### PR DESCRIPTION
If we are running outside a visual studio command prompt find an appropriate cl and the set the INCLUDE env var.

This allowed me to build the https://github.com/floooh/sokol-c3 examples in a git bash terminal on windows.

I referenced https://github.com/rust-lang/cc-rs/tree/main/find-msvc-tools to figure out what includes to set