### PR TITLE
Bump Docker build to use LLVM 22

### DIFF
--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -3,7 +3,7 @@
 : ${DOCKER:=docker}
 : ${IMAGE:="c3c-builder"}
 : ${CMAKE_BUILD_TYPE:=Release}
-: ${LLVM_VERSION:=18}
+: ${LLVM_VERSION:=22}
 : ${UBUNTU_VERSION:="22.04"}
 : ${CMAKE_VERSION:="3.20.0"}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG UBUNTU_VERSION=22.04
 FROM ubuntu:${UBUNTU_VERSION}
 
-ARG LLVM_VERSION=18
+ARG LLVM_VERSION=22
 ARG CMAKE_VERSION=3.20.0
 
 # Prevent interactive prompts during apt install


### PR DESCRIPTION
I often use this convenient script with fresh pulls of the repository on a development VPS. The build process requires LLVM 19-23, so I figured bumping to the second-to-most-recent version would be best.