### PR TITLE
Fix formatting of path assignment in msvc_build_libraries.py

### DIFF
--- a/msvc_build_libraries.py
+++ b/msvc_build_libraries.py
@@ -239,7 +239,7 @@ def copy(src, dst):
 	base = os.path.basename(low)
 	if base == "msvcrt.lib" or base == "oldnames.lib":
 		base = base[:-3].upper() + "lib"
-		path = os.path.join(os.path.dirname(low), base);
+		path = os.path.join(os.path.dirname(low), base)
 		shutil.copy(src, path)
 	shutil.copy(src, low)
 


### PR DESCRIPTION
There was an error with the semicolon, which has been corrected to the right one.