### PR TITLE
[stdlib] macOS - Add objc and core foundation types and enums.

### DIFF
--- a/lib/std/os/macos/core_foundation.c3
+++ b/lib/std/os/macos/core_foundation.c3
@@ -33,9 +33,6 @@ struct CGRect
 	CGSize size;
 }
 
-const CGFloat NS_VARIABLE_STATUS_ITEM_LENGTH = -1.0;
-const CGFloat NS_SQUARE_STATUS_ITEM_LENGTH = -2.0;
-
 extern fn ZString CFString.getCStringPtr(&self, CFStringEncoding encoding) @cname("CFStringGetCStringPtr");
 extern fn ZString CFString.getCString(&self, char* buffer, usz len, CFStringEncoding encoding) @cname("CFStringGetCString");
 

--- a/lib/std/os/macos/objc.c3
+++ b/lib/std/os/macos/objc.c3
@@ -71,7 +71,10 @@ extern fn ObjcIvar getInstanceVariable(ObjcId id, ZString name, void* outValue) 
 extern fn ObjcIvar setInstanceVariable(ObjcId id, ZString name, void* value) @cname("object_setInstanceVariable");
 extern fn ObjcClass allocateClassPair(ObjcClass cls, ZString name, uint extraBytes) @cname("objc_allocateClassPair");
 
-enum StatusItemLength : (double val) @deprecated("Use NS_VARIABLE_STATUS_ITEM_LENGTH and NS_SQUARE_STATUS_ITEM_LENGTH from std::os::macos::cf.")
+module std::os::macos::objc::ns @if(env::DARWIN) @link(env::DARWIN, "CoreFoundation.framework");
+import std::os::macos::cf;
+
+enum StatusItemLength : (double val) @deprecated("Use NSStatusItemLength.")
 {
     VARIABLE = -1.0,
     SQUARE   = -2.0,
@@ -236,7 +239,7 @@ fn EventType? event_type_from(int val) @deprecated("Use NSEventType directly.")
         case EventType.PRESSURE.val:            return PRESSURE;
         case EventType.DIRECT_TOUCH.val:        return DIRECT_TOUCH;
         case EventType.CHANGE_MODE.val:         return CHANGE_MODE;
-        default: return UNKNOWN_EVENT?;
+        default: return objc::UNKNOWN_EVENT?;
     }
 }
 
@@ -315,7 +318,7 @@ enum NSEventMask : const inline ulong
 	ANY                 = ulong.max,
 }
 
-fn NSEventMask ns_eventMaskFromType(NSEventType type) => (NSEventMask)1ul << type;
+fn NSEventMask event_mask_from_type(NSEventType type) => (NSEventMask)1ul << type;
 
 enum EventModifierFlag : (int val) @deprecated("Use NSEventModifierFlags.")
 {
@@ -397,3 +400,10 @@ enum NSWindowTabbingMode : const inline NSInteger
 	DISALLOWED  = 2,
 	PREFERRED   = 1,
 }
+
+enum NSStatusItemLength : const inline CGFloat
+{
+	VARIABLE = -1.0,
+	SQUARE = -2.0
+}
+

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -23,9 +23,9 @@
 
 ### Stdlib changes
 - Add `CGFloat` `CGPoint` `CGSize` `CGRect` types to core_foundation (macOS).
-- Add `NS_VARIABLE_STATUS_ITEM_LENGTH` and `NS_SQUARE_STATUS_ITEM_LENGTH` constants to core_foundation (macOS).
+- Add `NSStatusItem` const enum to ns module (macOS).
 - Add `NSWindowCollectionBehavior` `NSWindowLevel` `NSWindowTabbingMode` to objc (macOS).
-- Add `ns_eventMaskFromType` function to objc (macOS).
+- Add `ns::eventmask_from_type` function to objc (macOS).
 - Deprecate objc enums in favour of const inline enums backed by NS numerical types, and with the NS prefix, to better align with the objc api (macOS).
 - Deprecate `event_type_from` function in favour of using NSEvent directly, to better align with the objc api (macOS).
 - Add unit tests for objc and core_foundation (macOS).

--- a/src/compiler_tests/benchmark.c
+++ b/src/compiler_tests/benchmark.c
@@ -10,6 +10,7 @@ BenchTime begin;
 
 #if USE_PTHREAD
 
+
 void bench_begin(void)
 {
 	clock_gettime(CLOCK_MONOTONIC, &begin);

--- a/test/unit/stdlib/os/macos/core_foundation.c3
+++ b/test/unit/stdlib/os/macos/core_foundation.c3
@@ -58,11 +58,6 @@ fn void test_cgrect()
 	assert(rect2.size.width == 50.0);
 }
 
-fn void test_status_item_length()
-{
-	assert(NS_VARIABLE_STATUS_ITEM_LENGTH == -1.0);
-	assert(NS_SQUARE_STATUS_ITEM_LENGTH == -2.0);
-}
 
 fn void test_geometry_struct_sizes()
 {

--- a/test/unit/stdlib/os/macos/objc.c3
+++ b/test/unit/stdlib/os/macos/objc.c3
@@ -43,11 +43,11 @@ fn void test_event_type()
 
 fn void test_event_mask_from_type()
 {
-	NSEventMask maskMouseDown = ns_eventMaskFromType(NSEventType.LEFT_MOUSE_DOWN);
-	NSEventMask maskKeyDown = ns_eventMaskFromType(NSEventType.KEY_DOWN);
-	NSEventMask maskKeyUp = ns_eventMaskFromType(NSEventType.KEY_UP);
-	NSEventMask maskSmartMagnify = ns_eventMaskFromType(NSEventType.SMART_MAGNIFY);
-	NSEventMask maskDirectTouch = ns_eventMaskFromType(NSEventType.DIRECT_TOUCH);
+	NSEventMask maskMouseDown = ns::event_mask_from_type(NSEventType.LEFT_MOUSE_DOWN);
+	NSEventMask maskKeyDown = ns::event_mask_from_type(NSEventType.KEY_DOWN);
+	NSEventMask maskKeyUp = ns::event_mask_from_type(NSEventType.KEY_UP);
+	NSEventMask maskSmartMagnify = ns::event_mask_from_type(NSEventType.SMART_MAGNIFY);
+	NSEventMask maskDirectTouch = ns::event_mask_from_type(NSEventType.DIRECT_TOUCH);
 
 	assert(maskMouseDown == NSEventMask.LEFT_MOUSE_DOWN);
 	assert(maskKeyDown == NSEventMask.KEY_DOWN);
@@ -78,6 +78,13 @@ fn void test_event_mask()
 
 	NSEventMask combined = NSEventMask.KEY_DOWN | NSEventMask.FLAGS_CHANGED;
 	assert(combined == ((1ul << 10) | (1ul << 12)));
+}
+
+
+fn void test_status_item_length()
+{
+	assert(NSStatusItemLength.VARIABLE == -1.0);
+	assert(NSStatusItemLength.SQUARE == -2.0);
 }
 
 fn void test_event_modifier_flags()


### PR DESCRIPTION
Add additional objc types:
- CGFloat, CGPoint, CGSize, CGRect
- WindowCollectionBehavior, WindowLevel, WindowTabbingMode

Change EventMask to be a `ulong` to better align with objc's `unsigned long long`.

Change existing enum backing types to NSInteger/NSUInteger for 32/64 bit platform compatibility, and to better align with the objc implementations.

Add unit tests for the objc and core_foundation modules.