### PR TITLE
fix(build): fix directory checking in project-based commands

### DIFF
--- a/src/build/build.h
+++ b/src/build/build.h
@@ -213,7 +213,6 @@ typedef struct BuildOptions_
 	bool test_noleak;
 	bool test_show_output;
 	bool benchmark_csv_report;
-	bool defer_dir_checking;
 	bool print_large_functions;
 	const char *custom_linker_path;
 	uint32_t symtab_size;
@@ -302,6 +301,7 @@ typedef struct BuildOptions_
 	uint32_t max_stack_object_size;
 	const char *cpu_flags;
 	uint32_t max_macro_iterations;
+	bool is_project;
 	bool print_keywords;
 	bool print_attributes;
 	bool print_builtins;

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -511,7 +511,6 @@ static void parse_command(BuildOptions *options)
 	if (arg_match("build"))
 	{
 		options->command = COMMAND_BUILD;
-		options->defer_dir_checking = true;
 		parse_optional_target(options);
 		return;
 	}
@@ -519,21 +518,18 @@ static void parse_command(BuildOptions *options)
 	{
 		options->command = COMMAND_BENCHMARK;
 		options->benchmarking = true;
-		options->defer_dir_checking = true;
 		return;
 	}
 	if (arg_match("test"))
 	{
 		options->command = COMMAND_TEST;
 		options->testing = true;
-		options->defer_dir_checking = true;
 		parse_optional_target(options);
 		return;
 	}
 	if (arg_match("run"))
 	{
 		options->command = COMMAND_RUN;
-		options->defer_dir_checking = true;
 		parse_optional_target(options);
 		return;
 	}
@@ -545,7 +541,6 @@ static void parse_command(BuildOptions *options)
 	if (arg_match("clean-run"))
 	{
 		options->command = COMMAND_CLEAN_RUN;
-		options->defer_dir_checking = true;
 		parse_optional_target(options);
 		return;
 	}
@@ -557,14 +552,12 @@ static void parse_command(BuildOptions *options)
 	if (arg_match("dist"))
 	{
 		options->command = COMMAND_CLEAN_RUN;
-		options->defer_dir_checking = true;
 		parse_optional_target(options);
 		return;
 	}
 	if (arg_match("bench"))
 	{
 		options->command = COMMAND_BENCH;
-		options->defer_dir_checking = true;
 		parse_optional_target(options);
 		return;
 	}
@@ -1787,6 +1780,35 @@ BuildOptions parse_arguments(int argc, const char *argv[])
 			continue;
 		}
 		FAIL_WITH_ERR("Found the unexpected argument \"%s\".", current_arg);
