### PR TITLE
fix #2906: auto-fallback to built-in linker

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -5,6 +5,7 @@
 ### Changes / improvements
 - Removed support for LLVM 17, 18.
 - Detect large temporaries when creating slices on the stack #2665
+- Search for the linker in PATH; use the builtin linker if CC missing. #2906
 
 ### Stdlib changes
 - Add contract on `any_to_enum_ordinal` and `any_to_int` to improve error when passed an empty any. #2977

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -737,7 +737,7 @@ void compiler_compile(void)
 				if (!system_linker_available)
 				{
 					const char *cc = compiler.build.cc ? compiler.build.cc : default_c_compiler();
-					eprintf("The C compiler '%s' was not found or system linker is not supported, defaulting to built-in linker\n", cc);
+					OUTF("C compiler '%s' not found or system linker is unsupported; using built-in linker instead.\n", cc);
 					compiler.build.linker_type = LINKER_TYPE_BUILTIN;
 					use_system_linker = false;
 					break;

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -1051,7 +1051,6 @@ static bool link_exe(const char *output_file, const char **files_to_link, unsign
 		error_exit("Failed to create an executable: %s", error);
 	}
 	INFO_LOG("Linking complete.");
-	OUTF("Program linked to executable '%s'.\n", output_file);
 	return true;
 }
 

--- a/src/utils/file_utils.c
+++ b/src/utils/file_utils.c
@@ -11,6 +11,12 @@
 #include <windows.h>
 #endif
 
+#if PLATFORM_WINDOWS
+#define PATH_SEPARATOR '\\'
+#else
+#define PATH_SEPARATOR '/'
+#endif
+
 #ifndef _MSC_VER
 #include <dirent.h>
 #include <unistd.h>
@@ -632,16 +638,11 @@ const char *file_append_path_temp(const char *path, const char *name)
 		error_exit("Error generating path from %s and %s: buffer max size exceeded.", path, name);
 	}
 
-#if PLATFORM_WINDOWS
-	char separator = '\\';
-#else
-	char separator = '/';
-#endif
 
 	// format the string safely
-	bool insert_separator = path[path_len - 1] != '/' && path[path_len - 1] != separator;
+	bool insert_separator = path[path_len - 1] != '/' && path[path_len - 1] != PATH_SEPARATOR;
 	int written = insert_separator
-		              ? snprintf(path_buffer, PATH_BUFFER_SIZE, "%s%c%s", path, separator, name)
+		              ? snprintf(path_buffer, PATH_BUFFER_SIZE, "%s%c%s", path, PATH_SEPARATOR, name)
 		              : snprintf(path_buffer, PATH_BUFFER_SIZE, "%s%s", path, name);
 
 	// check if truncation occurred


### PR DESCRIPTION
- Search linker in PATH
- Use builtin linker if CC missing

https://github.com/c3lang/c3c/issues/2906