### PR TITLE
Ignore ctags and gtags files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,8 +73,12 @@ out/
 /cmake-build-debug/
 /cmake-build-release/
 
-# Emacs files
+# etags(Emacs), ctags, gtags
 TAGS
+GPATH
+GRTAGS
+GTAGS
+tags
 
 # Clangd LSP files
 /.cache/


### PR DESCRIPTION
This PR updates the .gitignore file to exclude automatically generated tags files from ctags and gtags.

Specifically, it ignores:
- ctags output file: tags
- GNU Global output files: GTAGS, GRTAGS, GPATH