### PR TITLE
fix #3030

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -523,10 +523,13 @@ void compiler_compile(void)
 				   "- If you just want to output object files for later linking, use 'compile-only'.");
 	}
 
-	if (compiler.build.type == TARGET_TYPE_STATIC_LIB)
-	{
-		compiler.build.single_module = SINGLE_MODULE_ON;
-	}
+	// Note: We intentionally do NOT force SINGLE_MODULE_ON for static libs here.
+	// Doing so merges all compile units into one, which breaks GNU addr2line's ability
+	// to resolve source locations from DWARF debug info in the resulting archive.
+	// if (compiler.build.type == TARGET_TYPE_STATIC_LIB)
+	// {
+	// 	compiler.build.single_module = SINGLE_MODULE_ON;
+	// }
 	if (compiler.build.emit_asm)
 	{
 		scratch_buffer_clear();


### PR DESCRIPTION
static-lib is unconditionally forcing `--single-module` on [`src/compiler/compiler.c:526`](https://github.com/c3lang/c3c/blob/master/src/compiler/compiler.c#L526), which merges all compile units into one and loses per-file source location info. Removing that "override" fixes GNU addr2line.

I don't know the implications on removing the **force single-module on static-lib** but this fixes the issue https://github.com/c3lang/c3c/issues/3030. This was introduced in https://github.com/c3lang/c3c/commit/5d026268a75c82d652f5fae7bd5c53714d132e47