### PR TITLE
small fix to generated C header global

### DIFF
--- a/src/compiler/headers.c
+++ b/src/compiler/headers.c
@@ -676,10 +676,10 @@ static void header_gen_global_var(HeaderContext *c, Decl *decl, bool fn_globals,
 		header_gen_maybe_generate_type(c, decl->type, false);
 		return;
 	}
-	header_print_type(c, decl->type);
 	ASSERT(decl->var.kind == VARDECL_GLOBAL || decl->var.kind == VARDECL_CONST);
 	PRINTF("extern ");
 	if (decl->var.kind == VARDECL_CONST) PRINTF("const ");
+	header_print_type(c, decl->type);
 	PRINTF(" %s;\n", decl_get_extname(decl));
 }
 


### PR DESCRIPTION
test:
```c3
module my_module;

alias Something = fn void(int);
Something something @export("something") = &something_else;
fn void something_else(int a) => {};
```

would generate
```c
/* GLOBALS */
my_module__Somethingextern  something;
```

now correctly generates
```c
/* GLOBALS */
extern my_module__Something  something;
```