### PR TITLE
Implement write_to_stdin() in std::os::process

### DIFF
--- a/lib/std/os/subprocess.c3
+++ b/lib/std/os/subprocess.c3
@@ -531,3 +531,9 @@ fn bool? SubProcess.is_running(&self)
 		return false;
 	$endif
 }
+
+fn usz? SubProcess.write_to_stdin(&self, char[] buffer)
+{
+	if (!self.stdin_file) return FAILED_TO_OPEN_STDIN?;
+	return os::native_fwrite(self.stdin_file, buffer);
+}

--- a/test/unit/stdlib/os/subprocess.c3
+++ b/test/unit/stdlib/os/subprocess.c3
@@ -145,7 +145,11 @@ fn void test_inherit_stdio_redirect()
 }
 
 fn void test_write_to_stdin() @test {
+$if env::WIN32:
+	SubProcess? subprocess = process::create({`powershell`, `-C`, `Read-Host`}, {.inherit_environment = true});
+$else
 	SubProcess? subprocess = process::create({"tee"}, {.read_async = true});
+$endif
 	test::eq(@ok(subprocess), true);
 	usz? write = subprocess!!.write_to_stdin(")");
 	test::eq(@ok(write), true);

--- a/test/unit/stdlib/os/subprocess.c3
+++ b/test/unit/stdlib/os/subprocess.c3
@@ -143,3 +143,17 @@ fn void test_inherit_stdio_redirect()
     assert(stdout_bytes == 0, "Should read 0 bytes from stdout");
     assert(stderr_bytes == 0, "Should read 0 bytes from stderr");
 }
+
+fn void test_write_to_stdin() @test {
+	SubProcess? subprocess = process::create({"tee"}, {.read_async = true});
+	test::eq(@ok(subprocess), true);
+	usz? write = subprocess!!.write_to_stdin(")");
+	test::eq(@ok(write), true);
+	test::eq(write!!, 1);
+	char buf;
+	test::eq(@ok(subprocess!!.join()), true);
+	usz? read = subprocess!!.read_stdout(&buf, 1);
+	test::eq(@ok(read), true);
+	test::eq(read!!, 1);
+	test::eq(buf, ')');
+}


### PR DESCRIPTION
Implementing feature `write_to_stdin` described in #2478