### PR TITLE
add time_emscripten.c3, clock::now() fails without it

### DIFF
--- a/lib/std/time/os/time_emscripten.c3
+++ b/lib/std/time/os/time_emscripten.c3
@@ -1,0 +1,13 @@
+module std::time::os @if(env::WASM && !env::WASI);
+
+extern fn double emscripten_get_now() @callconv("cdecl");
+
+fn Time native_timestamp()
+{
+	return (Time)(emscripten_get_now() * 1_000.0);
+}
+
+fn Clock native_clock()
+{
+	return (Clock)(emscripten_get_now() * 1_000_000.0);
+}


### PR DESCRIPTION
clock::now() and everything that uses fails in emscripten without this.