### PR TITLE
CI: update actions and migrate release job to `ncipollo/release-action`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         run: ./scripts/tools/package_build.sh "./build/c3c.exe" "c3-windows-${{ matrix.build_type }}" "zip"
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: c3-windows-${{ matrix.build_type }}
           path: c3-windows-${{ matrix.build_type }}.zip
@@ -141,7 +141,7 @@ jobs:
       - name: Bundle & Upload (Linux)
         run: |
           bash ./scripts/tools/package_build.sh "./build/c3c" "c3-linux-${{matrix.build_type}}" "tar"
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: c3-linux-${{matrix.build_type}}
           path: c3-linux-${{matrix.build_type}}.tar.gz
@@ -192,7 +192,7 @@ jobs:
       - name: Bundle
         run: bash ./scripts/tools/package_build.sh "./build/c3c" "c3-linux-static-${{ matrix.build_type }}" "tar"
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: c3-linux-static-${{ matrix.build_type }}
           path: c3-linux-static-${{ matrix.build_type }}.tar.gz
@@ -257,7 +257,7 @@ jobs:
         run: ./scripts/tools/ci_tests.sh "./build/c3c"
       - name: Bundle & Upload (Alpine)
         run: bash ./scripts/tools/package_build.sh "./build/c3c" "c3-linux-musl-${{ matrix.build_type }}" "tar"
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: c3-linux-musl-${{ matrix.build_type }}
           path: c3-linux-musl-${{ matrix.build_type }}.tar.gz
@@ -284,7 +284,7 @@ jobs:
 
       - name: Bundle & Upload (Mac)
         run: bash ./scripts/tools/package_build.sh "./build/c3c" "c3-macos-${{matrix.build_type}}" "zip"
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: c3-macos-${{matrix.build_type}}
           path: c3-macos-${{matrix.build_type}}.zip
@@ -342,7 +342,7 @@ jobs:
             cp build/c3c "$GITHUB_WORKSPACE"/build/
             cp *.tar.gz "$GITHUB_WORKSPACE"/
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: c3-openbsd-${{matrix.build_type}}
           path: c3-openbsd-${{matrix.build_type}}.tar.gz
@@ -410,7 +410,7 @@ jobs:
             cp build/c3c "$GITHUB_WORKSPACE"/build/
             cp *.tar.gz "$GITHUB_WORKSPACE"/
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: c3-netbsd-${{matrix.build_type}}
           path: c3-netbsd-${{matrix.build_type}}.tar.gz
@@ -575,72 +575,52 @@ jobs:
           ./scripts/tools/package_build.sh "./build/c3c" "c3-android-${{matrix.architecture}}-${{matrix.build_type}}" "tar"
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: c3-android-${{matrix.architecture}}-${{matrix.build_type}}
           path: c3-android-${{matrix.architecture}}-${{matrix.build_type}}.tar.gz
 
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     needs: [build-msvc, build-linux, build-mac, build-linux-alpine, build-openbsd, build-netbsd, build-android, build-linux-musl-static]
     if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
 
       - name: Prepare Assets
         run: |
-          # --- Release Assets ---
-          mv c3-windows-Release/c3-windows-Release.zip c3-windows.zip
-          mv c3-macos-Release/c3-macos-Release.zip c3-macos.zip
+          for config in Release Debug; do
+            for platform in windows macos linux linux-musl linux-static openbsd netbsd android-aarch64 android-x86_64; do
+              # Windows and macOS produce zip, others tar.gz
+              if [ "$platform" = "windows" ] || [ "$platform" = "macos" ]; then
+                ext="zip"
+              else
+                ext="tar.gz"
+              fi
 
-          mv c3-linux-Release/c3-linux-Release.tar.gz c3-linux.tar.gz
-          mv c3-linux-musl-Release/c3-linux-musl-Release.tar.gz c3-linux-musl.tar.gz
-          mv c3-linux-static-Release/c3-linux-static-Release.tar.gz c3-linux-static.tar.gz
-          mv c3-openbsd-Release/c3-openbsd-Release.tar.gz c3-openbsd.tar.gz || true
-          mv c3-netbsd-Release/c3-netbsd-Release.tar.gz c3-netbsd.tar.gz || true
-          mv c3-android-aarch64-Release/c3-android-aarch64-Release.tar.gz c3-android-aarch64.tar.gz
-          mv c3-android-x86_64-Release/c3-android-x86_64-Release.tar.gz c3-android-x86_64.tar.gz
+              src="c3-${platform}-${config}/c3-${platform}-${config}.${ext}"
+              dst="c3-${platform}"
+              [ "$config" = "Debug" ] && dst="${dst}-debug"
+              dst="${dst}.${ext}"
 
-          # --- Debug Assets ---
-          mv c3-windows-Debug/c3-windows-Debug.zip c3-windows-debug.zip
-          mv c3-macos-Debug/c3-macos-Debug.zip c3-macos-debug.zip
+              mv "$src" "$dst" || true
+            done
+          done
 
-          mv c3-linux-Debug/c3-linux-Debug.tar.gz c3-linux-debug.tar.gz
-          mv c3-linux-musl-Debug/c3-linux-musl-Debug.tar.gz c3-linux-musl-debug.tar.gz
-          mv c3-linux-static-Debug/c3-linux-static-Debug.tar.gz c3-linux-static-debug.tar.gz
-          mv c3-openbsd-Debug/c3-openbsd-Debug.tar.gz c3-openbsd-debug.tar.gz || true
-          mv c3-netbsd-Debug/c3-netbsd-Debug.tar.gz c3-netbsd-debug.tar.gz || true
-          mv c3-android-aarch64-Debug/c3-android-aarch64-Debug.tar.gz c3-android-aarch64-debug.tar.gz
-          mv c3-android-x86_64-Debug/c3-android-x86_64-Debug.tar.gz c3-android-x86_64-debug.tar.gz
-
-      - run: gh release delete latest-prerelease-tag --cleanup-tag -y || true
+      # - run: gh release delete latest-prerelease-tag --cleanup-tag -y || true
       - run: echo "RELEASE_NAME=latest-prerelease-$(date +'%Y%m%d-%H%M')" >> $GITHUB_ENV
 
-      - uses: softprops/action-gh-release@v2
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: latest-prerelease-tag
+          tag: latest-prerelease-tag
           name: ${{ env.RELEASE_NAME }}
           prerelease: true
-          files: |
-            c3-windows.zip
-            c3-macos.zip
-            c3-linux.tar.gz
-            c3-linux-musl.tar.gz
-            c3-linux-static.tar.gz
-            c3-openbsd.tar.gz
-            c3-netbsd.tar.gz
-            c3-android-aarch64.tar.gz
-            c3-android-x86_64.tar.gz
-            # --- Debug Artifacts ---
-            c3-windows-debug.zip
-            c3-macos-debug.zip
-            c3-linux-debug.tar.gz
-            c3-linux-musl-debug.tar.gz
-            c3-linux-static-debug.tar.gz
-            c3-openbsd-debug.tar.gz
-            c3-netbsd-debug.tar.gz
-            c3-android-aarch64-debug.tar.gz
-            c3-android-x86_64-debug.tar.gz
+          allowUpdates: true
+          removeArtifacts: true
+          artifacts: "*.zip,*.tar.gz"


### PR DESCRIPTION
Sometimes latest-prerelease-tag was not publishing the artifacts so I migrated the action to use `ncipollo/release-action`

Like right now, we don't have artifacts in https://github.com/c3lang/c3c/releases/tag/latest-prerelease-tag