### PR TITLE
Add $schema to project_default_keys

### DIFF
--- a/src/build/project.c
+++ b/src/build/project.c
@@ -7,6 +7,7 @@
 
 
 const char *project_default_keys[][2] = {
+		{"$schema", "Json schema url"},
 		{"authors", "Authors, optionally with email."},
 		{"benchfn", "Override the benchmark function."},
 		{"build-dir", "Build location, where intermediate files are placed by default, relative to project file."},


### PR DESCRIPTION
As noted in #2066 adding $schema to project.json causes compiler to emit a WARNING.
Adding $schema to avoid compiler WARNING about an unknown parameter.

