### PR TITLE
Add NSApplicationTerminateReply and registerClassPair to objc stdlib

### DIFF
--- a/lib/std/os/macos/objc.c3
+++ b/lib/std/os/macos/objc.c3
@@ -70,6 +70,7 @@ extern fn bool class_addMethod(ObjcClass cls, ObjcSelector name, void* imp, ZStr
 extern fn ObjcIvar getInstanceVariable(ObjcId id, ZString name, void* outValue) @cname("object_getInstanceVariable");
 extern fn ObjcIvar setInstanceVariable(ObjcId id, ZString name, void* value) @cname("object_setInstanceVariable");
 extern fn ObjcClass allocateClassPair(ObjcClass cls, ZString name, uint extraBytes) @cname("objc_allocateClassPair");
+extern fn void registerClassPair(ObjcClass cls) @cname("objc_registerClassPair");
 
 module std::os::macos::objc::ns @if(env::DARWIN) @link(env::DARWIN, "CoreFoundation.framework");
 import std::os::macos::cf;
@@ -407,3 +408,9 @@ enum NSStatusItemLength : const inline CGFloat
 	SQUARE = -2.0
 }
 
+enum NSApplicationTerminateReply : const inline NSUInteger
+{
+	CANCEL = 0,
+	NOW = 1,
+	LATER = 2,
+}

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -46,12 +46,14 @@
 ### Stdlib changes
 - Add `CGFloat` `CGPoint` `CGSize` `CGRect` types to core_foundation (macOS).
 - Add `NSStatusItem` const enum to ns module (macOS).
-- Add `NSWindowCollectionBehavior` `NSWindowLevel` `NSWindowTabbingMode` to objc (macOS).
+- Add `NSWindowCollectionBehavior` `NSWindowLevel` `NSWindowTabbingMode` to ns module (macOS).
 - Add `ns::eventmask_from_type` function to objc (macOS).
 - Deprecate objc enums in favour of const inline enums backed by NS numerical types, and with the NS prefix, to better align with the objc api (macOS).
 - Deprecate `event_type_from` function in favour of using NSEvent directly, to better align with the objc api (macOS).
 - Add unit tests for objc and core_foundation (macOS).
 - Make printing typeids give some helpful typeid data.
+- Add `NSApplicationTerminateReply` to ns module (macOS).
+- Add `registerClassPair` function to objc module (macOS).
 
 ## 0.7.7 Change list
 

--- a/test/unit/stdlib/os/macos/objc.c3
+++ b/test/unit/stdlib/os/macos/objc.c3
@@ -186,3 +186,14 @@ fn void test_event_mask_64bit_values()
 
 	assert(NSEventMask.sizeof == ulong.sizeof);
 }
+
+fn void test_application_terminate_reply()
+{
+	NSApplicationTerminateReply cancel = NSApplicationTerminateReply.CANCEL;
+	NSApplicationTerminateReply now = NSApplicationTerminateReply.NOW;
+	NSApplicationTerminateReply later = NSApplicationTerminateReply.LATER;
+
+	assert(cancel == 0);
+	assert(now == 1);
+	assert(later == 2);
+}


### PR DESCRIPTION
The missing `registerClassPair` function is required to register a class and make it active with objc after allocating with the existing `allocateClassPair` function.