### PR TITLE
collections: fix LinkedList.to_format

### DIFF
--- a/lib/std/collections/linkedlist.c3
+++ b/lib/std/collections/linkedlist.c3
@@ -24,9 +24,9 @@ struct LinkedList
 fn usz? LinkedList.to_format(&self, Formatter* f) @dynamic
 {
 	usz len = f.print("{ ")!;
-	for (Node* node = self._first; node != null; node.next)
+	for (Node* node = self._first; node != null; node = node.next)
 	{
-		len += f.printf(node.next ? "%s, " : "s", node.value)!;
+		len += f.printf(node.next ? "%s, " : "%s", node.value)!;
 	}
 	return len + f.print(" }");
 }

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -55,6 +55,7 @@
 - Assert on optional-returning-function in a comma expression. #2722
 - Creating recursive debug info for functions could cause assertions.
 - bitorder::read and bitorder::write may fail because of unaligned access #2734.
+- Fix `LinkedList.to_format` to properly iterate linked list for printing.
 
 ### Stdlib changes
 - Add `ThreadPool` join function to wait for all threads to finish in the pool without destroying the threads.


### PR DESCRIPTION
For-loop in LinkedList.to_format goes brrrrrr and prints the value of the first node an infinte number of times because it does not properly iterate the linked list.

Fix the list iterations and add the missing string format specifier.

Bug can be reproduced with:
```
import std;
fn void main() => @pool()
{
	io::printfn("%s", linkedlist::@tnew{usz}({1,2,3}));
}
```