### PR TITLE
Alphabetise import statements

### DIFF
--- a/lib/std/atomic.c3
+++ b/lib/std/atomic.c3
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-2025 Eduardo José Gómez Hernández. All rights reserved.
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
-module std::atomic::types{Type};
+module std::atomic::types {Type};
 
 struct Atomic
 {

--- a/lib/std/collections/anylist.c3
+++ b/lib/std/collections/anylist.c3
@@ -2,6 +2,7 @@
 // Use of self source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::collections::anylist;
+
 import std::collections::interfacelist;
 
 alias AnyPredicate = InterfacePredicate {any};

--- a/lib/std/collections/bitset.c3
+++ b/lib/std/collections/bitset.c3
@@ -172,7 +172,8 @@ fn void BitSet.set_bool(&self, usz i, bool value) @operator([]=) @inline
 <*
  @require Type.kindof == UNSIGNED_INT
 *>
-module std::collections::growablebitset{Type};
+module std::collections::growablebitset {Type};
+
 import std::collections::list;
 
 const BITS = Type.sizeof * 8;

--- a/lib/std/collections/elastic_array.c3
+++ b/lib/std/collections/elastic_array.c3
@@ -5,7 +5,10 @@
  @require MAX_SIZE >= 1 : `The size must be at least 1 element big.`
 *>
 module std::collections::elastic_array {Type, MAX_SIZE};
-import std::io, std::math, std::collections::list_common;
+
+import std::collections::list_common;
+import std::io;
+import std::math;
 
 alias ElementPredicate = fn bool(Type *type);
 alias ElementTest = fn bool(Type *type, any context);

--- a/lib/std/collections/enummap.c3
+++ b/lib/std/collections/enummap.c3
@@ -1,7 +1,8 @@
 <*
  @require Enum.kindof == TypeKind.ENUM : "Only enums may be used with an enummap"
 *>
-module std::collections::enummap{Enum, ValueType};
+module std::collections::enummap {Enum, ValueType};
+
 import std::io;
 
 struct EnumMap (Printable)

--- a/lib/std/collections/enumset.c3
+++ b/lib/std/collections/enumset.c3
@@ -5,7 +5,8 @@
 <*
  @require Enum.kindof == TypeKind.ENUM : "Only enums may be used with an enumset"
 *>
-module std::collections::enumset{Enum};
+module std::collections::enumset {Enum};
+
 import std::io;
 
 const ENUM_COUNT @private = Enum.values.len;

--- a/lib/std/collections/hashmap.c3
+++ b/lib/std/collections/hashmap.c3
@@ -4,9 +4,10 @@
 <*
  @require $defined((Key){}.hash()) : `No .hash function found on the key`
 *>
-module std::collections::map{Key, Value};
-import std::math;
+module std::collections::map {Key, Value};
+
 import std::io @norecurse;
+import std::math;
 
 const uint DEFAULT_INITIAL_CAPACITY = 16;
 const uint MAXIMUM_CAPACITY = 1u << 31;

--- a/lib/std/collections/hashset.c3
+++ b/lib/std/collections/hashset.c3
@@ -2,8 +2,9 @@
  @require $defined((Value){}.hash()) : `No .hash function found on the value`
 *>
 module std::collections::set {Value};
-import std::math;
+
 import std::io @norecurse;
+import std::math;
 
 const uint DEFAULT_INITIAL_CAPACITY = 16;
 const uint MAXIMUM_CAPACITY = 1u << 31;

--- a/lib/std/collections/interfacelist.c3
+++ b/lib/std/collections/interfacelist.c3
@@ -5,7 +5,9 @@
  @require Type.kindof == INTERFACE || Type.kindof == ANY : "The kind of an interfacelist must be an interface or `any`"
 *>
 module std::collections::interfacelist {Type};
-import std::io,std::math;
+
+import std::io;
+import std::math;
 
 alias InterfacePredicate = fn bool(Type value);
 alias InterfaceTest = fn bool(Type type, Type context);

--- a/lib/std/collections/linked_blockingqueue.c3
+++ b/lib/std/collections/linked_blockingqueue.c3
@@ -1,6 +1,7 @@
-module std::collections::blockingqueue { Value };
-import std::thread, std::time;
+module std::collections::blockingqueue {Value};
 
+import std::thread;
+import std::time;
 
 const INITIAL_CAPACITY = 16;
 

--- a/lib/std/collections/linked_hashmap.c3
+++ b/lib/std/collections/linked_hashmap.c3
@@ -4,9 +4,10 @@
 <*
  @require $defined((Key){}.hash()) : `No .hash function found on the key`
 *>
-module std::collections::map{Key, Value};
-import std::math;
+module std::collections::map {Key, Value};
+
 import std::io @norecurse;
+import std::math;
 
 const LinkedHashMap LINKEDONHEAP = { .allocator = MAP_HEAP_ALLOCATOR };
 

--- a/lib/std/collections/linked_hashset.c3
+++ b/lib/std/collections/linked_hashset.c3
@@ -2,8 +2,9 @@
  @require $defined((Value){}.hash()) : `No .hash function found on the value`
 *>
 module std::collections::set {Value};
-import std::math;
+
 import std::io @norecurse;
+import std::math;
 
 const LinkedHashSet LINKEDONHEAP = { .allocator = SET_HEAP_ALLOCATOR };
 

--- a/lib/std/collections/linkedlist.c3
+++ b/lib/std/collections/linkedlist.c3
@@ -1,7 +1,8 @@
 // Copyright (c) 2021-2024 Christoffer Lerno. All rights reserved.
 // Use of self source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
-module std::collections::linkedlist{Type};
+module std::collections::linkedlist {Type};
+
 import std::io;
 
 const ELEMENT_IS_EQUATABLE = types::is_equatable_type(Type);

--- a/lib/std/collections/list.c3
+++ b/lib/std/collections/list.c3
@@ -2,7 +2,10 @@
 // Use of self source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::collections::list{Type};
-import std::io, std::math, std::collections::list_common;
+
+import std::collections::list_common;
+import std::io;
+import std::math;
 
 alias ElementPredicate = fn bool(Type *type);
 alias ElementTest = fn bool(Type *type, any context);

--- a/lib/std/collections/maybe.c3
+++ b/lib/std/collections/maybe.c3
@@ -1,4 +1,5 @@
-module std::collections::maybe{Type};
+module std::collections::maybe {Type};
+
 import std::io;
 
 struct Maybe (Printable)

--- a/lib/std/collections/object.c3
+++ b/lib/std/collections/object.c3
@@ -2,7 +2,10 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::collections::object;
-import std::collections::map, std::collections::list, std::io;
+
+import std::collections::list;
+import std::collections::map;
+import std::io;
 
 const Object TRUE_OBJECT = { .b = true, .type = bool.typeid };
 const Object FALSE_OBJECT = { .b = false, .type = bool.typeid };

--- a/lib/std/collections/priorityqueue.c3
+++ b/lib/std/collections/priorityqueue.c3
@@ -20,14 +20,17 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
-module std::collections::priorityqueue{Type};
+module std::collections::priorityqueue {Type};
+
 import std::collections::priorityqueue::private;
 
 typedef PriorityQueue = inline PrivatePriorityQueue{Type, false};
 typedef PriorityQueueMax = inline PrivatePriorityQueue{Type, true};
 
-module std::collections::priorityqueue::private{Type, MAX};
-import std::collections::list, std::io;
+module std::collections::priorityqueue::private {Type, MAX};
+
+import std::collections::list;
+import std::io;
 
 struct PrivatePriorityQueue (Printable)
 {

--- a/lib/std/collections/range.c3
+++ b/lib/std/collections/range.c3
@@ -1,7 +1,8 @@
 <*
  @require Type.is_ordered : "The type must be ordered"
 *>
-module std::collections::range{Type};
+module std::collections::range {Type};
+
 import std::io;
 
 struct Range (Printable)

--- a/lib/std/collections/ringbuffer.c3
+++ b/lib/std/collections/ringbuffer.c3
@@ -1,7 +1,8 @@
 <*
  @require Type.kindof == ARRAY : "Required an array type"
 *>
-module std::collections::ringbuffer{Type};
+module std::collections::ringbuffer {Type};
+
 import std::io;
 
 alias Element = $typeof((Type){}[0]);

--- a/lib/std/collections/tuple.c3
+++ b/lib/std/collections/tuple.c3
@@ -1,4 +1,5 @@
-module std::collections::pair{Type1, Type2};
+module std::collections::pair {Type1, Type2};
+
 import std::io;
 
 struct Pair (Printable)
@@ -31,7 +32,8 @@ fn bool Pair.equal(self, Pair other) @operator(==) @if (types::has_equals(Type1)
 
 
 
-module std::collections::triple{Type1, Type2, Type3};
+module std::collections::triple {Type1, Type2, Type3};
+
 import std::io;
 
 struct Triple (Printable)
@@ -66,7 +68,7 @@ fn bool Triple.equal(self, Triple other) @operator(==) @if (types::has_equals(Ty
 }
 
 
-module std::collections::tuple{Type1, Type2};
+module std::collections::tuple {Type1, Type2};
 
 struct Tuple @deprecated("Use 'Pair' instead")
 {

--- a/lib/std/compression/qoi.c3
+++ b/lib/std/compression/qoi.c3
@@ -48,6 +48,7 @@ faultdef INVALID_PARAMETERS, FILE_OPEN_FAILED, FILE_WRITE_FAILED, INVALID_DATA, 
 
 // Let the user decide if they want to use std::io
 module std::compression::qoi @if(!$feature(QOI_NO_STDIO));
+
 import std::io;
 
 <*
@@ -109,6 +110,7 @@ fn char[]? read(Allocator allocator, String filename, QOIDesc* desc, QOIChannels
 
 // Back to basic non-stdio mode
 module std::compression::qoi;
+
 import std::bits;
 
 <*

--- a/lib/std/core/allocators/arena_allocator.c3
+++ b/lib/std/core/allocators/arena_allocator.c3
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::core::mem::allocator;
+
 import std::math;
 
 // The arena allocator allocates up to its maximum data

--- a/lib/std/core/allocators/backed_arena_allocator.c3
+++ b/lib/std/core/allocators/backed_arena_allocator.c3
@@ -1,5 +1,7 @@
 module std::core::mem::allocator;
-import std::io, std::math;
+
+import std::io;
+import std::math;
 
 <*
  The backed arena allocator provides an allocator that will allocate from a pre-allocated chunk of memory

--- a/lib/std/core/allocators/dynamic_arena.c3
+++ b/lib/std/core/allocators/dynamic_arena.c3
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::core::mem::allocator;
+
 import std::math;
 
 <*

--- a/lib/std/core/allocators/heap_allocator.c3
+++ b/lib/std/core/allocators/heap_allocator.c3
@@ -3,6 +3,7 @@
 // a copy of which can be found in the LICENSE_STDLIB file.
 
 module std::core::mem::allocator;
+
 import std::math;
 
 <*

--- a/lib/std/core/allocators/libc_allocator.c3
+++ b/lib/std/core/allocators/libc_allocator.c3
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::core::mem::allocator @if(env::LIBC);
+
 import std::io;
 import libc;
 
@@ -12,6 +13,7 @@ typedef LibcAllocator (Allocator) = uptr;
 const LibcAllocator LIBC_ALLOCATOR = {};
 
 module std::core::mem::allocator @if(env::POSIX);
+
 import std::os;
 import libc;
 
@@ -74,6 +76,7 @@ fn void LibcAllocator.release(&self, void* old_ptr, bool aligned) @dynamic
 }
 
 module std::core::mem::allocator @if(env::WIN32);
+
 import std::os::win32;
 import libc;
 
@@ -115,6 +118,7 @@ fn void LibcAllocator.release(&self, void* old_ptr, bool aligned) @dynamic
 }
 
 module std::core::mem::allocator @if(!env::WIN32 && !env::POSIX && env::LIBC);
+
 import libc;
 
 fn void*? LibcAllocator.acquire(&self, usz bytes, AllocInitType init_type, usz alignment) @dynamic

--- a/lib/std/core/allocators/on_stack_allocator.c3
+++ b/lib/std/core/allocators/on_stack_allocator.c3
@@ -1,5 +1,7 @@
 module std::core::mem::allocator;
+
 import std::math;
+
 <*
  The OnStackAllocator is similar to the ArenaAllocator: it allocates from a chunk of memory
  given to it.

--- a/lib/std/core/allocators/temp_allocator.c3
+++ b/lib/std/core/allocators/temp_allocator.c3
@@ -1,5 +1,7 @@
 module std::core::mem::allocator @if(!(env::POSIX || env::WIN32) || !$feature(VMEM_TEMP));
-import std::io, std::math;
+
+import std::io;
+import std::math;
 
 // This implements the temp allocator.
 // The temp allocator is a specialized allocator only intended for use where
@@ -327,6 +329,7 @@ fn void*? TempAllocator.acquire(&self, usz size, AllocInitType init_type, usz al
 }
 
 module std::core::mem::allocator @if((env::POSIX || env::WIN32) && $feature(VMEM_TEMP));
+
 import std::math;
 
 tlocal VmemOptions temp_allocator_default_options = {

--- a/lib/std/core/allocators/tracking_allocator.c3
+++ b/lib/std/core/allocators/tracking_allocator.c3
@@ -3,7 +3,10 @@
 // a copy of which can be found in the LICENSE_STDLIB file.
 
 module std::core::mem::allocator;
-import std::collections, std::io, std::os::backtrace;
+
+import std::collections;
+import std::io;
+import std::os::backtrace;
 
 const MAX_BACKTRACE = 16;
 struct Allocation

--- a/lib/std/core/allocators/vmem.c3
+++ b/lib/std/core/allocators/vmem.c3
@@ -1,9 +1,11 @@
 module std::core::mem::allocator @if(env::POSIX || env::WIN32);
-import std::math, std::os::posix, libc, std::bits;
+
+import std::bits;
 import std::core::mem;
 import std::core::env;
-
-
+import std::math;
+import std::os::posix;
+import libc;
 
 // Virtual Memory allocator
 

--- a/lib/std/core/array.c3
+++ b/lib/std/core/array.c3
@@ -1,5 +1,7 @@
 module std::core::array;
-import std::collections::pair, std::io;
+
+import std::collections::pair;
+import std::io;
 
 <*
  Returns true if the array contains at least one element, else false

--- a/lib/std/core/builtin.c3
+++ b/lib/std/core/builtin.c3
@@ -2,8 +2,11 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::core::builtin;
-import libc, std::hash, std::io, std::os::backtrace;
 
+import std::hash;
+import std::io;
+import std::os::backtrace;
+import libc;
 
 <*
  EMPTY_MACRO_SLOT is a value used for implementing optional arguments for macros in an efficient
@@ -993,7 +996,10 @@ macro void* get_returnaddress(int n)
 }
 
 module std::core::builtin @if((env::LINUX || env::ANDROID || env::DARWIN) && env::COMPILER_SAFE_MODE && env::DEBUG_SYMBOLS);
-import libc, std::io, std::os::posix;
+
+import std::io;
+import std::os::posix;
+import libc;
 
 fn void sig_panic(String message)
 {

--- a/lib/std/core/cinterop.c3
+++ b/lib/std/core/cinterop.c3
@@ -2,8 +2,8 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::core::cinterop;
-import std::core::env;
 
+import std::core::env;
 
 const C_INT_SIZE = $$C_INT_SIZE;
 const C_LONG_SIZE = $$C_LONG_SIZE;
@@ -63,6 +63,7 @@ macro typeid unsigned_int_from_bitsize(usz $bitsize) @private
 }
 
 const USE_STACK_VALIST = env::ARCH_32_BIT || env::WIN32 || (env::DARWIN && env::AARCH64);
+
 module std::core::cinterop @if(USE_STACK_VALIST);
 
 typedef CVaList = void*;

--- a/lib/std/core/dstring.c3
+++ b/lib/std/core/dstring.c3
@@ -1,4 +1,5 @@
 module std::core::dstring;
+
 import std::io;
 
 <*

--- a/lib/std/core/logging.c3
+++ b/lib/std/core/logging.c3
@@ -1,5 +1,9 @@
 module std::core::log;
-import std::io, std::thread, std::time, std::math::random;
+
+import std::io;
+import std::math::random;
+import std::thread;
+import std::time;
 
 const FULL_LOG = env::COMPILER_SAFE_MODE || $feature(FULL_LOG);
 
@@ -190,7 +194,10 @@ fn void MultiLogger.log(&self, LogPriority priority, LogCategory category, LogTa
 
 
 module std::core::log @private;
-import std::io, std::thread, std::time;
+
+import std::io;
+import std::thread;
+import std::time;
 
 struct StderrLogger (Logger) @if(env::LIBC)
 {

--- a/lib/std/core/mem.c3
+++ b/lib/std/core/mem.c3
@@ -2,8 +2,10 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::core::mem;
+
 import std::core::mem::allocator @public;
-import std::os::posix, std::os::win32;
+import std::os::posix;
+import std::os::win32;
 import std::math;
 
 const MAX_MEMORY_ALIGNMENT = 0x1000_0000;
@@ -654,7 +656,9 @@ macro void @pool(usz reserve = 0; @body) @builtin
 }
 
 module std::core::mem @if(env::FREESTANDING_WASM);
+
 import std::core::mem::allocator @public;
+
 SimpleHeapAllocator wasm_allocator @private;
 extern int __heap_base;
 
@@ -670,7 +674,6 @@ fn void initialize_wasm_mem() @init(1024) @private
 }
 
 module std::core::mem;
-
 
 macro TrackingEnv* get_tracking_env()
 {
@@ -1029,7 +1032,7 @@ fn void* __memcpy(void* dst, void* src, usz n) @weak @export("memcpy")
 }
 
 
-module std::core::mem::volatile { Type };
+module std::core::mem::volatile {Type};
 
 typedef Volatile @structlike = Type;
 
@@ -1046,7 +1049,8 @@ macro Type Volatile.set(&self, Type val)
 <*
  @require mem::@constant_is_power_of_2(ALIGNMENT) : "The alignment must be a power of 2"
 *>
-module std::core::mem::alignment { Type, ALIGNMENT };
+module std::core::mem::alignment {Type, ALIGNMENT};
+
 import std::core::mem @public;
 
 <*

--- a/lib/std/core/mem_allocator.c3
+++ b/lib/std/core/mem_allocator.c3
@@ -1,4 +1,5 @@
 module std::core::mem::allocator;
+
 import std::math;
 
 // C3 has several different allocators available:

--- a/lib/std/core/mem_mempool.c3
+++ b/lib/std/core/mem_mempool.c3
@@ -1,6 +1,9 @@
 module std::core::mem::mempool;
-import std::core::mem, std::core::mem::allocator, std::math;
+
+import std::core::mem;
+import std::core::mem::allocator;
 import std::core::sanitizer::asan;
+import std::math;
 
 const INITIAL_CAPACITY = 0;
 

--- a/lib/std/core/os/mem_vm.c3
+++ b/lib/std/core/os/mem_vm.c3
@@ -2,7 +2,11 @@
  The VM module holds code for working with virtual memory on supported platforms (currently Win32 and Posix)
 *>
 module std::core::mem::vm;
-import std::io, std::os::win32, std::os::posix, libc;
+
+import std::io;
+import std::os::posix;
+import std::os::win32;
+import libc;
 
 <*
  VirtualMemory is an abstraction for working with an allocated virtual memory area. It will invoke vm:: functions

--- a/lib/std/core/os/wasm/wasm_memory.c3
+++ b/lib/std/core/os/wasm/wasm_memory.c3
@@ -1,6 +1,5 @@
 module std::core::mem::allocator;
 
-
 const usz WASM_BLOCK_SIZE = 65536;
 
 WasmMemory wasm_memory;

--- a/lib/std/core/private/cpu_detect.c3
+++ b/lib/std/core/private/cpu_detect.c3
@@ -4,6 +4,7 @@ struct CpuId
 {
 	uint eax, ebx, ecx, edx;
 }
+
 fn CpuId x86_cpuid(uint eax, uint ecx = 0)
 {
 	int edx;

--- a/lib/std/core/refcount.c3
+++ b/lib/std/core/refcount.c3
@@ -8,8 +8,10 @@
  @require !$defined(Type.dealloc) ||| $defined(Type.dealloc(&&(Type){})) : "'dealloc' must only take a pointer to the underlying type"
  @require !$defined(Type.dealloc) ||| $typeof((Type){}.dealloc()) ==  void : "'dealloc' must return 'void'"
 *>
-module std::core::mem::ref { Type };
-import std::thread, std::atomic;
+module std::core::mem::ref {Type};
+
+import std::atomic;
+import std::thread;
 
 const OVERALIGNED @private = Type.alignof > mem::DEFAULT_MEM_ALIGNMENT;
 
@@ -79,7 +81,9 @@ fn void Ref.release(&self)
 }
 
 module std::core::mem::rc;
-import std::thread, std::atomic;
+
+import std::atomic;
+import std::thread;
 
 <*
  A RefCounted struct should be an inline base of a struct.

--- a/lib/std/core/runtime.c3
+++ b/lib/std/core/runtime.c3
@@ -2,7 +2,11 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::core::runtime;
-import libc, std::time, std::io, std::sort;
+
+import std::io;
+import std::sort;
+import std::time;
+import libc;
 
 struct ReflectedParam (Printable) @if(!$defined(ReflectedParam))
 {

--- a/lib/std/core/runtime_benchmark.c3
+++ b/lib/std/core/runtime_benchmark.c3
@@ -1,5 +1,11 @@
 module std::core::runtime;
-import libc, std::time, std::io, std::sort, std::math, std::collections::map;
+
+import std::collections::map;
+import std::io;
+import std::math;
+import std::sort;
+import std::time;
+import libc;
 
 alias BenchmarkFn = fn void ();
 

--- a/lib/std/core/runtime_test.c3
+++ b/lib/std/core/runtime_test.c3
@@ -2,10 +2,14 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::core::runtime;
-import std::core::test @public;
-import std::core::mem::allocator @public;
-import libc, std::time, std::io, std::sort, std::os;
 
+import std::core::mem::allocator @public;
+import std::core::test @public;
+import std::io;
+import std::os;
+import std::sort;
+import std::time;
+import libc;
 
 alias TestFn = fn void();
 

--- a/lib/std/core/string.c3
+++ b/lib/std/core/string.c3
@@ -1,6 +1,7 @@
 module std::core::string;
-import std::io, std::ascii;
 
+import std::ascii;
+import std::io;
 
 typedef String @if(!$defined(String)) = inline char[];
 <*

--- a/lib/std/core/string_escape.c3
+++ b/lib/std/core/string_escape.c3
@@ -8,6 +8,7 @@
  and other string literals.
 *>
 module std::core::string;
+
 import std::io;
 
 faultdef INVALID_ESCAPE_SEQUENCE, UNTERMINATED_STRING, INVALID_HEX_ESCAPE, INVALID_UNICODE_ESCAPE;

--- a/lib/std/core/string_to_real.c3
+++ b/lib/std/core/string_to_real.c3
@@ -1,4 +1,5 @@
 module std::core::string;
+
 import std::math;
 
 // Float parsing based on code in Musl floatscan.c by Rich Felker.

--- a/lib/std/core/test.c3
+++ b/lib/std/core/test.c3
@@ -6,6 +6,7 @@ This module provides a toolset of macros for running unit test checks
 Example:
 ```c3
 module sample::m;
+
 import std::io;
 
 faultdef DIVISION_BY_ZERO;
@@ -36,8 +37,11 @@ fn void? test_div() @test
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::core::test;
+
 import std::core::runtime @public;
-import std::math, std::io, libc;
+import std::io;
+import std::math;
+import libc;
 
 <*
  Initializes test case context.

--- a/lib/std/core/types.c3
+++ b/lib/std/core/types.c3
@@ -1,7 +1,7 @@
 
 module std::core::types;
-import libc;
 
+import libc;
 
 faultdef VALUE_OUT_OF_RANGE, VALUE_OUT_OF_UNSIGNED_RANGE;
 

--- a/lib/std/core/values.c3
+++ b/lib/std/core/values.c3
@@ -1,6 +1,6 @@
 module std::core::values;
-import std::core::types;
 
+import std::core::types;
 
 macro bool @typematch(#value1, #value2) @builtin @const => $typeof(#value1) == $typeof(#value2);
 <*

--- a/lib/std/crypto/aes.c3
+++ b/lib/std/crypto/aes.c3
@@ -16,7 +16,10 @@ with an AES 128-bit key:
 
 ```
 module app;
-import std::crypto::aes, std::io;
+
+import std::crypto::aes;
+import std::io;
+
 fn void main()
 {
 	char[] key 	= x"2b7e151628aed2a6abf7158809cf4f3c";

--- a/lib/std/crypto/aes_128_192_256.c3
+++ b/lib/std/crypto/aes_128_192_256.c3
@@ -1,5 +1,6 @@
 // Experimental implementation
 module std::crypto::aes128;
+
 import std::crypto::aes;
 
 fn char[] encrypt(Allocator allocator, char[16]* key, char[aes::BLOCKLEN] iv, char[] data)

--- a/lib/std/crypto/chacha20.c3
+++ b/lib/std/crypto/chacha20.c3
@@ -5,7 +5,6 @@
 // ChaCha20 code dedicated from repo: https://github.com/NotsoanoNimus/chacha20_aead.c3l (but massively cleaned)
 module std::crypto::chacha20;
 
-
 <* The typical cipher block size in bytes. *>
 const BLOCK_SIZE = 64;
 

--- a/lib/std/crypto/dh.c3
+++ b/lib/std/crypto/dh.c3
@@ -1,4 +1,5 @@
 module std::crypto::dh;
+
 import std::math::bigint;
 
 fn BigInt generate_secret(BigInt p, BigInt x, BigInt y)

--- a/lib/std/crypto/ed25519.c3
+++ b/lib/std/crypto/ed25519.c3
@@ -3,6 +3,7 @@
 */
 
 module std::crypto::ed25519;
+
 import std::hash::sha512;
 
 alias Ed25519PrivateKey = char[32];
@@ -599,6 +600,7 @@ fn F25519Int F25519Int.sqrt(&s)
 */
 
 module std::crypto::ed25519 @private;
+
 import std::math;
 
 typedef FBaseInt = inline char[32];

--- a/lib/std/encoding/base64.c3
+++ b/lib/std/encoding/base64.c3
@@ -1,4 +1,5 @@
 module std::encoding::base64;
+
 import std::core::bitorder;
 
 // The implementation is based on https://www.rfc-editor.org/rfc/rfc4648

--- a/lib/std/encoding/csv.c3
+++ b/lib/std/encoding/csv.c3
@@ -1,6 +1,6 @@
 module std::encoding::csv;
-import std::io;
 
+import std::io;
 
 struct CsvReader
 {

--- a/lib/std/encoding/hex.c3
+++ b/lib/std/encoding/hex.c3
@@ -1,4 +1,5 @@
 module std::encoding::hex;
+
 import std::encoding @norecurse;
 
 // The implementation is based on https://www.rfc-editor.org/rfc/rfc4648

--- a/lib/std/encoding/json.c3
+++ b/lib/std/encoding/json.c3
@@ -2,8 +2,9 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::encoding::json;
-import std::io;
+
 import std::collections::object;
+import std::io;
 
 faultdef UNEXPECTED_CHARACTER, INVALID_ESCAPE_SEQUENCE, INVALID_NUMBER, MAX_DEPTH_REACHED;
 

--- a/lib/std/experimental/FrameScheduler.c3
+++ b/lib/std/experimental/FrameScheduler.c3
@@ -1,5 +1,8 @@
-module std::experimental::scheduler{Event};
-import std::collections, std::thread, std::time;
+module std::experimental::scheduler {Event};
+
+import std::collections;
+import std::thread;
+import std::time;
 
 struct DelayedSchedulerEvent @local
 {

--- a/lib/std/hash/a5hash.c3
+++ b/lib/std/hash/a5hash.c3
@@ -32,7 +32,6 @@
 //
 module std::hash::a5hash;
 
-
 macro void @a5mul(#u, #v, #lo, #hi) @local
 {
 	uint128 imd = (uint128)#u * (uint128)#v;

--- a/lib/std/hash/blake2.c3
+++ b/lib/std/hash/blake2.c3
@@ -13,7 +13,6 @@
 //
 module std::hash::blake2;
 
-
 // Common hash output sizes. The library is NOT limited to these six output sizes, but
 //   these instead stand in for what would have been "magic numbers" throughout the code.
 const SIZE_128 = 16;

--- a/lib/std/hash/blake3.c3
+++ b/lib/std/hash/blake3.c3
@@ -7,7 +7,6 @@
 //
 module std::hash::blake3;
 
-
 const BLOCK_SIZE = 64;
 const CHUNK_SIZE = 1024;
 const KEY_SIZE = 32;

--- a/lib/std/hash/gost/streebog.c3
+++ b/lib/std/hash/gost/streebog.c3
@@ -7,7 +7,6 @@
 //
 module std::hash::streebog;
 
-
 enum StreebogLength : const inline uint
 {
 	SIZE_256 = 32,

--- a/lib/std/hash/gost/streebog_internal.c3
+++ b/lib/std/hash/gost/streebog_internal.c3
@@ -7,7 +7,6 @@
 //
 module std::hash::streebog @private;
 
-
 const usz BLOCK_SIZE = 64;
 
 const ulong[8] ZERO_512 @align(ulong.sizeof) = {};

--- a/lib/std/hash/hmac.c3
+++ b/lib/std/hash/hmac.c3
@@ -1,4 +1,5 @@
-module std::hash::hmac{HashAlg, HASH_BYTES, BLOCK_BYTES};
+module std::hash::hmac {HashAlg, HASH_BYTES, BLOCK_BYTES};
+
 import std::crypto;
 
 struct Hmac

--- a/lib/std/hash/komi.c3
+++ b/lib/std/hash/komi.c3
@@ -32,7 +32,6 @@
 //
 module std::hash::komi;
 
-
 macro void @komimul(#u, #v, #lo, #hi) @local
 {
 	uint128 imd = (uint128)#u * (uint128)#v;

--- a/lib/std/hash/md5.c3
+++ b/lib/std/hash/md5.c3
@@ -1,6 +1,7 @@
 module std::hash::md5;
-import std::hash::hmac;
+
 import std::bits;
+import std::hash::hmac;
 
 const BLOCK_BYTES = 64;
 const HASH_BYTES = 16;

--- a/lib/std/hash/sha1.c3
+++ b/lib/std/hash/sha1.c3
@@ -5,8 +5,9 @@
 // Implementation was off Steve Reid's SHA-1 C implementation
 
 module std::hash::sha1;
-import std::hash::hmac;
+
 import std::bits;
+import std::hash::hmac;
 
 const BLOCK_BYTES = 64;
 const HASH_BYTES = 20;

--- a/lib/std/hash/sha256.c3
+++ b/lib/std/hash/sha256.c3
@@ -1,5 +1,7 @@
 module std::hash::sha256;
-import std::bits, std::hash::hmac;
+
+import std::bits;
+import std::hash::hmac;
 
 const BLOCK_SIZE = 64;
 const HASH_SIZE = 32;

--- a/lib/std/hash/sha512.c3
+++ b/lib/std/hash/sha512.c3
@@ -11,7 +11,6 @@ module std::hash::sha512;
 
 import std::hash::hmac;
 
-
 const BLOCK_SIZE = 128;
 const HASH_SIZE = 64;
 

--- a/lib/std/hash/siphash.c3
+++ b/lib/std/hash/siphash.c3
@@ -7,7 +7,9 @@
  See std::hash::siphash for more information.
 *>
 module std::hash::siphash24;
+
 import std::hash::siphash;
+
 alias SipHash24 = SipHash { ulong, 2, 4 };
 alias hash = siphash::hash { ulong, 2, 4 };
 
@@ -16,20 +18,26 @@ alias hash = siphash::hash { ulong, 2, 4 };
  See std::hash::siphash for more information.
 *>
 module std::hash::siphash48;
+
 import std::hash::siphash;
+
 alias SipHash48 = SipHash { ulong, 4, 8 };
 alias hash = siphash::hash { ulong, 4, 8 };
 
 
 <* Exact same as siphash24, but for 128-bit outputs. Algorithm internally changes slightly. *>
 module std::hash::siphash24_128;
+
 import std::hash::siphash;
+
 alias SipHash24_128 = SipHash { uint128, 2, 4 };
 alias hash = siphash::hash { uint128, 2, 4 };
 
 <* Exact same as siphash48, but for 128-bit outputs. Algorithm internally changes slightly. *>
 module std::hash::siphash48_128;
+
 import std::hash::siphash;
+
 alias SipHash48_128 = SipHash { uint128, 4, 8 };
 alias hash = siphash::hash { uint128, 4, 8 };
 
@@ -48,7 +56,7 @@ alias hash = siphash::hash { uint128, 4, 8 };
 
  @require OutType.typeid == uint128.typeid || OutType.typeid == ulong.typeid : "Module OutType must be either uint128 or ulong."
 *>
-module std::hash::siphash { OutType, BLOCK_ROUNDS, FINALIZE_ROUNDS };
+module std::hash::siphash {OutType, BLOCK_ROUNDS, FINALIZE_ROUNDS};
 
 
 struct SipHash

--- a/lib/std/hash/whirlpool/whirlpool.c3
+++ b/lib/std/hash/whirlpool/whirlpool.c3
@@ -7,7 +7,6 @@ module std::hash::whirlpool;
 
 import std::hash::hmac;
 
-
 const BLOCK_SIZE = 64;
 const HASH_SIZE = 64;
 const BLOCK_128 = 64 / int128.sizeof;

--- a/lib/std/hash/whirlpool/whirlpool_sbox.c3
+++ b/lib/std/hash/whirlpool/whirlpool_sbox.c3
@@ -5,7 +5,6 @@
 // Dedicated from repo: https://github.com/NotsoanoNimus/whirlpool.c3l
 module std::hash::whirlpool @private;
 
-
 // =========================================================================
 // WHIRLPOOL s-box data.
 const ulong[8 * 256] S_BOX = {

--- a/lib/std/io/file.c3
+++ b/lib/std/io/file.c3
@@ -1,4 +1,5 @@
 module std::io;
+
 import libc;
 
 struct File (InStream, OutStream)
@@ -7,7 +8,10 @@ struct File (InStream, OutStream)
 }
 
 module std::io::file;
-import libc, std::io::path, std::io::os;
+
+import std::io::os;
+import std::io::path;
+import libc;
 
 fn File? open(String filename, String mode)
 {

--- a/lib/std/io/file_mmap.c3
+++ b/lib/std/io/file_mmap.c3
@@ -1,5 +1,7 @@
 module std::io::file::mmap @if(env::LIBC &&& env::POSIX);
-import std::core::mem::vm, std::io::file;
+
+import std::core::mem::vm;
+import std::io::file;
 
 struct FileMmap
 {

--- a/lib/std/io/formatter.c3
+++ b/lib/std/io/formatter.c3
@@ -1,4 +1,5 @@
 module std::io;
+
 import std::collections::map;
 import libc;
 

--- a/lib/std/io/formatter_private.c3
+++ b/lib/std/io/formatter_private.c3
@@ -1,4 +1,5 @@
 module std::io;
+
 import std::math;
 
 const char[16] XDIGITS_H = "0123456789ABCDEF";

--- a/lib/std/io/io.c3
+++ b/lib/std/io/io.c3
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::io;
+
 import libc;
 
 enum Seek
@@ -417,6 +418,7 @@ struct BufferData @private
 
 // Only available with LIBC
 module std::io @if (env::LIBC);
+
 import libc;
 
 <*

--- a/lib/std/io/os/chdir.c3
+++ b/lib/std/io/os/chdir.c3
@@ -1,5 +1,8 @@
 module std::io::os;
-import std::io::path, libc, std::os;
+
+import std::io::path;
+import std::os;
+import libc;
 
 macro void? native_chdir(Path path)
 {

--- a/lib/std/io/os/file_libc.c3
+++ b/lib/std/io/os/file_libc.c3
@@ -1,4 +1,5 @@
 module std::io::os @if(env::LIBC);
+
 import libc;
 
 <*

--- a/lib/std/io/os/file_nolibc.c3
+++ b/lib/std/io/os/file_nolibc.c3
@@ -1,4 +1,5 @@
 module std::io::os @if(env::NO_LIBC);
+
 import libc;
 
 alias FopenFn = fn void*?(String, String);

--- a/lib/std/io/os/fileinfo.c3
+++ b/lib/std/io/os/fileinfo.c3
@@ -1,5 +1,8 @@
 module std::io::os;
-import libc, std::os, std::io;
+
+import std::io;
+import std::os;
+import libc;
 
 fn void? native_stat(Stat* stat, String path) @if(env::DARWIN || env::LINUX || env::ANDROID || env::BSD_FAMILY) => @pool()
 {

--- a/lib/std/io/os/getcwd.c3
+++ b/lib/std/io/os/getcwd.c3
@@ -1,5 +1,7 @@
 module std::io::os;
-import libc, std::os;
+
+import std::os;
+import libc;
 
 macro String? getcwd(Allocator allocator)
 {

--- a/lib/std/io/os/ls.c3
+++ b/lib/std/io/os/ls.c3
@@ -1,5 +1,7 @@
 module std::io::os @if(env::POSIX);
-import std::io, std::os;
+
+import std::io;
+import std::os;
 
 fn PathList? native_ls(Path dir, bool no_dirs, bool no_symlinks, String mask, Allocator allocator)
 {
@@ -26,7 +28,10 @@ fn PathList? native_ls(Path dir, bool no_dirs, bool no_symlinks, String mask, Al
 }
 
 module std::io::os @if(env::WIN32);
-import std::time, std::os, std::io;
+
+import std::io;
+import std::os;
+import std::time;
 
 fn PathList? native_ls(Path dir, bool no_dirs, bool no_symlinks, String mask, Allocator allocator)
 {

--- a/lib/std/io/os/mkdir.c3
+++ b/lib/std/io/os/mkdir.c3
@@ -1,9 +1,9 @@
 module std::io::os;
-import libc;
-import std::io::path;
-import std::os::win32;
-import std::os::posix;
 
+import std::io::path;
+import std::os::posix;
+import std::os::win32;
+import libc;
 
 macro bool? native_mkdir(Path path, MkdirPermissions permissions)
 {

--- a/lib/std/io/os/rmdir.c3
+++ b/lib/std/io/os/rmdir.c3
@@ -1,8 +1,9 @@
 module std::io::os;
-import libc;
+
 import std::io::path;
-import std::os::win32;
 import std::os::posix;
+import std::os::win32;
+import libc;
 
 macro bool? native_rmdir(Path path)
 {

--- a/lib/std/io/os/rmtree.c3
+++ b/lib/std/io/os/rmtree.c3
@@ -1,5 +1,8 @@
 module std::io::os @if(env::POSIX);
-import std::io, std::os, libc;
+
+import std::io;
+import std::os;
+import libc;
 
 <*
  @require dir.str_view().len > 0
@@ -36,7 +39,10 @@ fn void? native_rmtree(Path dir)
 }
 
 module std::io::os @if(env::WIN32);
-import std::io, std::time, std::os;
+
+import std::io;
+import std::os;
+import std::time;
 
 fn void? native_rmtree(Path path)
 {

--- a/lib/std/io/os/temp_directory.c3
+++ b/lib/std/io/os/temp_directory.c3
@@ -15,7 +15,9 @@ enum NativeSystemDir
 }
 
 module std::io::os @if(env::LIBC);
-import std::io, std::os;
+
+import std::io;
+import std::os;
 
 fn String? win32_get_known_folder_temp(Win32_REFKNOWNFOLDERID rfid) @private @if(env::WIN32)
 {
@@ -128,6 +130,7 @@ fn Path? native_temp_directory(Allocator allocator) @if(env::WIN32) => @pool()
 }
 
 module std::io::os @if(env::NO_LIBC);
+
 import std::io::path;
 
 macro Path? native_home_directory(Allocator allocator) => io::PATH_COULD_NOT_BE_FOUND?;

--- a/lib/std/io/path.c3
+++ b/lib/std/io/path.c3
@@ -1,5 +1,7 @@
 module std::io::path;
-import std::collections::list, std::io::os;
+
+import std::collections::list;
+import std::io::os;
 import std::os::win32;
 
 const PathEnv DEFAULT_ENV = env::WIN32 ? PathEnv.WIN32 : PathEnv.POSIX;

--- a/lib/std/io/stream.c3
+++ b/lib/std/io/stream.c3
@@ -1,6 +1,7 @@
 module std::io;
-import std::math;
+
 import std::core::env;
+import std::math;
 
 
 interface InStream

--- a/lib/std/io/stream/bytebuffer.c3
+++ b/lib/std/io/stream/bytebuffer.c3
@@ -1,4 +1,5 @@
 module std::io;
+
 import std::math;
 
 struct ByteBuffer (InStream, OutStream)

--- a/lib/std/io/stream/bytewriter.c3
+++ b/lib/std/io/stream/bytewriter.c3
@@ -1,4 +1,5 @@
 module std::io;
+
 import std::math;
 
 struct ByteWriter (OutStream)

--- a/lib/std/libc/libc.c3
+++ b/lib/std/libc/libc.c3
@@ -211,6 +211,7 @@ const CInt STDOUT_FD = 1;
 const CInt STDERR_FD = 2;
 
 module libc @if(env::LINUX || env::ANDROID);
+
 extern CFile __stdin @cname("stdin");
 extern CFile __stdout @cname("stdout");
 extern CFile __stderr @cname("stderr");
@@ -222,6 +223,7 @@ macro CFile stdout() => __stdout;
 macro CFile stderr() => __stderr;
 
 module libc @if(env::NETBSD || env::OPENBSD);
+
 extern fn int fcntl(CInt socket, int cmd, ...);
 extern fn int _setjmp(void*);
 macro int setjmp(void* ptr) => _setjmp(ptr);
@@ -241,6 +243,7 @@ macro CFile stdout() { return fdopen(1, "w"); }
 macro CFile stderr() { return fdopen(2, "w"); }
 
 module libc @if(env::DARWIN || env::FREEBSD);
+
 extern CFile __stdinp;
 extern CFile __stdoutp;
 extern CFile __stderrp;
@@ -251,23 +254,26 @@ macro CFile stdout() => __stdoutp;
 macro CFile stderr() => __stderrp;
 
 module libc @if(env::FREEBSD);
+
 extern fn usz malloc_usable_size(void* ptr);
 macro usz malloc_size(void* ptr) => malloc_usable_size(ptr);
 
 module libc @if(env::WIN32);
+
 macro usz malloc_size(void* ptr) => _msize(ptr);
 macro CFile stdin() => __acrt_iob_func(STDIN_FD);
 macro CFile stdout() => __acrt_iob_func(STDOUT_FD);
 macro CFile stderr() => __acrt_iob_func(STDERR_FD);
 
 module libc @if(env::LIBC && !env::WIN32 && !env::LINUX && !env::ANDROID && !env::DARWIN && !env::BSD_FAMILY);
+
 macro CFile stdin() { return (CFile*)(uptr)STDIN_FD; }
 macro CFile stdout() { return (CFile*)(uptr)STDOUT_FD; }
 macro CFile stderr() { return (CFile*)(uptr)STDERR_FD; }
 
 module libc @if(env::NO_LIBC);
-import std::core::mem;
 
+import std::core::mem;
 
 fn void longjmp(JmpBuf* buffer, CInt value) @weak @cname("longjmp") @nostrip
 {
@@ -505,6 +511,7 @@ const Errno ERANGE                   = 34; // Math result not representable
 
 // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/intro.2.html
 module libc::errno @if(env::DARWIN);
+
 const Errno EWOULDBLOCK              = EAGAIN; // Operation would block
 const Errno EDEADLK                  = 11; // Resource deadlock would occur
 const Errno EINPROGRESS              = 36; // Operation now in progress
@@ -574,6 +581,7 @@ const Errno ETIME                    = 101; // STREAM ioctl() timeout
 const Errno EOPNOTSUPP               = 102; // Operation not supported on socket
 
 module libc::errno @if(env::NETBSD);
+
 const Errno EWOULDBLOCK     = EAGAIN;    // Operation would block
 const Errno EDEADLK         = 11;        // Resource deadlock avoided
 const Errno EINPROGRESS     = 36;        // Operation now in progress
@@ -641,6 +649,7 @@ const Errno EOWNERDEAD      = 97;        // Previous owner died
 const Errno ENOTRECOVERABLE = 98;        // State not recoverable
 
 module libc::errno @if(env::WIN32);
+
 const Errno EDEADLK                  = 36; // Resource deadlock would occur Win32
 const Errno ENAMETOOLONG             = 38; // File name too long Win32
 const Errno ENOTEMPTY                = 41; // Directory not empty
@@ -658,6 +667,7 @@ const Errno EDQUOT                   = -122; // Quota exceeded, not in Win32
 const Errno EWOULDBLOCK              = 140; // Operation would block
 
 module libc::errno @if(!env::WIN32 && !env::DARWIN && !env::NETBSD);
+
 const Errno EDEADLK                  = 35; // Resource deadlock would occur Linux (others?)
 const Errno ENAMETOOLONG             = 36; // File name too long Linux (others?)
 const Errno ENOTEMPTY                = 39; // Directory not empty

--- a/lib/std/libc/libc_extra.c3
+++ b/lib/std/libc/libc_extra.c3
@@ -1,4 +1,5 @@
 module libc;
+
 import std::time;
 
 <*

--- a/lib/std/libc/os/errno.c3
+++ b/lib/std/libc/os/errno.c3
@@ -1,4 +1,5 @@
 module libc::os @if(env::LIBC);
+
 import std::core::env;
 
 // Linux
@@ -34,6 +35,7 @@ extern fn void _set_errno(int err) @if(env::WIN32);
 
 // Default
 module libc::os @if(!env::LIBC || !env::HAS_NATIVE_ERRNO);
+
 tlocal int _errno_c3 = 0;
 fn void errno_set(int err) => _errno_c3 = err;
 fn int errno() => _errno_c3;

--- a/lib/std/libc/os/win32.c3
+++ b/lib/std/libc/os/win32.c3
@@ -1,4 +1,5 @@
 module libc @if(env::WIN32);
+
 import std::os::win32;
 
 alias fdopen = _fdopen;

--- a/lib/std/math/bigint.c3
+++ b/lib/std/math/bigint.c3
@@ -2,8 +2,9 @@
 Untested new big int implementation, missing unit tests. Etc
 *>
 module std::math::bigint;
-import std::math::random;
+
 import std::io;
+import std::math::random;
 
 const MAX_LEN = 4096 * 2 / 32;
 
@@ -927,7 +928,6 @@ fn void BigInt.randomize_bits(&self, Random random, int bits)
 }
 
 module std::math::bigint @private;
-
 
 <*
  @param [&out] quotient

--- a/lib/std/math/complex.c3
+++ b/lib/std/math/complex.c3
@@ -17,6 +17,7 @@ alias I_F @builtin = complex::IMAGINARY { float };
  @require Real.kindof == FLOAT : "A complex number must use a floating type"
 *>
 module std::math::complex {Real};
+
 import std::io;
 
 union ComplexNumber (Printable)

--- a/lib/std/math/math.c3
+++ b/lib/std/math/math.c3
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::math;
+
 import std::math::complex;
 import std::math::matrix;
 import std::math::quaternion;

--- a/lib/std/math/matrix.c3
+++ b/lib/std/math/matrix.c3
@@ -29,6 +29,7 @@ alias MATRIX4F_IDENTITY @builtin = matrix::IDENTITY4 {float};
  @require Real.kindof == FLOAT : "A matrix must use a floating type"
 *>
 module std::math::matrix {Real};
+
 import std::math::vector;
 
 struct Matrix2x2

--- a/lib/std/math/quaternion.c3
+++ b/lib/std/math/quaternion.c3
@@ -14,7 +14,9 @@ alias QUATERNIONF_IDENTITY @builtin = quaternion::IDENTITY {float};
 *>
 
 module std::math::quaternion {Real};
+
 import std::math::vector;
+
 union QuaternionNumber
 {
 	struct

--- a/lib/std/math/random/math.seeder.c3
+++ b/lib/std/math/random/math.seeder.c3
@@ -1,5 +1,7 @@
 module std::math::random;
-import std::hash::a5hash, std::time;
+
+import std::hash::a5hash;
+import std::time;
 
 const ODD_PHI64 @local = 0x9e3779b97f4a7c15;
 const MUL_MCG64 @local = 0xf1357aea2e62a9c5;

--- a/lib/std/math/uuid.c3
+++ b/lib/std/math/uuid.c3
@@ -1,6 +1,7 @@
 module std::math::uuid;
-import std::math::random @public;
+
 import std::io;
+import std::math::random @public;
 
 typedef Uuid (Printable) = char[16];
 

--- a/lib/std/math/vector.c3
+++ b/lib/std/math/vector.c3
@@ -1,6 +1,7 @@
 // Vector supplemental methods
 
 module std::math::vector;
+
 import std::math;
 
 <*

--- a/lib/std/net/inetaddr.c3
+++ b/lib/std/net/inetaddr.c3
@@ -1,4 +1,5 @@
 module std::net;
+
 import std::io;
 
 enum IpProtocol : char (AIFamily ai_family)

--- a/lib/std/net/net.c3
+++ b/lib/std/net/net.c3
@@ -1,4 +1,5 @@
 module std::net;
+
 import std::io;
 
 faultdef

--- a/lib/std/net/os/android.c3
+++ b/lib/std/net/os/android.c3
@@ -1,4 +1,5 @@
 module std::net::os @if(env::ANDROID);
+
 import libc;
 
 const AIFamily PLATFORM_AF_AX25         = 3;

--- a/lib/std/net/os/common.c3
+++ b/lib/std/net/os/common.c3
@@ -1,4 +1,5 @@
 module std::net::os;
+
 const bool SUPPORTS_INET = env::LIBC && (env::WIN32 || env::DARWIN || env::LINUX || env::ANDROID || env::OPENBSD || env::NETBSD);
 
 typedef AIFamily = CInt;

--- a/lib/std/net/os/darwin.c3
+++ b/lib/std/net/os/darwin.c3
@@ -1,4 +1,5 @@
 module std::net::os @if(env::DARWIN);
+
 import libc;
 
 const AIFlags AI_NUMERICSERV = 0x1000;

--- a/lib/std/net/os/linux.c3
+++ b/lib/std/net/os/linux.c3
@@ -1,4 +1,5 @@
 module std::net::os @if(env::LINUX);
+
 import libc;
 
 const AIFamily PLATFORM_AF_AX25         = 3;

--- a/lib/std/net/os/netbsd.c3
+++ b/lib/std/net/os/netbsd.c3
@@ -1,4 +1,5 @@
 module std::net::os @if(env::NETBSD);
+
 import libc;
 
 const AIFamily PLATFORM_AF_UNSPEC          = 0;                 // unspecified

--- a/lib/std/net/os/openbsd.c3
+++ b/lib/std/net/os/openbsd.c3
@@ -1,4 +1,5 @@
 module std::net::os @if(env::OPENBSD);
+
 import libc;
 
 // for most of this, see OpenBSD /usr/include/sys/socket.h

--- a/lib/std/net/os/posix.c3
+++ b/lib/std/net/os/posix.c3
@@ -1,5 +1,7 @@
 module std::net::os @if(env::POSIX && SUPPORTS_INET);
-import std::io, libc;
+
+import std::io;
+import libc;
 
 const int F_GETFL = 3;
 const int F_SETFL = 4;

--- a/lib/std/net/os/win32.c3
+++ b/lib/std/net/os/win32.c3
@@ -1,9 +1,11 @@
 module std::net::os @if(env::WIN32);
-import std::os, std::io, libc, std::thread;
+
 import std::core::mem;
+import std::io;
+import std::os;
 import std::os::win32;
-
-
+import std::thread;
+import libc;
 
 const AIFamily PLATFORM_AF_IPX          = 6;
 const AIFamily PLATFORM_AF_APPLETALK    = 16;

--- a/lib/std/net/socket.c3
+++ b/lib/std/net/socket.c3
@@ -1,5 +1,9 @@
 module std::net @if(os::SUPPORTS_INET);
-import std::io, std::os, std::time, libc;
+
+import std::io;
+import std::os;
+import std::time;
+import libc;
 
 struct Socket (InStream, OutStream)
 {

--- a/lib/std/net/socket_private.c3
+++ b/lib/std/net/socket_private.c3
@@ -1,9 +1,10 @@
 module std::net @if(os::SUPPORTS_INET);
-import std::time, libc, std::os;
+
 import std::core::env;
 import std::net::os;
-
-
+import std::os;
+import std::time;
+import libc;
 
 macro void? apply_sockoptions(sockfd, options) @private
 {

--- a/lib/std/net/tcp.c3
+++ b/lib/std/net/tcp.c3
@@ -1,11 +1,11 @@
 module std::net::tcp @if(os::SUPPORTS_INET);
-import std::net @public;
-import std::time, libc;
-import std::os::win32;
+
 import std::core::env;
+import std::net @public;
 import std::net::os;
-
-
+import std::os::win32;
+import std::time;
+import libc;
 
 typedef TcpSocket = inline Socket;
 typedef TcpServerSocket = inline Socket;

--- a/lib/std/net/udp.c3
+++ b/lib/std/net/udp.c3
@@ -1,4 +1,5 @@
 module std::net::udp @if(os::SUPPORTS_INET);
+
 import std::net @public;
 
 typedef UdpSocket = inline Socket;

--- a/lib/std/net/url.c3
+++ b/lib/std/net/url.c3
@@ -1,6 +1,8 @@
 module std::net::url;
 
-import std::io, std::collections::map, std::collections::list;
+import std::collections::list;
+import std::collections::map;
+import std::io;
 
 faultdef
 	EMPTY,

--- a/lib/std/net/url_encoding.c3
+++ b/lib/std/net/url_encoding.c3
@@ -3,6 +3,7 @@
  components according to RFC 3986.
 *>
 module std::net::url;
+
 import std::encoding::hex;
 
 enum UrlEncodingMode : char (String allowed)

--- a/lib/std/os/backtrace.c3
+++ b/lib/std/os/backtrace.c3
@@ -1,5 +1,8 @@
 module std::os::backtrace;
-import std::collections::list, std::os, std::io;
+
+import std::collections::list;
+import std::io;
+import std::os;
 
 faultdef SEGMENT_NOT_FOUND, EXECUTABLE_PATH_NOT_FOUND, IMAGE_NOT_FOUND, NO_BACKTRACE_SYMBOLS,
          RESOLUTION_FAILED;

--- a/lib/std/os/cpu.c3
+++ b/lib/std/os/cpu.c3
@@ -1,6 +1,7 @@
 // https://www.cprogramming.com/snippets/source-code/find-the-number-of-cpu-cores-for-windows-mac-or-linux
 
 module std::os @if(env::DARWIN);
+
 import std::os::macos;
 
 fn uint num_cpu()
@@ -16,6 +17,7 @@ fn uint num_cpu()
 }
 
 module std::os @if(env::LINUX);
+
 import std::os::posix;
 
 fn uint num_cpu()
@@ -24,6 +26,7 @@ fn uint num_cpu()
 }
 
 module std::os @if(env::WIN32);
+
 import std::os::win32;
 
 fn uint num_cpu()

--- a/lib/std/os/env.c3
+++ b/lib/std/os/env.c3
@@ -2,7 +2,10 @@
 // Use of this source code is governed by the MIT license
 // a copy of which can be found in the LICENSE_STDLIB file.
 module std::os::env;
-import std::io::path, libc, std::os;
+
+import std::io::path;
+import std::os;
+import libc;
 
 <*
  @param [in] name

--- a/lib/std/os/linux/linux.c3
+++ b/lib/std/os/linux/linux.c3
@@ -1,5 +1,10 @@
 module std::os::linux @if(env::LINUX);
-import libc, std::os, std::io, std::collections::list, std::net::os;
+
+import std::collections::list;
+import std::io;
+import std::net::os;
+import std::os;
+import libc;
 
 // https://man7.org/linux/man-pages/man3/inet_ntop.3.html
 extern fn char** inet_ntop(int, void*, char*, Socklen_t);

--- a/lib/std/os/macos/darwin.c3
+++ b/lib/std/os/macos/darwin.c3
@@ -1,5 +1,7 @@
 module std::os::darwin @if(env::DARWIN);
-import std::collections::list, std::os;
+
+import std::collections::list;
+import std::os;
 
 const CTL_UNSPEC	= 0; /* unused */
 const CTL_KERN		= 1; /* "high kernel": proc, limits */

--- a/lib/std/os/macos/general.c3
+++ b/lib/std/os/macos/general.c3
@@ -1,5 +1,8 @@
 module std::os::darwin @if(env::DARWIN) @link("Foundation.framework");
-import std::os::macos::cf, std::os::macos::objc, std::io;
+
+import std::io;
+import std::os::macos::cf;
+import std::os::macos::objc;
 
 enum NSSearchPathDomainMask : const NSUInteger
 {

--- a/lib/std/os/macos/objc.c3
+++ b/lib/std/os/macos/objc.c3
@@ -73,6 +73,7 @@ extern fn ObjcClass allocateClassPair(ObjcClass cls, ZString name, uint extraByt
 extern fn void registerClassPair(ObjcClass cls) @cname("objc_registerClassPair");
 
 module std::os::macos::objc::ns @if(env::DARWIN) @link(env::DARWIN, "CoreFoundation.framework");
+
 import std::os::macos::cf;
 
 enum StatusItemLength : (double val) @deprecated("Use NSStatusItemLength.")

--- a/lib/std/os/openbsd/general.c3
+++ b/lib/std/os/openbsd/general.c3
@@ -1,6 +1,8 @@
 module std::os::openbsd @if(env::OPENBSD);
-import libc, std::os, std::collections::list;
 
+import std::collections::list;
+import std::os;
+import libc;
 
 // Native `sysctl` identifiers from <sys/sysctl.h>
 const CTL_UNSPEC        =  0;   /* unused */

--- a/lib/std/os/os.c3
+++ b/lib/std/os/os.c3
@@ -1,4 +1,5 @@
 module std::os;
+
 import libc;
 
 <*

--- a/lib/std/os/posix/clock.c3
+++ b/lib/std/os/posix/clock.c3
@@ -1,9 +1,11 @@
 module std::os::posix @if(env::POSIX);
+
 import libc;
 
 extern fn CInt clock_gettime(int type, TimeSpec *time) @cname(env::NETBSD ??? "__clock_gettime50" : "clock_gettime");
 
 module std::os::posix @if(env::OPENBSD);
+
 const CLOCK_REALTIME = 0;
 const CLOCK_PROCESS_CPUTIME_ID = 2;
 const CLOCK_MONOTONIC = 3;
@@ -12,6 +14,7 @@ const CLOCK_UPTIME = 5;
 const CLOCK_BOOTTIME = 6;
 
 module std::os::posix @if(env::FREEBSD);
+
 const CLOCK_REALTIME = 0;
 const CLOCK_VIRTUAL = 1;
 const CLOCK_PROF = 2;
@@ -31,6 +34,7 @@ const CLOCK_REALTIME_COARSE = CLOCK_REALTIME_FAST;
 const CLOCK_MONOTONIC_COARSE = CLOCK_MONOTONIC_FAST;
 
 module std::os::posix @if(env::NETBSD);
+
 const CLOCK_REALTIME = 0;
 const CLOCK_VIRTUAL = 1;
 const CLOCK_PROF = 2;
@@ -39,11 +43,13 @@ const CLOCK_THREAD_CPUTIME_ID = 0x20000000;
 const CLOCK_PROCESS_CPUTIME_ID = 0x40000000;
 
 module std::os::posix @if(env::WASI);
+
 // Not implemented
 const CLOCK_REALTIME = 0;
 const CLOCK_MONOTONIC = 0;
 
 module std::os::posix @if(env::DARWIN);
+
 const CLOCK_REALTIME = 0;
 const CLOCK_MONOTONIC = 6;
 const CLOCK_MONOTONIC_RAW = 4;
@@ -54,6 +60,7 @@ const CLOCK_PROCESS_CPUTIME_ID = 12;
 const CLOCK_THREAD_CPUTIME_ID = 16;
 
 module std::os::posix @if(env::LINUX || env::ANDROID);
+
 const CLOCK_REALTIME = 0;
 const CLOCK_MONOTONIC = 1;
 const CLOCK_PROCESS_CPUTIME_ID = 2;

--- a/lib/std/os/posix/files.c3
+++ b/lib/std/os/posix/files.c3
@@ -1,4 +1,5 @@
 module std::os::posix @if(env::POSIX);
+
 import libc;
 
 alias Mode_t = uint;

--- a/lib/std/os/posix/mman.c3
+++ b/lib/std/os/posix/mman.c3
@@ -1,6 +1,6 @@
 module std::os::posix @if(env::POSIX);
-import libc;
 
+import libc;
 
 const PROT_NONE     = 0x00;    // no permissions
 const PROT_READ     = 0x01;    // pages can be read

--- a/lib/std/os/posix/process.c3
+++ b/lib/std/os/posix/process.c3
@@ -1,5 +1,7 @@
 module std::os::posix @if(env::POSIX);
-import libc, std::os::darwin;
+
+import std::os::darwin;
+import libc;
 
 struct Posix_spawn_file_actions_t
 {

--- a/lib/std/os/posix/threads.c3
+++ b/lib/std/os/posix/threads.c3
@@ -1,4 +1,5 @@
 module std::os::posix @if(env::POSIX);
+
 import std::thread;
 import libc;
 

--- a/lib/std/os/subprocess.c3
+++ b/lib/std/os/subprocess.c3
@@ -1,5 +1,8 @@
 module std::os::process @if(env::WIN32 || env::POSIX);
-import std::io, libc, std::os;
+
+import std::io;
+import std::os;
+import libc;
 
 // This code is based on https://github.com/sheredom/subprocess.h
 

--- a/lib/std/os/win32/clock.c3
+++ b/lib/std/os/win32/clock.c3
@@ -1,4 +1,5 @@
 module std::os::win32 @if(env::WIN32);
+
 import std::math;
 
 extern fn void getSystemTimeAsFileTime(Win32_FILETIME* time) @cname("GetSystemTimeAsFileTime");

--- a/lib/std/os/win32/files.c3
+++ b/lib/std/os/win32/files.c3
@@ -1,4 +1,5 @@
 module std::os::win32 @if(env::WIN32);
+
 import libc;
 
 enum Win32_GET_FILEEX_INFO_LEVELS

--- a/lib/std/os/win32/process.c3
+++ b/lib/std/os/win32/process.c3
@@ -1,5 +1,7 @@
 module std::os::win32 @if(env::WIN32);
-import std::thread, std::os::backtrace;
+
+import std::os::backtrace;
+import std::thread;
 
 const Win32_DWORD STARTF_USESTDHANDLES = 0x00000100;
 const Win32_DWORD CREATE_NO_WINDOW = 0x08000000;

--- a/lib/std/os/xdg.c3
+++ b/lib/std/os/xdg.c3
@@ -1,5 +1,7 @@
 module std::os::posix @if(env::POSIX);
-import std::io, std::os::env;
+
+import std::io;
+import std::os::env;
 
 fn String? xdg_user_dir_lookup(Allocator allocator, String type) => @pool()
 {

--- a/lib/std/sort/countingsort.c3
+++ b/lib/std/sort/countingsort.c3
@@ -1,4 +1,5 @@
 module std::sort;
+
 import std::sort::is;
 import std::sort::cs;
 import std::sort::qs;
@@ -39,7 +40,7 @@ macro void quicksort_indexed(list, start, end, cmp = EMPTY_MACRO_SLOT, context =
 	$endif
 }
 
-module std::sort::cs{Type, KeyFn};
+module std::sort::cs {Type, KeyFn};
 
 alias Counts @private = usz[256];
 alias Ranges @private = usz[257];

--- a/lib/std/sort/insertionsort.c3
+++ b/lib/std/sort/insertionsort.c3
@@ -1,4 +1,5 @@
 module std::sort;
+
 import std::sort::is;
 
 <*
@@ -17,7 +18,7 @@ macro void insertionsort(list, cmp = EMPTY_MACRO_SLOT, context = EMPTY_MACRO_SLO
 	$endif
 }
 
-module std::sort::is{Type, CmpFn, Context};
+module std::sort::is {Type, CmpFn, Context};
 
 alias ElementType = $typeof(((Type){})[0]);
 const bool IS_SLICE = Type.kindof == SLICE;

--- a/lib/std/sort/quicksort.c3
+++ b/lib/std/sort/quicksort.c3
@@ -1,4 +1,5 @@
 module std::sort;
+
 import std::sort::qs;
 
 <*
@@ -37,7 +38,7 @@ macro quickselect(list, isz k, cmp = EMPTY_MACRO_SLOT, context = EMPTY_MACRO_SLO
 	$endif
 }
 
-module std::sort::qs{Type, CmpFn, Context};
+module std::sort::qs {Type, CmpFn, Context};
 
 alias ElementType = $typeof(((Type){})[0]);
 const bool IS_SLICE = Type.kindof == SLICE;

--- a/lib/std/threads/buffered_channel.c3
+++ b/lib/std/threads/buffered_channel.c3
@@ -1,4 +1,4 @@
-module std::thread::channel{Type};
+module std::thread::channel {Type};
 
 typedef BufferedChannel = void*;
 

--- a/lib/std/threads/fixed_pool.c3
+++ b/lib/std/threads/fixed_pool.c3
@@ -1,7 +1,9 @@
 module std::thread;
+
 faultdef THREAD_QUEUE_FULL;
 
 module std::thread::threadpool @if (env::POSIX || env::WIN32);
+
 import std::thread;
 
 // Please do not use this one in production.

--- a/lib/std/threads/os/cpu.c3
+++ b/lib/std/threads/os/cpu.c3
@@ -1,6 +1,7 @@
 // https://www.cprogramming.com/snippets/source-code/find-the-number-of-cpu-cores-for-windows-mac-or-linux
 
 module std::thread::cpu @if(env::DARWIN);
+
 import libc;
 
 const CTL_UNSPEC	= 0; /* unused */
@@ -51,6 +52,7 @@ fn uint native_cpu()
 }
 
 module std::thread::cpu @if(env::OPENBSD);
+
 import std::os::openbsd;
 import libc;
 
@@ -66,6 +68,7 @@ fn uint native_cpu()
 }
 
 module std::thread::cpu @if(env::LINUX);
+
 import libc;
 
 fn uint native_cpu()
@@ -74,6 +77,7 @@ fn uint native_cpu()
 }
 
 module std::thread::cpu @if(env::WIN32);
+
 import libc;
 
 fn uint native_cpu()

--- a/lib/std/threads/os/thread_posix.c3
+++ b/lib/std/threads/os/thread_posix.c3
@@ -1,9 +1,10 @@
 module std::thread::os @if(env::POSIX);
-import std::os::posix, std::time, libc;
-import libc::errno;
+
+import std::os::posix;
 import std::thread;
-
-
+import std::time;
+import libc;
+import libc::errno;
 
 struct NativeMutex
 {

--- a/lib/std/threads/os/thread_win32.c3
+++ b/lib/std/threads/os/thread_win32.c3
@@ -1,7 +1,8 @@
 module std::thread::os @if(env::WIN32);
-import std::os::win32, std::time;
-import std::thread;
 
+import std::os::win32;
+import std::thread;
+import std::time;
 
 typedef NativeThread = inline Win32_HANDLE;
 

--- a/lib/std/threads/pool.c3
+++ b/lib/std/threads/pool.c3
@@ -1,4 +1,5 @@
-module std::thread::pool{SIZE};
+module std::thread::pool {SIZE};
+
 import std::thread;
 
 struct ThreadPool

--- a/lib/std/threads/thread.c3
+++ b/lib/std/threads/thread.c3
@@ -1,4 +1,5 @@
 module std::thread;
+
 import std::thread::os;
 import std::time;
 

--- a/lib/std/time/clock.c3
+++ b/lib/std/time/clock.c3
@@ -1,4 +1,5 @@
 module std::time::clock;
+
 import std::time::os;
 
 fn Clock now()

--- a/lib/std/time/datetime.c3
+++ b/lib/std/time/datetime.c3
@@ -1,4 +1,5 @@
 module std::time::datetime @if(env::LIBC);
+
 import libc;
 
 fn DateTime now()

--- a/lib/std/time/format.c3
+++ b/lib/std/time/format.c3
@@ -1,6 +1,5 @@
 module std::time::datetime @if(env::LIBC);
 
-
 enum DateTimeFormat
 {
 	ANSIC,	 	// "Mon Jan _2 15:04:05 2006"

--- a/lib/std/time/os/time_darwin.c3
+++ b/lib/std/time/os/time_darwin.c3
@@ -1,4 +1,5 @@
 module std::time::os @if(env::DARWIN);
+
 import std::os::darwin;
 
 fn Clock native_clock()

--- a/lib/std/time/os/time_posix.c3
+++ b/lib/std/time/os/time_posix.c3
@@ -1,5 +1,7 @@
 module std::time::os @if(env::POSIX);
-import libc, std::os::posix;
+
+import std::os::posix;
+import libc;
 
 fn Time native_timestamp()
 {

--- a/lib/std/time/os/time_win32.c3
+++ b/lib/std/time/os/time_win32.c3
@@ -1,6 +1,7 @@
 module std::time::os @if(env::WIN32);
-import std::os::win32;
+
 import std::math;
+import std::os::win32;
 
 const ulong WINDOWS_TICK_US @local = 10;
 const ulong WIN_TO_UNIX_EPOCH_US @local = 116444736000000000UL / WINDOWS_TICK_US;

--- a/lib/std/time/time.c3
+++ b/lib/std/time/time.c3
@@ -1,5 +1,7 @@
 module std::time;
-import std::io, std::time::os;
+
+import std::io;
+import std::time::os;
 
 typedef Time @structlike = long;
 typedef Duration @structlike = long;


### PR DESCRIPTION
The import statements in `lib/std` are not alphabetised, and some are all on one line while others are on a separate line. This PR addresses this by alphabetising the statements, which is hopefully easier to maintain.