### PR TITLE
Fix segmentation fault when exporting headers with no explicit name

### DIFF
--- a/src/compiler/headers.c
+++ b/src/compiler/headers.c
@@ -278,7 +278,7 @@ static void header_gen_function(HeaderContext *c, Decl *decl, bool print_fn, boo
 {
 	if (!decl->is_export) return;
 	const char *ext_name = decl_get_extname(decl);
-	if (ext_name[0] == '_' && ext_name[1] == '_') return;
+	if (!ext_name || (ext_name[0] == '_' && ext_name[1] == '_')) return;
 	if (print_fn && !*fn_found)
 	{
 		*fn_found = true;


### PR DESCRIPTION
This PR fixes issue #1368 - Segmentation fault on library project build when exporting headers.

The problem occurs when building a template project with an export that has no explicit name (i.e.,  without providing a name). The code was accessing  and  without first checking if  is NULL, causing a segmentation fault.

The fix adds a null check before accessing the array elements:


This ensures that if  returns NULL for any reason, we safely return early instead of dereferencing a null pointer.