### PR TITLE
Added unit tests for `Crc32` hashing.

### DIFF
--- a/test/unit/stdlib/hash/crc32.c3
+++ b/test/unit/stdlib/hash/crc32.c3
@@ -5,60 +5,60 @@ import std::io;
 
 fn void test_crc32_empty()
 {
-  const uint EXPECTED = 0x00000000;
+	const uint EXPECTED = 0x00000000;
 
 	Crc32 crc;
 	crc.init();
 	crc.update("");
 
-  uint final = crc.final();
+	uint final = crc.final();
 	test::@check(final == EXPECTED, "Actual crc32: 0x%x == 0x%x", final, EXPECTED);
 }
 
 fn void test_crc32_a()
 {
-  const uint EXPECTED = 0xe8b7be43;
+	const uint EXPECTED = 0xe8b7be43;
 
 	Crc32 crc;
 	crc.init();
 	crc.updatec('a');
 
-  uint final = crc.final();
+	uint final = crc.final();
 	test::@check(final == EXPECTED, "Actual crc32: 0x%x == 0x%x", final, EXPECTED);
 }
 
 fn void test_crc32_abc()
 {
-  const uint EXPECTED = 0x352441c2;
+	const uint EXPECTED = 0x352441c2;
 
 	Crc32 crc;
 	crc.init();
 	crc.update("abc");
 
-  uint final = crc.final();
+	uint final = crc.final();
 	test::@check(final == EXPECTED, "Actual crc32: 0x%x == 0x%x", final, EXPECTED);
 }
 
 fn void test_crc32_longer()
 {
-  const uint EXPECTED = 0x656e49ed;
+	const uint EXPECTED = 0x656e49ed;
 
 	Crc32 crc;
 	crc.init();
 	crc.update("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopqabcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq");
 
-  uint final = crc.final();
+	uint final = crc.final();
 	test::@check(final == EXPECTED, "Actual crc32: 0x%x == 0x%x", final, EXPECTED);
 }
 
 fn void test_crc32_alphabet()
 {
-  const uint EXPECTED = 0x4c2750bd;
+	const uint EXPECTED = 0x4c2750bd;
 
 	Crc32 crc;
 	crc.init();
 	crc.update("abcdefghijklmnopqrstuvwxyz");
 
-  uint final = crc.final();
+	uint final = crc.final();
 	test::@check(final == EXPECTED, "Actual crc32: 0x%x == 0x%x", final, EXPECTED);
 }


### PR DESCRIPTION
Added basic set of unit tests for the CRC32 hashing.
I validated the C3 hashing utilities again Python `zlib.crc32`:
```
python3 -c "import zlib; print(hex(zlib.crc32('Hash here') & 0xFFFFFFFF))"
```

Just a basic addition for the unit tests.