+	}
+	switch (build_options.command)
+	{
+		case COMMAND_BUILD:
+		case COMMAND_RUN:
+		case COMMAND_CLEAN_RUN:
+		case COMMAND_CLEAN:
+		case COMMAND_DIST:
+		case COMMAND_BENCH:
+		case COMMAND_BENCHMARK:
+		case COMMAND_TEST:
+			build_options.is_project = true;
+			break;
+		case COMMAND_MISSING:
+		case COMMAND_COMPILE:
+		case COMMAND_COMPILE_ONLY:
+		case COMMAND_COMPILE_BENCHMARK:
+		case COMMAND_COMPILE_TEST:
+		case COMMAND_INIT:
+		case COMMAND_INIT_LIB:
+		case COMMAND_COMPILE_RUN:
+		case COMMAND_STATIC_LIB:
+		case COMMAND_DYNAMIC_LIB:
+		case COMMAND_VENDOR_FETCH:
+		case COMMAND_UNIT_TEST:
+		case COMMAND_PRINT_SYNTAX:
+		case COMMAND_PROJECT:
+		case COMMAND_FETCH_SDK:
+			break;
 	}
 	if (build_options.command == COMMAND_MISSING)
 	{

--- a/src/build/builder.c
+++ b/src/build/builder.c
@@ -777,7 +777,8 @@ void init_build_target(BuildTarget *target, BuildOptions *options)
 	const char *filename;
 	Project *project = project_load(&filename);
 	
-	if (options->defer_dir_checking) {
+	if (options->is_project)
+	{
 		FOREACH(const char *, dir, options->unchecked_directories)
 		{
 			(void)check_dir(dir);

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -53,7 +53,8 @@ void compiler_init(BuildOptions *build_options)
 		error_exit("Failed to change path to '%s'.", build_options->path);
 	}
 
-	if (!build_options->defer_dir_checking) {
+	if (!build_options->is_project)
+	{
 		FOREACH(const char *, dir, build_options->unchecked_directories)
 		{
 			(void)check_dir(dir);
@@ -156,7 +157,7 @@ void thread_compile_task_llvm(void *compile_data)
 #else 
 void thread_compile_task_llvm(void *compile_data)
 {
-    error_exit("LLVM backend not available.");
+	error_exit("LLVM backend not available.");
 }
 #endif 
 
@@ -296,7 +297,7 @@ static void free_arenas(void)
 }
 
 static int compile_cfiles(const char *cc, const char **files, const char *flags, const char **include_dirs,
-                          const char **out_files, const char *output_subdir)
+						  const char **out_files, const char *output_subdir)
 {
 	if (!cc) cc = default_c_compiler();
 	int total = 0;
@@ -549,9 +550,9 @@ void compiler_compile(void)
 			gen_contexts = llvm_gen(modules, module_count);
 			task = &thread_compile_task_llvm;
 #else 
-            error_exit("C3C compiled without LLVM!");
+			error_exit("C3C compiled without LLVM!");
 #endif
-            break;
+			break;
 		case BACKEND_TB:
 			gen_contexts = tilde_gen(modules, module_count);
 			task = &thread_compile_task_tb;
@@ -645,7 +646,7 @@ void compiler_compile(void)
 	if (cfiles)
 	{
 		int compiled = compile_cfiles(compiler.build.cc, compiler.build.csources,
-		                              compiler.build.cflags, compiler.build.cinclude_dirs, &obj_files[output_file_count], "tmp_c_compile");
+									  compiler.build.cflags, compiler.build.cinclude_dirs, &obj_files[output_file_count], "tmp_c_compile");
 		ASSERT(cfiles == compiled);
 		(void)compiled;
 	}
@@ -653,7 +654,7 @@ void compiler_compile(void)
 	FOREACH(LibraryTarget *, lib, compiler.build.ccompiling_libraries)
 	{
 		obj_file_next += compile_cfiles(lib->cc ? lib->cc : compiler.build.cc, lib->csources,
-		                                lib->cflags, lib->cinclude_dirs, obj_file_next, lib->parent->provides);
+										lib->cflags, lib->cinclude_dirs, obj_file_next, lib->parent->provides);
 	}
 	for (unsigned i = 0; i < external_objfile_count; i++)
 	{
@@ -1292,7 +1293,7 @@ void execute_scripts(void)
 		StringSlice call = slice_next_token(&execs, ' ');
 		File *script;
 		if (call.len < 3 || call.ptr[call.len - 3] != '.' || call.ptr[call.len - 2] != 'c' ||
-		    call.ptr[call.len - 1] != '3')
+			call.ptr[call.len - 1] != '3')
 		{
 			char *res = execute_cmd(exec, false, NULL, 0);
 			if (compiler.build.silent) continue;
@@ -1548,15 +1549,15 @@ void compile()
 	setup_bool_define("PANIC_MSG", compiler.build.feature.panic_level != PANIC_OFF);
 	setup_bool_define("BACKTRACE", compiler.build.show_backtrace != SHOW_BACKTRACE_OFF);
 #if LLVM_AVAILABLE
-    setup_int_define("LLVM_VERSION", llvm_version_major, type_int);
+	setup_int_define("LLVM_VERSION", llvm_version_major, type_int);
 #else 
-    setup_int_define("LLVM_VERSION", 0, type_int);
+	setup_int_define("LLVM_VERSION", 0, type_int);
 #endif
 
 	setup_string_define("VERSION", COMPILER_VERSION);
 	setup_bool_define("PRERELEASE", PRERELEASE);
 
-    setup_bool_define("BENCHMARKING", compiler.build.benchmarking);
+	setup_bool_define("BENCHMARKING", compiler.build.benchmarking);
 	setup_int_define("JMP_BUF_SIZE", jump_buffer_size(), type_int);
 	setup_bool_define("TESTING", compiler.build.testing);
 	setup_int_define("LANGUAGE_DEV_VERSION", 7, type_int);
@@ -1705,7 +1706,7 @@ const char *scratch_buffer_interned(void)
 const char *scratch_buffer_interned_as(TokenType* type)
 {
 	return symtab_add(scratch_buffer.str, scratch_buffer.len,
-	                  fnv1a(scratch_buffer.str, scratch_buffer.len), type);
+					  fnv1a(scratch_buffer.str, scratch_buffer.len), type);
 }
 
 void scratch_buffer_append_native_safe_path(const char *data, int len)


### PR DESCRIPTION
- Introduced a BuildOptions field to indicate commands that need deferring
- Moved project based commands dir checking to after the cwd is set as project root

closes #2980