### PR TITLE
Split formatting options out of .clang-tidy into .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,15 @@
+IndentWidth: 4
+UseCRLF: false
+IndentCaseLabels: true
+UseTab: ForIndentation
+TabWidth: 4
+BreakBeforeBraces: Allman
+AllowShortBlocksOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: WithoutElse
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeParens: ControlStatementsExceptControlMacros
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,21 +1,7 @@
 ---
 # Configure clang-tidy for this project.
 
-IndentWidth: 4
-UseCRLF: false
-IndentCaseLabels: true
-UseTab: UT_ForIndentation
-TabWidth: 4
-BreakBeforeBraces: Allman
-AllowShortBlocksOnASingleLine: SBS_Empty
-AllowShortIfStatementsOnASingleLine: SIS_WithoutElse
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeCaseColon: false
-SpaceBeforeParens: SBPO_ControlStatementsExceptControlMacros
-SpacesInCStyleCastParentheses: false
-SpacesInConditionalStatement: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
+
 
 # Disabled:
 #  -google-readability-namespace-comments the *_CLIENT_NS is a macro, and


### PR DESCRIPTION
This splits out the .clang-format settings from the .clang-tidy file.

Right now, the .clang-tidy file has a bit of a mix: it contains both clang-tidy checks and clang-format style options.
This actually works fine in some tools (like CLion which doesn't completely fail), but newer versions of clangd-based tools (VSCode, Neovim, etc.) are stricter and will outright reject the config because they expect .clang-tidy to only contain tidy-related stuff.

So here's what I did:
- Moved all the formatting-related options into a brand new .clang-format file
- Kept .clang-tidy focused only on checks, warnings-as-errors, and any check-specific options

No changes to the actual style rules or tidy checks. Everything should behave exactly the same as before.

This should now work well with clangd, VSCode/VSCodium, Neovim, and other modern clang-based tools, while still working in CLion. I've tested on latest VSCodium, CLion and nvim.

I did this because some/*my* PRs had some formatting errors that could be prevented in the future, thus lessing the work while reviewing/merging.

Test the old .clang-tidy with

```
clang-tidy --dump-config
./.clang-tidy:13:1: error: unknown key 'SpaceBeforeCaseColon'
... more errors
```