### PR TITLE
fix(ps-install): ensure c3-windows-release folder exists before renaming

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -124,6 +124,7 @@ if ($Env:C3_REPOURL) { $C3Repourl = $Env:C3_REPOURL -replace '/$', '' }
 
 # Set binary name
 $BINARY = "c3-windows"
+$BINARY_DIR = "c3"
 
 # Determine the download URL based on version
 if ($C3Version -eq 'latest') {
@@ -160,7 +161,9 @@ try {
     Expand-Archive -Path $ZIP_FILE -DestinationPath $Env:USERPROFILE -Force
 
     # Rename extracted folder to target installation directory
-    Rename-Item -Path "$Env:USERPROFILE/c3-windows-Release" -NewName $BinDir
+    if (Test-Path -Path "$Env:USERPROFILE/$BINARY_DIR") {
+        Rename-Item -Path "$Env:USERPROFILE/$BINARY_DIR" -NewName $BinDir
+    }
 } catch {
     Write-Host "Error: '$DOWNLOAD_URL' is not available or failed to download"
     exit 1


### PR DESCRIPTION
```
PS C:\Users\vivaperon> iwr -useb https://raw.githubusercontent.com/c3lang/c3c/refs/heads/master/install/install.ps1 | iex

This script will automatically download and install C3 (latest) for you.
Getting it from this url: https://github.com/c3lang/c3c/releases/latest/download/c3-windows.zip
The binary will be installed into 'C:\Users\vivaperon\.c3'
Rename-Item : Cannot rename because item at 'C:\Users\vivaperon/c3-windows-Release' does not exist.
At line:163 char:5
+     Rename-Item -Path "$Env:USERPROFILE/c3-windows-Release" -NewName  ...
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Rename-Item], PSInvalidOperationException
    + FullyQualifiedErrorId : InvalidOperation,Microsoft.PowerShell.Commands.RenameItemCommand
```