### PR TITLE
Implement lazy-loaded libcurl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,9 +129,6 @@ if(C3_USE_MIMALLOC)
     )
     FetchContent_MakeAvailable(mimalloc)
 endif()
-if (NOT WIN32)
-    find_package(CURL)
-endif()
 
 find_package(Git QUIET)
 if(C3_USE_TB AND GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
@@ -606,12 +603,11 @@ if(MINGW)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,8388608")
 endif ()
 
-if (CURL_FOUND)
-    target_link_libraries(c3c ${CURL_LIBRARIES})
-    target_include_directories(c3c PRIVATE ${CURL_INCLUDE_DIRS})
-    target_compile_definitions(c3c PUBLIC CURL_FOUND=1)
-else()
-    target_compile_definitions(c3c PUBLIC CURL_FOUND=0)
+if (NOT WIN32)
+    # For dlopen support
+    if (CMAKE_DL_LIBS)
+        target_link_libraries(c3c ${CMAKE_DL_LIBS})
+    endif()
 endif()
 
 

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -259,9 +259,7 @@ static void project_usage()
 	PRINTF("Project Subcommands:");
 	print_cmd("view", "view the current projects structure.");
 	print_cmd("add-target <name>  <target_type>  [sources...]", "add a new target to the project.");
-	#if FETCH_AVAILABLE
-		print_cmd("fetch", "fetch missing project libraries.");
-	#endif
+	print_cmd("fetch", "fetch missing project libraries.");
 }
 
 static void project_view_usage()

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -268,9 +268,14 @@ static void view_target(BuildParseContext context, JSONObject *target, bool verb
 
 
 
-#if FETCH_AVAILABLE
+
 void fetch_project(BuildOptions* options)
 {
+	if (!download_available())
+	{
+		error_exit("The 'project fetch' command requires libcurl to download dependencies.\n"
+				   "Please ensure libcurl is installed on your system.");
+	}
 	if (!file_exists(PROJECT_JSON5) && !file_exists(PROJECT_JSON))
 	{
 		error_exit("Failed: no project file found.");
@@ -343,12 +348,7 @@ void fetch_project(BuildOptions* options)
 		}
 	}
 }
-#else
-void fetch_project(BuildOptions* options)
-{
-	error_exit("Error: project fetch only available when compiled with cURL.");
-}
-#endif
+
 
 
 void add_libraries_to_project_file(const char** libs, const char* target_name) {

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -966,7 +966,7 @@ bool use_ansi(void)
 #endif
 }
 
-#if FETCH_AVAILABLE
+
 const char * vendor_fetch_single(const char* lib, const char* path) 
 {
 	const char *resource = str_printf("/c3lang/vendor/releases/download/latest/%s.c3l", lib);
@@ -993,6 +993,11 @@ void update_progress_bar(const char* lib, int current_step, int total_steps)
 
 void vendor_fetch(BuildOptions *options)
 {
+	if (!download_available())
+	{
+		error_exit("The 'vendor-fetch' command requires libcurl to download libraries.\n"
+				   "Please ensure libcurl is installed on your system.");
+	}
 	bool ansi = use_ansi();
 
 	if (str_eq(options->path, DEFAULT_PATH))
@@ -1061,12 +1066,7 @@ void vendor_fetch(BuildOptions *options)
 
 	if (ansi) printf("\033[32mFetching complete.\033[0m\t\t\n");
 }
-#else
-void vendor_fetch(BuildOptions *options)
-{
-	error_exit("Error: vendor-fetch only available when compiled with cURL.");
-}
-#endif
+
 
 void print_syntax(BuildOptions *options)
 {

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -54,11 +54,6 @@
 #endif
 #endif
 
-#if CURL_FOUND || PLATFORM_WINDOWS
-#define FETCH_AVAILABLE 1
-#else
-#define FETCH_AVAILABLE 0
-#endif
 
 #define IS_GCC 0
 #define IS_CLANG 0

--- a/src/utils/fetch_msvc.c
+++ b/src/utils/fetch_msvc.c
@@ -136,7 +136,7 @@ static void closedir(DIR *dir)
 }
 #endif
 
-#if FETCH_AVAILABLE
+
 
 static int version_compare(const char *v1, const char *v2)
 {
@@ -509,6 +509,13 @@ static bool check_license(JSONObject *rj1_channel_items, bool accept_all)
 
 void fetch_msvc(BuildOptions *options)
 {
+	if (!download_available())
+	{
+		error_exit("Failed to find Windows SDK.\n"
+				   "Windows applications cannot be cross-compiled without it.\n"
+				   "To download the SDK automatically, please ensure libcurl is installed.\n"
+				   "Alternatively, provide the SDK path manually using --winsdk.");
+	}
 	verbose_level = options->verbosity_level;
 	const char *tmp_dir_base = dir_make_temp_dir();
 	if (!tmp_dir_base) error_exit("Failed to create temp directory");
@@ -749,13 +756,5 @@ void fetch_msvc(BuildOptions *options)
 
 	if (verbose_level == 0) file_delete_dir(tmp_dir_base);
 }
-#else
-void fetch_msvc(BuildOptions *options)
-{
-	error_exit("Failed to find Windows SDK.\n"
-			   "Windows applications cannot be cross-compiled without it.\n"
-			   "This build of c3c lacks cURL support and cannot download the SDK automatically.\n"
-			   "Please provide the SDK path manually using --winsdk.");
-}
-#endif
+
 

--- a/src/utils/lib.h
+++ b/src/utils/lib.h
@@ -12,9 +12,8 @@
 #include "intrin.h"
 #endif
 
-#if FETCH_AVAILABLE
 const char *download_file(const char *url, const char *resource, const char *file_path);
-#endif
+bool download_available(void);
 
 #define ELEMENTLEN(x) (sizeof(x) / sizeof(x[0]))
 extern const char *compiler_exe_name;


### PR DESCRIPTION
- Uses `dlopen` to load libcurl at runtime for better portability.
- Replaces the FETCH_AVAILABLE macro with download_available() check.
- Provides descriptive error messages when libcurl is missing.