### PR TITLE
fix overriding with custom patches in the nix build

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,13 +9,13 @@
   rev,
   debug ? false,
   checks ? false,
-}: let 
+}: let
   inherit (builtins) readFile elemAt;
   # inherit (lib.sources) cleanSourceWith cleanSource; 
   inherit (lib.lists) findFirst;
   inherit (lib.asserts) assertMsg;
   inherit (lib.strings) hasInfix splitString removeSuffix removePrefix optionalString;
-in llvmPackages.stdenv.mkDerivation (_: 
+in llvmPackages.stdenv.mkDerivation (_:
 {
   pname = "c3c${optionalString debug "-debug"}";
 
@@ -33,7 +33,7 @@ in llvmPackages.stdenv.mkDerivation (_:
   # Here we substitute GIT_HASH which is not set for cmake in nix builds.
   # Similar situation is with __DATE__ and __TIME__ macros, which are
   # set to "Jan 01 1980 00:00:00" by default.
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace git_hash.cmake --replace-fail "\''${GIT_HASH}" "${rev}"
 
     local FILE_NAMES="$(find src -type f)"
@@ -49,8 +49,8 @@ in llvmPackages.stdenv.mkDerivation (_:
     "-DLLVM_CRT_LIBRARY_DIR=${llvmPackages.compiler-rt}/lib/darwin"
   ];
 
-  nativeBuildInputs = [ 
-    cmake 
+  nativeBuildInputs = [
+    cmake
     llvmPackages.llvm
     llvmPackages.lld 
     llvmPackages.compiler-rt
@@ -71,6 +71,7 @@ in llvmPackages.stdenv.mkDerivation (_:
   # In check phase we preserve BUILD directory as
   # we need to return to it before install phase
   checkPhase = ''
+    runHook preCheck
     local BUILD_DIR=$(pwd)
     
     cd ../resources/testproject
@@ -80,6 +81,7 @@ in llvmPackages.stdenv.mkDerivation (_:
     ../build/c3c compile-run -O1 src/test_suite_runner.c3 -- ../build/c3c ./test_suite
     
     cd $BUILD_DIR
+    runHook postCheck
   '';
 
   meta = with lib; {


### PR DESCRIPTION
The previous method of setting the correct date in the nix build was to override the `patchPhase` and substitute them there, the problem is that this will completely remove the ability to patch the compiler at build time through this method:
```nix
pkgs.c3c.overrideAttrs {
  patches = [ ./my_custom_c3c_patch.diff ];
}
```
following the advice at https://github.com/jtojnar/nixpkgs-hammering/blob/main/explanations/patch-phase.md I have moved the date substitution to the `postPatch` phase and tested that it still correctly sets the date at build time.
I have also added calls to the `preCheck` and `postCheck` hooks, which will also allow them to be overridden if needed.