### PR TITLE
common.h: define static_assert to _Static_assert when undefined

### DIFF
--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -75,6 +75,10 @@
 #define __unused
 #endif
 
+#ifndef static_assert
+#define static_assert _Static_assert
+#endif
+
 
 #if (defined(__GNUC__) && __GNUC__ >= 7) || defined(__clang__)
 #define PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))


### PR DESCRIPTION
Fixes build error:
```
[  8%] Building C object CMakeFiles/c3c.dir/src/build/project_manipulation.c.o
/opt/local/bin/ccache /opt/local/bin/gcc-mp-14 -DCURL_FOUND=1 -DLLVM_AVAILABLE=0 -DTB_AVAILABLE=0 -I/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src -I/opt/local/var/macports/build/c3c-7b939bf2/work/build -I/opt/local/include -I/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/dependencies/miniz -pipe -Os -DNDEBUG -I/opt/local/include -std=gnu11 -arch ppc -mmacosx-version-min=10.6 -gdwarf-3 -fno-exceptions -pthread -Wall -Werror -Wno-unknown-pragmas -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unused-parameter -MD -MT CMakeFiles/c3c.dir/src/build/project_manipulation.c.o -MF CMakeFiles/c3c.dir/src/build/project_manipulation.c.o.d -o CMakeFiles/c3c.dir/src/build/project_manipulation.c.o -c /opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/build/project_manipulation.c
[  9%] Building C object CMakeFiles/c3c.dir/src/build/libraries.c.o
/opt/local/bin/ccache /opt/local/bin/gcc-mp-14 -DCURL_FOUND=1 -DLLVM_AVAILABLE=0 -DTB_AVAILABLE=0 -I/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src -I/opt/local/var/macports/build/c3c-7b939bf2/work/build -I/opt/local/include -I/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/dependencies/miniz -pipe -Os -DNDEBUG -I/opt/local/include -std=gnu11 -arch ppc -mmacosx-version-min=10.6 -gdwarf-3 -fno-exceptions -pthread -Wall -Werror -Wno-unknown-pragmas -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unused-parameter -MD -MT CMakeFiles/c3c.dir/src/build/libraries.c.o -MF CMakeFiles/c3c.dir/src/build/libraries.c.o.d -o CMakeFiles/c3c.dir/src/build/libraries.c.o -c /opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/build/libraries.c
In file included from /opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:9,
                 from /opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/build/libraries.c:2:
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/enums.h:1788:24: error: expected ')' before '<' token
 1788 | static_assert(EXPR_LAST < 128, "Too many expression types");
      |                        ^~
      |                        )
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:182:15: error: expected declaration specifiers or '...' before 'sizeof'
  182 | static_assert(sizeof(SourceSpan) == 8, "Expected 8 bytes");
      |               ^~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:182:40: error: expected declaration specifiers or '...' before string constant
  182 | static_assert(sizeof(SourceSpan) == 8, "Expected 8 bytes");
      |                                        ^~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:759:15: error: expected declaration specifiers or '...' before 'sizeof'
  759 | static_assert(sizeof(void*) != 8 || sizeof(Decl) == 136, "Decl has unexpected size.");
      |               ^~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:759:58: error: expected declaration specifiers or '...' before string constant
  759 | static_assert(sizeof(void*) != 8 || sizeof(Decl) == 136, "Decl has unexpected size.");
      |                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:1300:15: error: expected declaration specifiers or '...' before 'sizeof'
 1300 | static_assert(sizeof(void*) != 8 || sizeof(Expr) == 56, "Expr not expected size");
      |               ^~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:1300:57: error: expected declaration specifiers or '...' before string constant
 1300 | static_assert(sizeof(void*) != 8 || sizeof(Expr) == 56, "Expr not expected size");
      |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:1616:15: error: expected declaration specifiers or '...' before 'sizeof'
 1616 | static_assert(sizeof(void*) != 8 || sizeof(Ast) == 56, "Not expected Ast size");
      |               ^~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:1616:56: error: expected declaration specifiers or '...' before string constant
 1616 | static_assert(sizeof(void*) != 8 || sizeof(Ast) == 56, "Not expected Ast size");
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/c3c.dir/src/build/libraries.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 11%] Building C object CMakeFiles/c3c.dir/src/compiler/ast.c.o
/opt/local/bin/ccache /opt/local/bin/gcc-mp-14 -DCURL_FOUND=1 -DLLVM_AVAILABLE=0 -DTB_AVAILABLE=0 -I/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src -I/opt/local/var/macports/build/c3c-7b939bf2/work/build -I/opt/local/include -I/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/dependencies/miniz -pipe -Os -DNDEBUG -I/opt/local/include -std=gnu11 -arch ppc -mmacosx-version-min=10.6 -gdwarf-3 -fno-exceptions -pthread -Wall -Werror -Wno-unknown-pragmas -Wno-unused-result -Wno-unused-function -Wno-unused-variable -Wno-unused-parameter -MD -MT CMakeFiles/c3c.dir/src/compiler/ast.c.o -MF CMakeFiles/c3c.dir/src/compiler/ast.c.o.d -o CMakeFiles/c3c.dir/src/compiler/ast.c.o -c /opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/ast.c
In file included from /opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:9,
                 from /opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/ast.c:5:
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/enums.h:1788:24: error: expected ')' before '<' token
 1788 | static_assert(EXPR_LAST < 128, "Too many expression types");
      |                        ^~
      |                        )
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:182:15: error: expected declaration specifiers or '...' before 'sizeof'
  182 | static_assert(sizeof(SourceSpan) == 8, "Expected 8 bytes");
      |               ^~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:182:40: error: expected declaration specifiers or '...' before string constant
  182 | static_assert(sizeof(SourceSpan) == 8, "Expected 8 bytes");
      |                                        ^~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:759:15: error: expected declaration specifiers or '...' before 'sizeof'
  759 | static_assert(sizeof(void*) != 8 || sizeof(Decl) == 136, "Decl has unexpected size.");
      |               ^~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:759:58: error: expected declaration specifiers or '...' before string constant
  759 | static_assert(sizeof(void*) != 8 || sizeof(Decl) == 136, "Decl has unexpected size.");
      |                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:1300:15: error: expected declaration specifiers or '...' before 'sizeof'
 1300 | static_assert(sizeof(void*) != 8 || sizeof(Expr) == 56, "Expr not expected size");
      |               ^~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:1300:57: error: expected declaration specifiers or '...' before string constant
 1300 | static_assert(sizeof(void*) != 8 || sizeof(Expr) == 56, "Expr not expected size");
      |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:1616:15: error: expected declaration specifiers or '...' before 'sizeof'
 1616 | static_assert(sizeof(void*) != 8 || sizeof(Ast) == 56, "Not expected Ast size");
      |               ^~~~~~
/opt/local/var/macports/build/c3c-7b939bf2/work/c3c-0.7.8/src/compiler/compiler_internal.h:1616:56: error: expected declaration specifiers or '...' before string constant
 1616 | static_assert(sizeof(void*) != 8 || sizeof(Ast) == 56, "Not expected Ast size");
      |                                                        ^~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/c3c.dir/src/compiler/ast.c.o] Error 1
```