### PR TITLE
Fix bitset doc comments

### DIFF
--- a/lib/std/collections/bitset.c3
+++ b/lib/std/collections/bitset.c3
@@ -186,7 +186,7 @@ struct GrowableBitSet
 
 <*
  @param initial_capacity
- @param [&inout] allocator : "The allocator to use, defaults to the heap allocator"
+ @param [&inout] allocator : "The allocator to use"
 *>
 fn GrowableBitSet* GrowableBitSet.init(&self, Allocator allocator, usz initial_capacity = 1)
 {

--- a/lib/std/collections/linkedlist.c3
+++ b/lib/std/collections/linkedlist.c3
@@ -45,7 +45,7 @@ macro LinkedList @tnew(Type[] #default_values = {})
 }
 
 <*
- @param [&inout] allocator : "The allocator to use, defaults to the heap allocator"
+ @param [&inout] allocator : "The allocator to use"
  @return "the initialized list"
 *>
 fn LinkedList* LinkedList.init(&self, Allocator allocator)

--- a/lib/std/collections/list.c3
+++ b/lib/std/collections/list.c3
@@ -25,7 +25,7 @@ struct List (Printable)
 
 <*
  @param initial_capacity : "The initial capacity to reserve"
- @param [&inout] allocator : "The allocator to use, defaults to the heap allocator"
+ @param [&inout] allocator : "The allocator to use"
 *>
 fn List* List.init(&self, Allocator allocator, usz initial_capacity = 16)
 {

--- a/lib/std/core/array.c3
+++ b/lib/std/core/array.c3
@@ -84,7 +84,7 @@ macro usz? rindex_of(array, element)
 
  @param [in] arr1
  @param [in] arr2
- @param [&inout] allocator : "The allocator to use, default is the heap allocator"
+ @param [&inout] allocator : "The allocator to use"
  @require $kindof(arr1) == SLICE || $kindof(arr1) == ARRAY
  @require $kindof(arr2) == SLICE || $kindof(arr2) == ARRAY
  @require @typematch(arr1[0], arr2[0]) : "Arrays must have the same type"
@@ -444,7 +444,7 @@ macro unlace(Allocator allocator, array, left, right)
  where the `left` array is the shorter iterable, will put 7 into that lambda in each place
  where `left` is being filled in during the zip operation.
 
- @param [&inout] allocator : "The allocator to use; default is the heap allocator."
+ @param [&inout] allocator : "The allocator to use."
  @param [in] left : "The left-side array. These items will be placed as the First in each Pair"
  @param [in] right : "The right-side array. These items will be placed as the Second in each Pair"
  @param #operation : "The function to apply. Must have a signature of `$typeof(a) (a, b)`, where the type of 'a' and 'b' is the element type of left/right respectively."


### PR DESCRIPTION
Fixes doc comments for the bitwise operations of Bitset.

There is also: https://github.com/c3lang/c3c/blob/master/lib/std/collections/bitset.c3#L189
which has the line `defaults to the heap allocator` while there is no default value for that variable.
Should that be changed as well?