### PR TITLE
also set utf8 codepage on win32 when the main function takes no args

### DIFF
--- a/lib/std/core/private/main_stub.c3
+++ b/lib/std/core/private/main_stub.c3
@@ -77,6 +77,23 @@ macro win32_set_utf8_codepage() @local
 	win32::setConsoleOutputCP(UTF8);
 }
 
+macro int @wmain_to_err_main(#m, int, Char16**)
+{
+	win32_set_utf8_codepage();
+	if (catch #m()) return 1;
+	return 0;
+}
+macro int @wmain_to_int_main(#m, int, Char16**)
+{
+	win32_set_utf8_codepage();
+	return #m();
+}
+macro int @wmain_to_void_main(#m, int, Char16**)
+{
+	win32_set_utf8_codepage();
+	#m();
+	return 0;
+}
 
 extern fn Char16** _win_command_line_to_argv_w(ushort* cmd_line, int* argc_ptr) @cname("CommandLineToArgvW");
 

--- a/src/compiler/sema_decls.c
+++ b/src/compiler/sema_decls.c
@@ -4134,7 +4134,6 @@ static inline Decl *sema_create_synthetic_main(SemaContext *context, Decl *decl,
 				default: UNREACHABLE
 			}
 		case MAIN_TYPE_NO_ARGS:
-			ASSERT(!is_wmain);
 			if (is_winmain)
 			{
 				switch (type)
@@ -4142,6 +4141,16 @@ static inline Decl *sema_create_synthetic_main(SemaContext *context, Decl *decl,
 					case 0 : main_invoker = "@win_to_void_main_noargs"; goto NEXT;
 					case 1 : main_invoker = "@win_to_int_main_noargs"; goto NEXT;
 					case 2 : main_invoker = "@win_to_err_main_noargs"; goto NEXT;
+					default: UNREACHABLE
+				}
+			}
+			if (is_wmain)
+			{
+				switch (type)
+				{
+					case 0 : main_invoker = "@wmain_to_void_main"; goto NEXT;
+					case 1 : main_invoker = "@wmain_to_int_main"; goto NEXT;
+					case 2 : main_invoker = "@wmain_to_err_main"; goto NEXT;
 					default: UNREACHABLE
 				}
 			}
@@ -4243,7 +4252,7 @@ static inline bool sema_analyse_main_function(SemaContext *context, Decl *decl)
 		function = decl;
 		goto REGISTER_MAIN;
 	}
-	bool is_wmain = is_win32 && !is_winmain && type != MAIN_TYPE_NO_ARGS;
+	bool is_wmain = is_win32 && !is_winmain;
 	compiler.build.win.use_win_subsystem = is_winmain && is_win32;
 	function = sema_create_synthetic_main(context, decl, type, is_int_return, is_err_return, is_winmain, is_wmain);
 	if (!decl_ok(function)) return false;


### PR DESCRIPTION
in https://github.com/c3lang/c3c/pull/2670#issuecomment-3766496033 the reading input and printing utf8 tests work apart from 1 and 4, which are the `fn void main()` and `fn int main()` tests from https://github.com/c3lang/c3c/pull/2670#issuecomment-3764518823.

in sema_decls.c it calls the `@main_to_int_main` and `@main_to_void_main` macros when the main function has no args and isn't `@winmain`, so this PR also sets the utf8 codepage in these macros and fixes printing utf8 text for main functions with no args:
https://github.com/c3lang/c3c/blob/396263f5c3ef4c933f5bf6d82154788636838fd3/src/compiler/sema_decls.c#L4136-L4154

it would also be possible to add `@wmain_to_void_main` and `@wmain_to_int_main` macros that get called instead of  `@main_to_int_main` and `@main_to_void_main` on win32, I can do that instead if you prefer.