### PR TITLE
Add Fedora COPR installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,15 @@ cd c3c-git
 makepkg -si
 ```
 
+#### Installing on Fedora
+
+C3 is available as a community maintained COPR package for Fedora.  
+To install via dnf:
+```sh
+sudo dnf copr enable sisyphus1813/c3
+sudo dnf install c3
+```
+
 #### Installing via Nix
 
 You can access `c3c` via [flake.nix](./flake.nix), which will contain the latest commit of the compiler. To add `c3c` to your `flake.nix`, do the following:


### PR DESCRIPTION
Hey! I've created a COPR repository for the compiler, so this PR adds documentation to reference that in the installation section.

For transparency, the RPM files can be found [here](https://github.com/Sisyphus1813/c3-rpm).
And the COPR repository in question is located [here](https://copr.fedorainfracloud.org/coprs/sisyphus1813/c3)

Please let me know if there is any issue or if you would like something changed. Thanks!