### PR TITLE
Proposal to add passing of list arguments to the linker through the -z flag.

### DIFF
--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -601,15 +601,15 @@ static void parse_option(BuildOptions *options)
 			if (match_shortopt("z"))
 			{
 				if (at_end()) error_exit("error: -z needs a value.");
-				if (str_eq(peek_next_arg(), "[")) // If we match a ], we can parse the list of args
+				if (str_eq(peek_next_arg(), "["))
 				{
-					next_arg(); // Jump past [
-					while(!at_end() && !str_eq(peek_next_arg(), "]")) // Consume until we reach end or reach ]
+					next_arg();
+					while(!at_end() && !str_eq(peek_next_arg(), "]"))
 					{
 						add_linker_arg(options, next_arg());
 					}
-					if (at_end()) error_exit("error: ']' needed at the end of the linker arguments"); // One final bounds check
-					next_arg(); // Jump past ]
+					if (at_end()) error_exit("error: ']' needed at the end of the linker arguments");
+					next_arg();
 					return;
 				}
 				add_linker_arg(options, next_arg());


### PR DESCRIPTION
I use macOS and linking with frameworks is a massive pain so I am proposing the ability to pass a "list" to the linker using the -z flag.

My idea goes like so, during the parsing of arguments in the parse_options function, I added this small bit of code in the 'z' case.

```
if (str_eq(peek_next_arg(), "["))
{
    next_arg();
    while(!at_end() && !str_eq(peek_next_arg(), "]"))
    {
        add_linker_arg(options, next_arg());
    }
    if (at_end()) error_exit("error: ']' needed at the end of the linker arguments");
    next_arg();
    return;
}
```

The peek_next_arg() is another small function I added that returns the next argument without incrementing the index. So we first match against the open bracket '['. We can then jump over it using next_arg() and begin consuming arguments to pass to the linker. It then bounds tests one final time to ensure we are not at the end and then jumps over the final bracket ']'.

This addition changes the following makefile by quite a bit,.

```
c3c compile -z -L./src/libs -l raylib -z -framework -z CoreFoundation -z -framework -z CoreVideo -z -framework -z IOKit -z -framework -z Cocoa -z -framework -z OpenGL -o probe/main ./src/src/raylib.c3 ./src/src/test.c3
Program linked to executable './probe/main'.

./build/c3c compile -z -L./src/libs -l raylib -z [ -framework CoreFoundation -framework CoreVideo -framework IOKit -framework Cocoa -framework OpenGL ] -o probe/main ./src/src/raylib.c3 ./src/src/test.c3
Program linked to executable './probe/main'.
```

In order to pass the -framework option and the corresponding framework to the linker, a -z flag is needed before each case which made the compilation command quite verbose.

The only other solution I can think of is to add '-framework' as an option, but this seemed like the easiest and simplest solution to me.