### PR TITLE
Add stdlib::regex module - regular expression engine for C3

### DIFF
--- a/benchmarks/stdlib/regex/regex.c3
+++ b/benchmarks/stdlib/regex/regex.c3
@@ -1,0 +1,306 @@
+module regex_benchmarks;
+
+import std::regex;
+import std::io;
+
+
+const DEFAULT_ITERATIONS = 50_000;
+
+// A moderately long input string used across several benchmarks.
+const String HAYSTACK = "The quick brown fox jumps over the lazy dog. "
+    "Pack my box with five dozen liquor jugs. "
+    "How vexingly quick daft zebras jump! "
+    "The five boxing wizards jump quickly. "
+    "Sphinx of black quartz, judge my vow.";
+const String EMAIL_INPUT = "Contact us at support@example.com for help.";
+const String BACKREF_HIT = "hello hello";
+const String BACKREF_MISS = "hello world";
+const String BACKREF_FIND_INPUT = "IDs: 42-42 and 71-19";
+const String CONDITIONAL_HIT = "3xdigit";
+const String CONDITIONAL_MISS = "3xother";
+const String GPOS_INPUT = "12345678x";
+
+Regex* re_literal;
+Regex* re_charclass;
+Regex* re_quantifiers;
+Regex* re_alternation;
+Regex* re_groups;
+Regex* re_anchors;
+Regex* re_complex;
+Regex* re_bt_backref;
+Regex* re_bt_atomic;
+Regex* re_bt_conditional;
+Regex* re_bt_find_backref;
+Regex* re_bt_gpos;
+
+fn void bench_setup() @init
+{
+    set_benchmark_warmup_iterations(3);
+    set_benchmark_max_iterations(DEFAULT_ITERATIONS);
+
+    set_benchmark_func_iterations($qnameof(compile_literal),       200_000);
+    set_benchmark_func_iterations($qnameof(compile_charclass),     100_000);
+    set_benchmark_func_iterations($qnameof(compile_quantifiers),   100_000);
+    set_benchmark_func_iterations($qnameof(compile_alternation),    80_000);
+    set_benchmark_func_iterations($qnameof(compile_groups),         80_000);
+    set_benchmark_func_iterations($qnameof(compile_complex),        20_000);
+    set_benchmark_func_iterations($qnameof(compile_bt_backref),     80_000);
+    set_benchmark_func_iterations($qnameof(compile_bt_atomic),      80_000);
+    set_benchmark_func_iterations($qnameof(compile_bt_conditional), 60_000);
+
+    set_benchmark_func_iterations($qnameof(is_match_literal_hit),  200_000);
+    set_benchmark_func_iterations($qnameof(is_match_literal_miss), 200_000);
+    set_benchmark_func_iterations($qnameof(is_match_charclass),    100_000);
+    set_benchmark_func_iterations($qnameof(is_match_quantifiers),  100_000);
+    set_benchmark_func_iterations($qnameof(is_match_alternation),  100_000);
+    set_benchmark_func_iterations($qnameof(is_match_groups),       100_000);
+    set_benchmark_func_iterations($qnameof(is_match_anchors),      100_000);
+    set_benchmark_func_iterations($qnameof(is_match_complex),       20_000);
+    set_benchmark_func_iterations($qnameof(is_match_bt_backref_hit),  80_000);
+    set_benchmark_func_iterations($qnameof(is_match_bt_backref_miss), 80_000);
+    set_benchmark_func_iterations($qnameof(is_match_bt_atomic),       80_000);
+    set_benchmark_func_iterations($qnameof(is_match_bt_conditional),  60_000);
+
+    set_benchmark_func_iterations($qnameof(find_short_input),      100_000);
+    set_benchmark_func_iterations($qnameof(find_long_input),        50_000);
+    set_benchmark_func_iterations($qnameof(find_all_words),         20_000);
+    set_benchmark_func_iterations($qnameof(find_bt_backref),        80_000);
+    set_benchmark_func_iterations($qnameof(find_all_bt_gpos),       40_000);
+
+    set_benchmark_func_iterations($qnameof(replace_literal),        50_000);
+    set_benchmark_func_iterations($qnameof(replace_all_words),      10_000);
+
+    re_literal     = regex::compile(mem, "fox")!!;
+    re_charclass   = regex::compile(mem, "[a-z]+")!!;
+    re_quantifiers = regex::compile(mem, "\\w{3,8}")!!;
+    re_alternation = regex::compile(mem, "fox|dog|cat|rat|owl")!!;
+    re_groups      = regex::compile(mem, "(quick)(\\s+)(brown)")!!;
+    re_anchors     = regex::compile(mem, "^The")!!;
+    re_complex     = regex::compile(mem, `[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)!!;
+    re_bt_backref     = regex::compile(mem, "(\\w+) \\1")!!;
+    re_bt_atomic      = regex::compile(mem, "(?>a|ab)c")!!;
+    re_bt_conditional = regex::compile(mem, "^(\\d)?x(?(1)digit|other)$")!!;
+    re_bt_find_backref = regex::compile(mem, "(\\d+)-\\1")!!;
+    re_bt_gpos        = regex::compile(mem, "\\G\\d{2}")!!;
+}
+
+fn void bench_teardown() @finalizer
+{
+    re_literal.free();
+    re_charclass.free();
+    re_quantifiers.free();
+    re_alternation.free();
+    re_groups.free();
+    re_anchors.free();
+    re_complex.free();
+    re_bt_backref.free();
+    re_bt_atomic.free();
+    re_bt_conditional.free();
+    re_bt_find_backref.free();
+    re_bt_gpos.free();
+}
+
+
+// ==============================================================================================
+module regex_benchmarks @benchmark;
+
+import std::regex;
+
+
+// ----- Compilation benchmarks ---------------------------------------------------------------
+// These measure parse + NFA-build cost for patterns of increasing complexity.
+
+fn void compile_literal() => @pool()
+{
+    Regex* re = regex::tcompile("hello");
+    re.free();
+}
+
+fn void compile_charclass() => @pool()
+{
+    Regex* re = regex::tcompile("[a-zA-Z0-9_]+");
+    re.free();
+}
+
+fn void compile_quantifiers() => @pool()
+{
+    Regex* re = regex::tcompile("a{2,5}b*c+d?");
+    re.free();
+}
+
+fn void compile_alternation() => @pool()
+{
+    Regex* re = regex::tcompile("foo|bar|baz|qux|quux");
+    re.free();
+}
+
+fn void compile_groups() => @pool()
+{
+    Regex* re = regex::tcompile("(foo)(bar)(baz)");
+    re.free();
+}
+
+fn void compile_complex() => @pool()
+{
+    // Simulate a realistic pattern: simple email-ish validator
+    Regex* re = regex::tcompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`);
+    re.free();
+}
+
+fn void compile_bt_backref() => @pool()
+{
+    Regex* re = regex::tcompile("(\\w+) \\1");
+    re.free();
+}
+
+fn void compile_bt_atomic() => @pool()
+{
+    Regex* re = regex::tcompile("(?>a|ab)c");
+    re.free();
+}
+
+fn void compile_bt_conditional() => @pool()
+{
+    Regex* re = regex::tcompile("^(\\d)?x(?(1)digit|other)$");
+    re.free();
+}
+
+
+// ----- is_match benchmarks ------------------------------------------------------------------
+// Pre-compiled regexes (set up in bench_setup); only measure the matching engine.
+
+fn void is_match_literal_hit()
+{
+    assert(re_literal.is_match("The quick brown fox jumps over the lazy dog."));
+}
+
+fn void is_match_literal_miss()
+{
+    assert(!re_literal.is_match("No match here at all."));
+}
+
+fn void is_match_charclass()
+{
+    assert(re_charclass.is_match(HAYSTACK));
+}
+
+fn void is_match_quantifiers()
+{
+    assert(re_quantifiers.is_match(HAYSTACK));
+}
+
+fn void is_match_alternation()
+{
+    assert(re_alternation.is_match(HAYSTACK));
+}
+
+fn void is_match_groups()
+{
+    assert(re_groups.is_match(HAYSTACK));
+}
+
+fn void is_match_anchors()
+{
+    assert(re_anchors.is_match(HAYSTACK));
+}
+
+fn void is_match_complex()
+{
+    assert(!re_complex.is_match(HAYSTACK));
+    assert(re_complex.is_match(EMAIL_INPUT));
+}
+
+
+// ----- Backtracking-only is_match benchmarks -------------------------------------------------
+// These patterns force the dedicated backtracking engine via backrefs, atomics, or conditionals.
+
+fn void is_match_bt_backref_hit()
+{
+    assert(re_bt_backref.is_match(BACKREF_HIT));
+}
+
+fn void is_match_bt_backref_miss()
+{
+    assert(!re_bt_backref.is_match(BACKREF_MISS));
+}
+
+fn void is_match_bt_atomic()
+{
+    assert(!re_bt_atomic.is_match("abc"));
+    assert(re_bt_atomic.is_match("ac"));
+}
+
+fn void is_match_bt_conditional()
+{
+    assert(re_bt_conditional.is_match(CONDITIONAL_HIT));
+    assert(!re_bt_conditional.is_match(CONDITIONAL_MISS));
+}
+
+
+// ----- find / find_all benchmarks -----------------------------------------------------------
+
+fn void find_short_input() => @pool()
+{
+    Regex* re = regex::tcompile("\\b\\w{5}\\b");
+    Match m = re.find(tmem, "The quick brown fox")!!;
+    defer m.free();
+}
+
+fn void find_long_input() => @pool()
+{
+    Match m = re_alternation.find(tmem, HAYSTACK)!!;
+    defer m.free();
+    assert(m.full() == "fox" || m.full() == "dog");
+}
+
+fn void find_all_words() => @pool()
+{
+    Regex* re = regex::tcompile("\\b[A-Z][a-z]+\\b");
+    MatchIter it = re.find_all(tmem, HAYSTACK);
+    usz count;
+    while (try m = it.next())
+    {
+        defer m.free();
+        count++;
+    }
+    assert(count > 0);
+}
+
+
+// ----- Backtracking-only find benchmarks -----------------------------------------------------
+
+fn void find_bt_backref() => @pool()
+{
+    Match m = re_bt_find_backref.find(tmem, BACKREF_FIND_INPUT)!!;
+    defer m.free();
+    assert(m.full() == "42-42");
+}
+
+fn void find_all_bt_gpos() => @pool()
+{
+    MatchIter it = re_bt_gpos.find_all(tmem, GPOS_INPUT);
+    usz count;
+    while (try m = it.next())
+    {
+        defer m.free();
+        count++;
+    }
+    assert(count == 4);
+}
+
+
+// ----- replace benchmarks -------------------------------------------------------------------
+
+fn void replace_literal() => @pool()
+{
+    Regex* re = regex::tcompile("fox");
+    String result = re.replace(tmem, "The quick brown fox", "cat")!!;
+    assert(result == "The quick brown cat");
+}
+
+fn void replace_all_words() => @pool()
+{
+    Regex* re = regex::tcompile("\\b(fox|dog)\\b");
+    String result = re.replace_all(tmem, HAYSTACK, "animal")!!;
+    assert(result.len > 0);
+}

--- a/lib/std/regex/engine.c3
+++ b/lib/std/regex/engine.c3
@@ -6,14 +6,14 @@ import std::collections::list;
 // Thompson NFA simulation
 // ============================================================
 
-struct Thread
+struct RegexThread @local
 {
-	NfaState* state;
+	RegexNfaState* state;
 	MatchGroup* captures;
 	bool greedy;
 }
 
-alias ThreadList = List{Thread};
+alias RegexThreadList = List{RegexThread};
 
 fn bool is_word_char(Char32 c)
 {
@@ -25,8 +25,8 @@ fn bool is_word_char(Char32 c)
 }
 
 fn void add_thread(
-	ThreadList* list,
-	NfaState* state,
+	RegexThreadList* list,
+	RegexNfaState* state,
 	MatchGroup* caps,
 	usz* gen,
 	usz cur_gen,
@@ -152,29 +152,29 @@ fn void add_thread(
 	}
 }
 
-struct BacktrackChoice
+struct RegexBacktrackChoice @local
 {
-	NfaState* state;
+	RegexNfaState* state;
 	usz pos;
 	MatchGroup* captures;
 }
 
-alias BacktrackChoiceList = List{BacktrackChoice};
+alias RegexBacktrackChoiceList = List{RegexBacktrackChoice};
 
-struct BacktrackFrame
+struct RegexBacktrackFrame @local
 {
-	NfaState* state;
+	RegexNfaState* state;
 	usz pos;
 	MatchGroup* captures;
-	BacktrackChoiceList choices;
+	RegexBacktrackChoiceList choices;
 	bool exact_end;
 	usz end_pos;
-	BacktrackFrame* parent;
+	RegexBacktrackFrame* parent;
 	MatchGroup* parent_captures;
-	NfaState* resume_state;
+	RegexNfaState* resume_state;
 }
 
-alias BacktrackFrameList = List{BacktrackFrame*};
+alias RegexBacktrackFrameList = List{RegexBacktrackFrame*};
 
 fn MatchGroup* clone_match_groups(MatchGroup* caps, int n_groups) @local
 {
@@ -183,7 +183,7 @@ fn MatchGroup* clone_match_groups(MatchGroup* caps, int n_groups) @local
 	return clone;
 }
 
-fn void push_backtrack_choice(BacktrackChoiceList* choices, NfaState* state, usz pos, MatchGroup* caps, int n_groups) @local
+fn void push_backtrack_choice(RegexBacktrackChoiceList* choices, RegexNfaState* state, usz pos, MatchGroup* caps, int n_groups) @local
 {
 	if (state == null) return;
 	choices.push({
@@ -193,18 +193,18 @@ fn void push_backtrack_choice(BacktrackChoiceList* choices, NfaState* state, usz
 	});
 }
 
-fn BacktrackFrame* create_backtrack_frame(
-	NfaState* state,
+fn RegexBacktrackFrame* create_backtrack_frame(
+	RegexNfaState* state,
 	usz pos,
 	MatchGroup* caps,
 	bool exact_end,
 	usz end_pos,
-	BacktrackFrame* parent = null,
+	RegexBacktrackFrame* parent = null,
 	MatchGroup* parent_captures = null,
-	NfaState* resume_state = null
+	RegexNfaState* resume_state = null
 ) @local
 {
-	BacktrackFrame* frame = mem::tnew(BacktrackFrame);
+	RegexBacktrackFrame* frame = mem::tnew(RegexBacktrackFrame);
 	*frame = {
 		.state = state,
 		.pos = pos,
@@ -219,17 +219,17 @@ fn BacktrackFrame* create_backtrack_frame(
 	return frame;
 }
 
-fn usz? backtrack_execute(NfaState* state, String input, usz pos, Regex* re, MatchGroup* caps, int n_groups, bool exact_end, usz end_pos, MatchGroup** final_caps) @local
+fn usz? backtrack_execute(RegexNfaState* state, String input, usz pos, Regex* re, MatchGroup* caps, int n_groups, bool exact_end, usz end_pos, MatchGroup** final_caps) @local
 {
 	if (state == null) return NO_MATCH~;
 
-	BacktrackFrameList frames;
+	RegexBacktrackFrameList frames;
 	frames.tinit(8);
 	frames.push(create_backtrack_frame(state, pos, caps, exact_end, end_pos));
 
 	while FRAME_LOOP: (!frames.is_empty())
 	{
-		BacktrackFrame* frame = frames[frames.size - 1];
+		RegexBacktrackFrame* frame = frames[frames.size - 1];
 		while EXECUTE_PATH: (frame.state != null)
 		{
 			switch (frame.state.kind)
@@ -243,7 +243,7 @@ fn usz? backtrack_execute(NfaState* state, String input, usz pos, Regex* re, Mat
 							return frame.pos;
 						}
 						mem::copy(frame.parent_captures, frame.captures, (usz)n_groups * MatchGroup.sizeof);
-						BacktrackFrame* parent = frame.parent;
+						RegexBacktrackFrame* parent = frame.parent;
 						parent.pos = frame.pos;
 						parent.state = frame.resume_state;
 						frames.pop()!!;
@@ -284,8 +284,8 @@ fn usz? backtrack_execute(NfaState* state, String input, usz pos, Regex* re, Mat
 					frame.state = frame.state.out1;
 					continue;
 				case STATE_SPLIT:
-					NfaState* first = frame.state.lazy ? frame.state.out2 : frame.state.out1;
-					NfaState* second = frame.state.lazy ? frame.state.out1 : frame.state.out2;
+					RegexNfaState* first = frame.state.lazy ? frame.state.out2 : frame.state.out1;
+					RegexNfaState* second = frame.state.lazy ? frame.state.out1 : frame.state.out2;
 					push_backtrack_choice(&frame.choices, second, frame.pos, frame.captures, n_groups);
 					frame.state = first;
 					continue;
@@ -428,7 +428,7 @@ fn usz? backtrack_execute(NfaState* state, String input, usz pos, Regex* re, Mat
 				case STATE_COND_GROUP:
 					bool cond_ok = (frame.state.backref_id > 0 && frame.state.backref_id < n_groups)
 						&& frame.captures[frame.state.backref_id].matched;
-					NfaState* cond_branch = cond_ok ? frame.state.lookaround_start : frame.state.out2;
+					RegexNfaState* cond_branch = cond_ok ? frame.state.lookaround_start : frame.state.out2;
 					MatchGroup* cond_caps = clone_match_groups(frame.captures, n_groups);
 					frames.push(create_backtrack_frame(
 						cond_branch,
@@ -445,7 +445,7 @@ fn usz? backtrack_execute(NfaState* state, String input, usz pos, Regex* re, Mat
 					break EXECUTE_PATH;
 			}
 		}
-		BacktrackChoice? choice = frame.choices.pop();
+		RegexBacktrackChoice? choice = frame.choices.pop();
 		if (try choice)
 		{
 			frame.state = choice.state;
@@ -454,14 +454,14 @@ fn usz? backtrack_execute(NfaState* state, String input, usz pos, Regex* re, Mat
 			continue;
 		}
 		if (frame.parent == null) return NO_MATCH~;
-		BacktrackFrame* parent = frame.parent;
+		RegexBacktrackFrame* parent = frame.parent;
 		frames.pop()!!;
 		parent.state = null;
 	}
 	return NO_MATCH~;
 }
 
-fn bool backtrack_match(NfaState* state, String input, usz pos, Regex* re)
+fn bool backtrack_match(RegexNfaState* state, String input, usz pos, Regex* re)
 {
 	if (state == null) return false;
 	int n_groups = re.group_count + 1;
@@ -474,7 +474,7 @@ fn bool backtrack_match(NfaState* state, String input, usz pos, Regex* re)
 	};
 }
 
-fn bool backtrack_match_at_end(NfaState* state, String input, usz pos, usz end_pos, Regex* re)
+fn bool backtrack_match_at_end(RegexNfaState* state, String input, usz pos, usz end_pos, Regex* re)
 {
 	if (state == null) return false;
 	int n_groups = re.group_count + 1;
@@ -487,7 +487,7 @@ fn bool backtrack_match_at_end(NfaState* state, String input, usz pos, usz end_p
 	};
 }
 
-fn bool variable_lookbehind_has_match(NfaState* state, String input, usz pos, Regex* re) @local
+fn bool variable_lookbehind_has_match(RegexNfaState* state, String input, usz pos, Regex* re) @local
 {
 	for (usz ls = 0; ls < pos; ls = next_utf8_codepoint_start(input, ls, pos))
 	{
@@ -496,7 +496,7 @@ fn bool variable_lookbehind_has_match(NfaState* state, String input, usz pos, Re
 	return false;
 }
 
-fn usz? backtrack_full_exact(NfaState* state, String input, usz pos, usz end_pos, Regex* re, MatchGroup* caps, int n_groups)
+fn usz? backtrack_full_exact(RegexNfaState* state, String input, usz pos, usz end_pos, Regex* re, MatchGroup* caps, int n_groups)
 {
 	MatchGroup* final_caps = caps;
 	usz? result = backtrack_execute(state, input, pos, re, caps, n_groups, true, end_pos, &final_caps);
@@ -507,7 +507,7 @@ fn usz? backtrack_full_exact(NfaState* state, String input, usz pos, usz end_pos
 	return result;
 }
 
-fn usz? backtrack_full(NfaState* state, String input, usz pos, Regex* re, MatchGroup* caps, int n_groups)
+fn usz? backtrack_full(RegexNfaState* state, String input, usz pos, Regex* re, MatchGroup* caps, int n_groups)
 {
 	MatchGroup* final_caps = caps;
 	usz? result = backtrack_execute(state, input, pos, re, caps, n_groups, false, 0, &final_caps);
@@ -547,22 +547,22 @@ fn Match? try_match_at_bt(Regex* re, String input, usz start_pos, Allocator resu
 	};
 }
 
-fn void charclass_merge_ranges(CharClass* dst, TempRangeList* unicode, CharClass src) @local
+fn void charclass_merge_ranges(RegexCharClass* dst, RegexTempRangeList* unicode, RegexCharClass src) @local
 {
 	dst.ascii_bits |= src.ascii_bits;
 	dst.props |= src.props;
 	for (usz i = 0; i < src.ranges_count; i++)
 	{
-		UnicodeRange r = src.ranges[i];
+		RegexUnicodeRange r = src.ranges[i];
 		charclass_add_range(dst, unicode, r.lo, r.hi);
 	}
 }
 
 fn void collect_start_filter(
-	NfaState* state,
+	RegexNfaState* state,
 	bool* visited,
-	CharClass* filter,
-	TempRangeList* unicode,
+	RegexCharClass* filter,
+	RegexTempRangeList* unicode,
 	bool* supported,
 	bool* reaches_match
 ) @local
@@ -619,8 +619,8 @@ fn void Regex.compute_start_filter(&self)
 	{
 		bool* visited = alloc::new_array(tmem, bool, self.state_count);
 		mem::set(visited, 0, self.state_count * bool.sizeof);
-		CharClass filter = {};
-		TempRangeList unicode;
+		RegexCharClass filter = {};
+		RegexTempRangeList unicode;
 		unicode.tinit(4);
 		defer unicode.free();
 		bool supported = true;
@@ -631,8 +631,8 @@ fn void Regex.compute_start_filter(&self)
 		self.start_filter = filter;
 		if (unicode.size > 0)
 		{
-			self.start_filter.ranges = alloc::new_array(self.allocator, UnicodeRange, unicode.size);
-			mem::copy(self.start_filter.ranges, unicode.entries, unicode.size * UnicodeRange.sizeof);
+			self.start_filter.ranges = alloc::new_array(self.allocator, RegexUnicodeRange, unicode.size);
+			mem::copy(self.start_filter.ranges, unicode.entries, unicode.size * RegexUnicodeRange.sizeof);
 			self.start_filter.ranges_count = unicode.size;
 		}
 		self.has_start_filter = true;
@@ -651,8 +651,8 @@ fn Match? try_match_at(Regex* re, String input, usz start_pos, Allocator result_
 		usz* gen = alloc::new_array(tmem, usz, n_states);
 		mem::set(gen, 0, n_states * usz.sizeof);
 
-		ThreadList current; current.tinit(32);
-		ThreadList next_t; next_t.tinit(32);
+		RegexThreadList current; current.tinit(32);
+		RegexThreadList next_t; next_t.tinit(32);
 
 		usz cur_gen = 1;
 		MatchGroup* best = null;
@@ -694,7 +694,7 @@ fn Match? try_match_at(Regex* re, String input, usz start_pos, Allocator result_
 
 			foreach (t : current.array_view())
 			{
-				NfaState* s = t.state;
+				RegexNfaState* s = t.state;
 				bool matched_char = false;
 				switch (s.kind)
 				{
@@ -730,7 +730,7 @@ fn Match? try_match_at(Regex* re, String input, usz start_pos, Allocator result_
 			prev_char = cp;
 			is_start = false;
 
-			ThreadList tmp = current;
+			RegexThreadList tmp = current;
 			current = next_t;
 			next_t = tmp;
 			next_t.clear();

--- a/lib/std/regex/engine.c3
+++ b/lib/std/regex/engine.c3
@@ -1,0 +1,764 @@
+module std::regex;
+import std::core::string::iterator;
+import std::collections::list;
+
+// ============================================================
+// Thompson NFA simulation
+// ============================================================
+
+struct Thread
+{
+	NfaState* state;
+	MatchGroup* captures;
+	bool greedy;
+}
+
+alias ThreadList = List{Thread};
+
+fn bool is_word_char(Char32 c)
+{
+	if (c < 128) return WORD_SET.contains((char)c);
+	if (c == 0xAA || c == 0xB5 || c == 0xBA) return true;
+	return (c >= 0xC0 && c <= 0xD6)
+		|| (c >= 0xD8 && c <= 0xF6)
+		|| (c >= 0xF8 && c <= 0xFF);
+}
+
+fn void add_thread(
+	ThreadList* list,
+	NfaState* state,
+	MatchGroup* caps,
+	usz* gen,
+	usz cur_gen,
+	String input,
+	usz pos,
+	bool is_start,
+	Char32 prev_char,
+	Regex* re,
+	int n_groups,
+	bool parent_greedy
+)
+{
+	if (state == null) return;
+	if (gen[state.index] == cur_gen) return;
+	gen[state.index] = cur_gen;
+
+	switch (state.kind)
+	{
+		case STATE_SPLIT:
+			MatchGroup* caps2 = alloc::new_array(tmem, MatchGroup, (usz)n_groups);
+			mem::copy(caps2, caps, (usz)n_groups * MatchGroup.sizeof);
+			if (state.lazy)
+			{
+				add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, false);
+				add_thread(list, state.out2, caps2, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+			}
+			else
+			{
+				add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+				add_thread(list, state.out2, caps2, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, true);
+			}
+		case STATE_CAPTURE_START:
+			MatchGroup* nc_s = alloc::new_array(tmem, MatchGroup, (usz)n_groups);
+			mem::copy(nc_s, caps, (usz)n_groups * MatchGroup.sizeof);
+			if (state.group_id < n_groups)
+			{
+				nc_s[state.group_id].start = pos;
+				nc_s[state.group_id].matched = false;
+			}
+			add_thread(list, state.out1, nc_s, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_CAPTURE_END:
+			MatchGroup* nc_e = alloc::new_array(tmem, MatchGroup, (usz)n_groups);
+			mem::copy(nc_e, caps, (usz)n_groups * MatchGroup.sizeof);
+			if (state.group_id < n_groups)
+			{
+				nc_e[state.group_id].end = pos;
+				nc_e[state.group_id].matched = true;
+			}
+			add_thread(list, state.out1, nc_e, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_ANCHOR_START:
+			bool ok_s = (re.flags & FLAG_MULTILINE) != FLAG_NONE
+				? is_start || (pos > 0 && input[pos - 1] == '\n')
+				: is_start;
+			if (ok_s) add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_ANCHOR_END:
+			bool ok_e = (re.flags & FLAG_MULTILINE) != FLAG_NONE
+				? pos >= input.len || input[pos] == '\n'
+				: pos >= input.len;
+			if (ok_e) add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_WORD_BOUND:
+			bool cur_w = is_word_position(input, pos);
+			bool prev_w = is_word_char(prev_char);
+			if (cur_w != prev_w) add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_WORD_NBOUND:
+			bool cur_wn = is_word_position(input, pos);
+			bool prev_wn = is_word_char(prev_char);
+			if (cur_wn == prev_wn) add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_LOOKAHEAD_POS:
+			if (backtrack_match(state.lookaround_start, input, pos, re))
+			{
+				add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+			}
+		case STATE_LOOKAHEAD_NEG:
+			if (!backtrack_match(state.lookaround_start, input, pos, re))
+			{
+				add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+			}
+		case STATE_LOOKBEHIND_POS:
+			bool lb_ok;
+			if (state.lookbehind_variable)
+			{
+				lb_ok = variable_lookbehind_has_match(state, input, pos, re);
+			}
+			else
+			{
+				lb_ok = pos >= state.lookbehind_len
+					&& backtrack_match(state.lookaround_start, input, pos - state.lookbehind_len, re);
+			}
+			if (lb_ok) add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_LOOKBEHIND_NEG:
+			bool lbn_ok;
+			if (state.lookbehind_variable)
+			{
+				lbn_ok = !variable_lookbehind_has_match(state, input, pos, re);
+			}
+			else
+			{
+				lbn_ok = pos < state.lookbehind_len
+					|| !backtrack_match(state.lookaround_start, input, pos - state.lookbehind_len, re);
+			}
+			if (lbn_ok) add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_KEEP:
+			MatchGroup* kc = alloc::new_array(tmem, MatchGroup, (usz)n_groups);
+			mem::copy(kc, caps, (usz)n_groups * MatchGroup.sizeof);
+			kc[0].start = pos;
+			add_thread(list, state.out1, kc, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_ANCHOR_ABSOLUTE_START:
+			if (pos == 0) add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_ANCHOR_ABSOLUTE_END:
+			if (pos >= input.len) add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_ANCHOR_ABSOLUTE_END_NL:
+			bool ok_enl = pos >= input.len || (pos + 1 == input.len && input[pos] == '\n');
+			if (ok_enl) add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_ANCHOR_GPOS:
+			if (pos == re.gpos) add_thread(list, state.out1, caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		case STATE_COND_GROUP:
+			bool cond_ok = (state.backref_id > 0 && state.backref_id < n_groups)
+				&& caps[state.backref_id].matched;
+			add_thread(list, cond_ok ? state.lookaround_start : state.out2,
+				caps, gen, cur_gen, input, pos, is_start, prev_char, re, n_groups, parent_greedy);
+		default:
+			list.push({ .state = state, .captures = caps, .greedy = parent_greedy });
+	}
+}
+
+struct BacktrackChoice
+{
+	NfaState* state;
+	usz pos;
+	MatchGroup* captures;
+}
+
+alias BacktrackChoiceList = List{BacktrackChoice};
+
+struct BacktrackFrame
+{
+	NfaState* state;
+	usz pos;
+	MatchGroup* captures;
+	BacktrackChoiceList choices;
+	bool exact_end;
+	usz end_pos;
+	BacktrackFrame* parent;
+	MatchGroup* parent_captures;
+	NfaState* resume_state;
+}
+
+alias BacktrackFrameList = List{BacktrackFrame*};
+
+fn MatchGroup* clone_match_groups(MatchGroup* caps, int n_groups) @local
+{
+	MatchGroup* clone = alloc::new_array(tmem, MatchGroup, (usz)n_groups);
+	mem::copy(clone, caps, (usz)n_groups * MatchGroup.sizeof);
+	return clone;
+}
+
+fn void push_backtrack_choice(BacktrackChoiceList* choices, NfaState* state, usz pos, MatchGroup* caps, int n_groups) @local
+{
+	if (state == null) return;
+	choices.push({
+		.state = state,
+		.pos = pos,
+		.captures = clone_match_groups(caps, n_groups)
+	});
+}
+
+fn BacktrackFrame* create_backtrack_frame(
+	NfaState* state,
+	usz pos,
+	MatchGroup* caps,
+	bool exact_end,
+	usz end_pos,
+	BacktrackFrame* parent = null,
+	MatchGroup* parent_captures = null,
+	NfaState* resume_state = null
+) @local
+{
+	BacktrackFrame* frame = mem::tnew(BacktrackFrame);
+	*frame = {
+		.state = state,
+		.pos = pos,
+		.captures = caps,
+		.exact_end = exact_end,
+		.end_pos = end_pos,
+		.parent = parent,
+		.parent_captures = parent_captures,
+		.resume_state = resume_state,
+	};
+	frame.choices.tinit(32);
+	return frame;
+}
+
+fn usz? backtrack_execute(NfaState* state, String input, usz pos, Regex* re, MatchGroup* caps, int n_groups, bool exact_end, usz end_pos, MatchGroup** final_caps) @local
+{
+	if (state == null) return NO_MATCH~;
+
+	BacktrackFrameList frames;
+	frames.tinit(8);
+	frames.push(create_backtrack_frame(state, pos, caps, exact_end, end_pos));
+
+	while FRAME_LOOP: (!frames.is_empty())
+	{
+		BacktrackFrame* frame = frames[frames.size - 1];
+		while EXECUTE_PATH: (frame.state != null)
+		{
+			switch (frame.state.kind)
+			{
+				case STATE_MATCH:
+					if (!frame.exact_end || frame.pos == frame.end_pos)
+					{
+						if (frame.parent == null)
+						{
+							if (final_caps != null) *final_caps = frame.captures;
+							return frame.pos;
+						}
+						mem::copy(frame.parent_captures, frame.captures, (usz)n_groups * MatchGroup.sizeof);
+						BacktrackFrame* parent = frame.parent;
+						parent.pos = frame.pos;
+						parent.state = frame.resume_state;
+						frames.pop()!!;
+						continue FRAME_LOOP;
+					}
+					break EXECUTE_PATH;
+				case STATE_LITERAL:
+					if (frame.pos >= input.len || (frame.exact_end && frame.pos >= frame.end_pos)) break EXECUTE_PATH;
+					StringIterator lit_it = { .utf8 = input, .current = frame.pos };
+					Char32? lit_cp = lit_it.next();
+					if (catch lit_cp) break EXECUTE_PATH;
+					Char32 lit_input = lit_cp;
+					Char32 lit_state = frame.state.codepoint;
+					if ((re.flags & FLAG_IGNORECASE) != FLAG_NONE)
+					{
+						lit_input = unicode_case_fold(lit_input);
+						lit_state = unicode_case_fold(lit_state);
+					}
+					if (lit_input != lit_state) break EXECUTE_PATH;
+					frame.pos = lit_it.current;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_CHARSET:
+					if (frame.pos >= input.len || (frame.exact_end && frame.pos >= frame.end_pos)) break EXECUTE_PATH;
+					StringIterator set_it = { .utf8 = input, .current = frame.pos };
+					Char32? set_cp = set_it.next();
+					if (catch set_cp) break EXECUTE_PATH;
+					bool set_icase = (re.flags & FLAG_IGNORECASE) != FLAG_NONE;
+					bool set_dotall = (re.flags & FLAG_DOTALL) != FLAG_NONE;
+					bool set_is_dot = frame.state.char_class.ascii_bits == CLASS_DOT.ascii_bits
+						&& frame.state.char_class.ranges_count == 0
+						&& !frame.state.char_class.negated;
+					bool set_ok = (set_is_dot && !set_dotall)
+						? set_cp != '\n'
+						: frame.state.char_class.matches(set_cp, set_icase);
+					if (!set_ok) break EXECUTE_PATH;
+					frame.pos = set_it.current;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_SPLIT:
+					NfaState* first = frame.state.lazy ? frame.state.out2 : frame.state.out1;
+					NfaState* second = frame.state.lazy ? frame.state.out1 : frame.state.out2;
+					push_backtrack_choice(&frame.choices, second, frame.pos, frame.captures, n_groups);
+					frame.state = first;
+					continue;
+				case STATE_CAPTURE_START:
+					if (frame.state.group_id < n_groups)
+					{
+						frame.captures[frame.state.group_id].start = frame.pos;
+						frame.captures[frame.state.group_id].matched = false;
+					}
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_CAPTURE_END:
+					if (frame.state.group_id < n_groups)
+					{
+						frame.captures[frame.state.group_id].end = frame.pos;
+						frame.captures[frame.state.group_id].matched = true;
+					}
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_KEEP:
+					frame.captures[0].start = frame.pos;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_ANCHOR_START:
+					bool ok_as = frame.pos == 0 || ((re.flags & FLAG_MULTILINE) != FLAG_NONE && frame.pos > 0 && input[frame.pos - 1] == '\n');
+					if (!ok_as) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_ANCHOR_END:
+					bool ok_ae = frame.pos >= input.len || ((re.flags & FLAG_MULTILINE) != FLAG_NONE && input[frame.pos] == '\n');
+					if (!ok_ae) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_ANCHOR_ABSOLUTE_START:
+					if (frame.pos != 0) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_ANCHOR_ABSOLUTE_END:
+					if (frame.pos < input.len) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_ANCHOR_ABSOLUTE_END_NL:
+					bool ok_enl = frame.pos >= input.len || (frame.pos + 1 == input.len && input[frame.pos] == '\n');
+					if (!ok_enl) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_WORD_BOUND:
+					bool wb_cur = is_word_position(input, frame.pos);
+					bool wb_prev = is_word_char(previous_codepoint_before(input, frame.pos));
+					if (wb_cur == wb_prev) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_WORD_NBOUND:
+					bool wnb_cur = is_word_position(input, frame.pos);
+					bool wnb_prev = is_word_char(previous_codepoint_before(input, frame.pos));
+					if (wnb_cur != wnb_prev) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_LOOKAHEAD_POS:
+					if (!backtrack_match(frame.state.lookaround_start, input, frame.pos, re)) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_LOOKAHEAD_NEG:
+					if (backtrack_match(frame.state.lookaround_start, input, frame.pos, re)) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_LOOKBEHIND_POS:
+					bool lbp_ok;
+					if (frame.state.lookbehind_variable)
+					{
+						lbp_ok = variable_lookbehind_has_match(frame.state, input, frame.pos, re);
+					}
+					else
+					{
+						lbp_ok = frame.pos >= frame.state.lookbehind_len
+							&& backtrack_match(frame.state.lookaround_start, input, frame.pos - frame.state.lookbehind_len, re);
+					}
+					if (!lbp_ok) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_LOOKBEHIND_NEG:
+					bool lbn_ok;
+					if (frame.state.lookbehind_variable)
+					{
+						lbn_ok = !variable_lookbehind_has_match(frame.state, input, frame.pos, re);
+					}
+					else
+					{
+						lbn_ok = frame.pos < frame.state.lookbehind_len
+							|| !backtrack_match(frame.state.lookaround_start, input, frame.pos - frame.state.lookbehind_len, re);
+					}
+					if (!lbn_ok) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_BACKREF:
+					int brid = frame.state.backref_id;
+					if (brid <= 0 || brid >= n_groups) break EXECUTE_PATH;
+					if (!frame.captures[brid].matched) break EXECUTE_PATH;
+					usz br_len = frame.captures[brid].end - frame.captures[brid].start;
+					if (frame.pos + br_len > input.len || (frame.exact_end && frame.pos + br_len > frame.end_pos)) break EXECUTE_PATH;
+					if ((re.flags & FLAG_IGNORECASE) != FLAG_NONE)
+					{
+						StringIterator br_a = { .utf8 = input, .current = frame.captures[brid].start };
+						StringIterator br_b = { .utf8 = input, .current = frame.pos };
+						usz br_end = frame.captures[brid].end;
+						while (br_a.current < br_end)
+						{
+							Char32? br_ca = br_a.next();
+							Char32? br_cb = br_b.next();
+							if (catch br_ca) break EXECUTE_PATH;
+							if (catch br_cb) break EXECUTE_PATH;
+							if (unicode_case_fold(br_ca) != unicode_case_fold(br_cb)) break EXECUTE_PATH;
+						}
+						frame.pos = br_b.current;
+					}
+					else
+					{
+						if (!mem::equals(input[frame.pos : br_len].ptr, input[frame.captures[brid].start : br_len].ptr, br_len)) break EXECUTE_PATH;
+						frame.pos += br_len;
+					}
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_ATOMIC:
+					MatchGroup* atm_caps = clone_match_groups(frame.captures, n_groups);
+					frames.push(create_backtrack_frame(
+						frame.state.lookaround_start,
+						frame.pos,
+						atm_caps,
+						frame.exact_end,
+						frame.end_pos,
+						frame,
+						frame.captures,
+						frame.state.out1
+					));
+					continue FRAME_LOOP;
+				case STATE_ANCHOR_GPOS:
+					if (frame.pos != re.gpos) break EXECUTE_PATH;
+					frame.state = frame.state.out1;
+					continue;
+				case STATE_COND_GROUP:
+					bool cond_ok = (frame.state.backref_id > 0 && frame.state.backref_id < n_groups)
+						&& frame.captures[frame.state.backref_id].matched;
+					NfaState* cond_branch = cond_ok ? frame.state.lookaround_start : frame.state.out2;
+					MatchGroup* cond_caps = clone_match_groups(frame.captures, n_groups);
+					frames.push(create_backtrack_frame(
+						cond_branch,
+						frame.pos,
+						cond_caps,
+						frame.exact_end,
+						frame.end_pos,
+						frame,
+						frame.captures,
+						frame.state.out1
+					));
+					continue FRAME_LOOP;
+				default:
+					break EXECUTE_PATH;
+			}
+		}
+		BacktrackChoice? choice = frame.choices.pop();
+		if (try choice)
+		{
+			frame.state = choice.state;
+			frame.pos = choice.pos;
+			frame.captures = choice.captures;
+			continue;
+		}
+		if (frame.parent == null) return NO_MATCH~;
+		BacktrackFrame* parent = frame.parent;
+		frames.pop()!!;
+		parent.state = null;
+	}
+	return NO_MATCH~;
+}
+
+fn bool backtrack_match(NfaState* state, String input, usz pos, Regex* re)
+{
+	if (state == null) return false;
+	int n_groups = re.group_count + 1;
+	@pool()
+	{
+		MatchGroup* caps = alloc::new_array(tmem, MatchGroup, (usz)n_groups);
+		mem::set(caps, 0, (usz)n_groups * MatchGroup.sizeof);
+		caps[0].start = pos;
+		return @ok(backtrack_full(state, input, pos, re, caps, n_groups));
+	};
+}
+
+fn bool backtrack_match_at_end(NfaState* state, String input, usz pos, usz end_pos, Regex* re)
+{
+	if (state == null) return false;
+	int n_groups = re.group_count + 1;
+	@pool()
+	{
+		MatchGroup* caps = alloc::new_array(tmem, MatchGroup, (usz)n_groups);
+		mem::set(caps, 0, (usz)n_groups * MatchGroup.sizeof);
+		caps[0].start = pos;
+		return @ok(backtrack_full_exact(state, input, pos, end_pos, re, caps, n_groups));
+	};
+}
+
+fn bool variable_lookbehind_has_match(NfaState* state, String input, usz pos, Regex* re) @local
+{
+	for (usz ls = 0; ls < pos; ls = next_utf8_codepoint_start(input, ls, pos))
+	{
+		if (backtrack_match_at_end(state.lookaround_start, input, ls, pos, re)) return true;
+	}
+	return false;
+}
+
+fn usz? backtrack_full_exact(NfaState* state, String input, usz pos, usz end_pos, Regex* re, MatchGroup* caps, int n_groups)
+{
+	MatchGroup* final_caps = caps;
+	usz? result = backtrack_execute(state, input, pos, re, caps, n_groups, true, end_pos, &final_caps);
+	if (try result && final_caps != caps)
+	{
+		mem::copy(caps, final_caps, (usz)n_groups * MatchGroup.sizeof);
+	}
+	return result;
+}
+
+fn usz? backtrack_full(NfaState* state, String input, usz pos, Regex* re, MatchGroup* caps, int n_groups)
+{
+	MatchGroup* final_caps = caps;
+	usz? result = backtrack_execute(state, input, pos, re, caps, n_groups, false, 0, &final_caps);
+	if (try result && final_caps != caps)
+	{
+		mem::copy(caps, final_caps, (usz)n_groups * MatchGroup.sizeof);
+	}
+	return result;
+}
+
+fn Match? try_match_at_bt(Regex* re, String input, usz start_pos, Allocator result_alloc)
+{
+	int n_groups = re.group_count + 1;
+	re.gpos = start_pos;
+	@pool()
+	{
+		MatchGroup* caps = alloc::new_array(tmem, MatchGroup, (usz)n_groups);
+		mem::set(caps, 0, (usz)n_groups * MatchGroup.sizeof);
+		caps[0].start = start_pos;
+
+		usz? end_pos = backtrack_full(&re.states[re.start_idx], input, start_pos, re, caps, n_groups);
+		if (catch end_pos) return NO_MATCH~;
+
+		caps[0].end = end_pos;
+		caps[0].matched = true;
+
+		MatchGroup* result_groups = alloc::new_array(result_alloc, MatchGroup, (usz)n_groups);
+		mem::copy(result_groups, caps, (usz)n_groups * MatchGroup.sizeof);
+		Match result = {
+			.regex = re,
+			.input = input,
+			.groups = result_groups,
+			.group_count = (usz)n_groups,
+			.allocator = result_alloc
+		};
+		return result;
+	};
+}
+
+fn void charclass_merge_ranges(CharClass* dst, TempRangeList* unicode, CharClass src) @local
+{
+	dst.ascii_bits |= src.ascii_bits;
+	dst.props |= src.props;
+	for (usz i = 0; i < src.ranges_count; i++)
+	{
+		UnicodeRange r = src.ranges[i];
+		charclass_add_range(dst, unicode, r.lo, r.hi);
+	}
+}
+
+fn void collect_start_filter(
+	NfaState* state,
+	bool* visited,
+	CharClass* filter,
+	TempRangeList* unicode,
+	bool* supported,
+	bool* reaches_match
+) @local
+{
+	if (state == null || !*supported) return;
+	if (visited[state.index]) return;
+	visited[state.index] = true;
+
+	switch (state.kind)
+	{
+		case STATE_MATCH:
+			*reaches_match = true;
+			return;
+		case STATE_LITERAL:
+			charclass_add_range(filter, unicode, state.codepoint, state.codepoint);
+			return;
+		case STATE_CHARSET:
+			if (state.char_class.negated || state.char_class.complement_props != PROP_NONE)
+			{
+				*supported = false;
+				return;
+			}
+			charclass_merge_ranges(filter, unicode, state.char_class);
+			return;
+		case STATE_SPLIT:
+		case STATE_CAPTURE_START:
+		case STATE_CAPTURE_END:
+		case STATE_ANCHOR_START:
+		case STATE_ANCHOR_END:
+		case STATE_WORD_BOUND:
+		case STATE_WORD_NBOUND:
+		case STATE_LOOKAHEAD_POS:
+		case STATE_LOOKAHEAD_NEG:
+		case STATE_LOOKBEHIND_POS:
+		case STATE_LOOKBEHIND_NEG:
+		case STATE_KEEP:
+		case STATE_ANCHOR_ABSOLUTE_START:
+		case STATE_ANCHOR_ABSOLUTE_END:
+		case STATE_ANCHOR_ABSOLUTE_END_NL:
+		case STATE_ANCHOR_GPOS:
+			collect_start_filter(state.out1, visited, filter, unicode, supported, reaches_match);
+			if (state.kind == STATE_SPLIT) collect_start_filter(state.out2, visited, filter, unicode, supported, reaches_match);
+			return;
+		default:
+			*supported = false;
+			return;
+	}
+}
+
+fn void Regex.compute_start_filter(&self)
+{
+	if (self.states == null || self.state_count == 0) return;
+	@pool()
+	{
+		bool* visited = alloc::new_array(tmem, bool, self.state_count);
+		mem::set(visited, 0, self.state_count * bool.sizeof);
+		CharClass filter = {};
+		TempRangeList unicode;
+		unicode.tinit(4);
+		defer unicode.free();
+		bool supported = true;
+		bool reaches_match = false;
+		collect_start_filter(&self.states[self.start_idx], visited, &filter, &unicode, &supported, &reaches_match);
+		if (!supported || reaches_match) return;
+		if (filter.ascii_bits == (AsciiCharset)0 && filter.props == PROP_NONE && unicode.size == 0) return;
+		self.start_filter = filter;
+		if (unicode.size > 0)
+		{
+			self.start_filter.ranges = alloc::new_array(self.allocator, UnicodeRange, unicode.size);
+			mem::copy(self.start_filter.ranges, unicode.entries, unicode.size * UnicodeRange.sizeof);
+			self.start_filter.ranges_count = unicode.size;
+		}
+		self.has_start_filter = true;
+	};
+}
+
+fn Match? try_match_at(Regex* re, String input, usz start_pos, Allocator result_alloc)
+{
+	if (re.has_backref || re.has_atomic || re.has_gpos || re.has_cond) return try_match_at_bt(re, input, start_pos, result_alloc);
+
+	int n_groups = re.group_count + 1;
+	usz n_states = re.state_count;
+
+	@pool()
+	{
+		usz* gen = alloc::new_array(tmem, usz, n_states);
+		mem::set(gen, 0, n_states * usz.sizeof);
+
+		ThreadList current; current.tinit(32);
+		ThreadList next_t; next_t.tinit(32);
+
+		usz cur_gen = 1;
+		MatchGroup* best = null;
+
+		MatchGroup* init_caps = alloc::new_array(tmem, MatchGroup, (usz)n_groups);
+		mem::set(init_caps, 0, (usz)n_groups * MatchGroup.sizeof);
+		init_caps[0].start = start_pos;
+
+		bool is_start = start_pos == 0;
+		Char32 prev_char = is_start ? 0 : previous_codepoint_before(input, start_pos);
+
+		add_thread(&current, &re.states[re.start_idx], init_caps, gen, cur_gen, input, start_pos, is_start, prev_char, re, n_groups, true);
+
+		foreach (t : current.array_view())
+		{
+			if (t.state.kind == STATE_MATCH)
+			{
+				MatchGroup* mc = t.captures;
+				mc[0].end = start_pos;
+				mc[0].matched = true;
+				if (t.greedy || best == null) best = mc;
+				break;
+			}
+		}
+
+		StringIterator it = { .utf8 = input, .current = start_pos };
+		usz pos = start_pos;
+
+		while (it.has_next())
+		{
+			Char32? maybe_cp = it.next();
+			if (catch maybe_cp) break;
+			Char32 cp = maybe_cp;
+			usz next_pos = it.current;
+			cur_gen++;
+
+			bool icase = (re.flags & FLAG_IGNORECASE) != FLAG_NONE;
+			bool dotall = (re.flags & FLAG_DOTALL) != FLAG_NONE;
+
+			foreach (t : current.array_view())
+			{
+				NfaState* s = t.state;
+				bool matched_char = false;
+				switch (s.kind)
+				{
+					case STATE_MATCH:
+						MatchGroup* mc = t.captures;
+						mc[0].end = pos;
+						mc[0].matched = true;
+						if (t.greedy || best == null) best = mc;
+						continue;
+					case STATE_LITERAL:
+						Char32 lc = s.codepoint;
+						Char32 tc = cp;
+						if (icase) lc = unicode_case_fold(lc);
+						if (icase) tc = unicode_case_fold(tc);
+						matched_char = tc == lc;
+					case STATE_CHARSET:
+						bool is_dot = s.char_class.ascii_bits == CLASS_DOT.ascii_bits
+							&& s.char_class.ranges_count == 0
+							&& !s.char_class.negated;
+						matched_char = (is_dot && !dotall)
+							? cp != '\n'
+							: s.char_class.matches(cp, icase);
+					default:
+						continue;
+				}
+				if (matched_char)
+				{
+					add_thread(&next_t, s.out1, t.captures, gen, cur_gen, input, next_pos, false, cp, re, n_groups, t.greedy);
+				}
+			}
+
+			pos = next_pos;
+			prev_char = cp;
+			is_start = false;
+
+			ThreadList tmp = current;
+			current = next_t;
+			next_t = tmp;
+			next_t.clear();
+		}
+
+		foreach (t : current.array_view())
+		{
+			if (t.state.kind == STATE_MATCH)
+			{
+				MatchGroup* mc = t.captures;
+				mc[0].end = pos;
+				mc[0].matched = true;
+				if (t.greedy || best == null) best = mc;
+				break;
+			}
+		}
+
+		if (best == null || !best[0].matched) return NO_MATCH~;
+
+		MatchGroup* result_groups = alloc::new_array(result_alloc, MatchGroup, (usz)n_groups);
+		mem::copy(result_groups, best, (usz)n_groups * MatchGroup.sizeof);
+		Match result = {
+			.regex = re,
+			.input = input,
+			.groups = result_groups,
+			.group_count = (usz)n_groups,
+			.allocator = result_alloc
+		};
+		return result;
+	};
+}

--- a/lib/std/regex/nfa.c3
+++ b/lib/std/regex/nfa.c3
@@ -1,0 +1,455 @@
+module std::regex;
+
+// ============================================================
+// NFA construction — Thompson fragment model
+// ============================================================
+
+fn NfaState* nfa_new(BuildCtx* bctx, StateKind kind)
+{
+	NfaState* s = alloc::new(bctx.alloc, NfaState);
+	s.kind = kind;
+	s.index = bctx.all_states.size;
+	bctx.all_states.push(s);
+	return s;
+}
+
+fn NfaFrag frag_make(NfaState* start)
+{
+	NfaFrag f;
+	f.start = start;
+	f.out.tinit(4);
+	return f;
+}
+
+fn NfaFrag frag_literal(BuildCtx* bctx, Char32 c)
+{
+	NfaState* s = nfa_new(bctx, STATE_LITERAL);
+	s.codepoint = c;
+	NfaFrag f = frag_make(s);
+	f.out.push(&s.out1);
+	return f;
+}
+
+fn NfaFrag frag_charset(BuildCtx* bctx, CharClass cls)
+{
+	NfaState* s = nfa_new(bctx, STATE_CHARSET);
+	if (cls.ranges_count > 0)
+	{
+		usz pool_offset = bctx.range_pool.size;
+		for (usz i = 0; i < cls.ranges_count; i++) bctx.range_pool.push(cls.ranges[i]);
+		s.char_class = cls;
+		s.char_class.ranges = (UnicodeRange*)(uptr)pool_offset;
+	}
+	else
+	{
+		s.char_class = cls;
+		s.char_class.ranges = null;
+	}
+	NfaFrag f = frag_make(s);
+	f.out.push(&s.out1);
+	return f;
+}
+
+fn void frag_patch(NfaFrag* f, NfaState* target)
+{
+	foreach (pp : f.out.array_view()) *pp = target;
+}
+
+fn NfaFrag frag_concat(NfaFrag e1, NfaFrag e2)
+{
+	frag_patch(&e1, e2.start);
+	e1.out.free();
+	NfaFrag result;
+	result.start = e1.start;
+	result.out = e2.out;
+	return result;
+}
+
+fn NfaFrag frag_alt(BuildCtx* bctx, NfaFrag e1, NfaFrag e2)
+{
+	NfaState* split = nfa_new(bctx, STATE_SPLIT);
+	split.out1 = e1.start;
+	split.out2 = e2.start;
+	NfaFrag result;
+	result.start = split;
+	result.out.tinit(e1.out.size + e2.out.size);
+	foreach (pp : e1.out.array_view()) result.out.push(pp);
+	foreach (pp : e2.out.array_view()) result.out.push(pp);
+	e1.out.free();
+	e2.out.free();
+	return result;
+}
+
+fn NfaFrag frag_star(BuildCtx* bctx, NfaFrag e, bool lazy)
+{
+	NfaState* split = nfa_new(bctx, STATE_SPLIT);
+	split.lazy = lazy;
+	frag_patch(&e, split);
+	e.out.free();
+	NfaFrag result;
+	result.start = split;
+	result.out.tinit(2);
+	if (lazy)
+	{
+		split.out2 = e.start;
+		result.out.push(&split.out1);
+	}
+	else
+	{
+		split.out1 = e.start;
+		result.out.push(&split.out2);
+	}
+	return result;
+}
+
+fn NfaFrag frag_plus(BuildCtx* bctx, NfaFrag e, bool lazy)
+{
+	NfaState* split = nfa_new(bctx, STATE_SPLIT);
+	split.lazy = lazy;
+	frag_patch(&e, split);
+	NfaFrag result;
+	result.start = e.start;
+	e.out.free();
+	result.out.tinit(2);
+	if (lazy)
+	{
+		split.out2 = e.start;
+		result.out.push(&split.out1);
+	}
+	else
+	{
+		split.out1 = e.start;
+		result.out.push(&split.out2);
+	}
+	return result;
+}
+
+fn NfaFrag frag_quest(BuildCtx* bctx, NfaFrag e, bool lazy)
+{
+	NfaState* split = nfa_new(bctx, STATE_SPLIT);
+	split.lazy = lazy;
+	NfaFrag result;
+	result.start = split;
+	result.out.tinit(e.out.size + 1);
+	if (lazy)
+	{
+		split.out2 = e.start;
+		result.out.push(&split.out1);
+	}
+	else
+	{
+		split.out1 = e.start;
+		result.out.push(&split.out2);
+	}
+	foreach (pp : e.out.array_view()) result.out.push(pp);
+	e.out.free();
+	return result;
+}
+
+// Epsilon fragment: a SPLIT state with one dangling out (out1) and null out2.
+// Use instead of STATE_MATCH for transparent pass-through nodes (empty groups, comments).
+fn NfaFrag frag_epsilon(BuildCtx* bctx)
+{
+	NfaState* s = nfa_new(bctx, STATE_SPLIT);
+	NfaFrag f = frag_make(s);
+	f.out.tinit(1);
+	f.out.push(&s.out1);
+	return f;
+}
+
+fn usz? ast_fixed_width(AstNode* node)
+{
+	if (node == null) return 0;
+	switch (node.kind)
+	{
+		case AST_LITERAL:
+			return utf8_codepoint_width(node.codepoint);
+		case AST_CHARCLASS:
+			return charclass_fixed_width(node.char_class);
+		case AST_CONCAT:
+			usz a = ast_fixed_width(node.left)!;
+			usz b = ast_fixed_width(node.right)!;
+			return a + b;
+		case AST_GROUP:
+		case AST_NCGROUP:
+			return ast_fixed_width(node.left);
+		case AST_REPEAT:
+			if (node.repeat_min != node.repeat_max || node.repeat_max == -1) return INVALID_PATTERN~;
+			usz w = ast_fixed_width(node.left)!;
+			return w * (usz)node.repeat_min;
+		case AST_ALT:
+			usz aw = ast_fixed_width(node.left)!;
+			usz bw = ast_fixed_width(node.right)!;
+			if (aw != bw) return INVALID_PATTERN~;
+			return aw;
+		case AST_ANCHOR_START:
+		case AST_ANCHOR_END:
+		case AST_ANCHOR_ABSOLUTE_START:
+		case AST_ANCHOR_ABSOLUTE_END:
+		case AST_ANCHOR_ABSOLUTE_END_NL:
+		case AST_WORD_BOUND:
+		case AST_WORD_NBOUND:
+		case AST_LOOKAHEAD_POS:
+		case AST_LOOKAHEAD_NEG:
+		case AST_LOOKBEHIND_POS:
+		case AST_LOOKBEHIND_NEG:
+			return 0;
+		case AST_LINEBREAK:
+		case AST_STAR:
+		case AST_PLUS:
+		case AST_QUEST:
+			return INVALID_PATTERN~;
+		case AST_KEEP:
+			return 0;
+		case AST_NON_NEWLINE:
+			return INVALID_PATTERN~;
+		case AST_ANCHOR_GPOS:
+			return 0;
+		case AST_BACKREF:
+			return INVALID_PATTERN~;
+		case AST_ATOMIC:
+		case AST_BRANCH_RESET:
+			return ast_fixed_width(node.left);
+		case AST_COND_GROUP:
+			usz cond_w_yes = ast_fixed_width(node.left)!;
+			usz cond_w_no = node.right != null ? ast_fixed_width(node.right)! : 0;
+			if (cond_w_yes != cond_w_no) return INVALID_PATTERN~;
+			return cond_w_yes;
+		default:
+			return INVALID_PATTERN~;
+	}
+}
+
+fn NfaFrag? build_nfa(BuildCtx* bctx, AstNode* node, RegexFlags flags)
+{
+	if (node == null) return frag_epsilon(bctx);
+
+	switch (node.kind)
+	{
+		case AST_LITERAL:
+			return frag_literal(bctx, node.codepoint);
+		case AST_CHARCLASS:
+			if ((flags & FLAG_DOTALL) != FLAG_NONE
+				&& node.char_class.ascii_bits == CLASS_DOT.ascii_bits
+				&& node.char_class.ranges_count == 0
+				&& !node.char_class.negated)
+			{
+				CharClass all = { .ascii_bits = ~(AsciiCharset)0 };
+				return frag_charset(bctx, all);
+			}
+			return frag_charset(bctx, node.char_class);
+		case AST_CONCAT:
+			if (node.left == null && node.right == null)
+			{
+				return frag_epsilon(bctx);
+			}
+			NfaFrag cl = build_nfa(bctx, node.left, flags)!;
+			NfaFrag cr = build_nfa(bctx, node.right, flags)!;
+			return frag_concat(cl, cr);
+		case AST_ALT:
+			NfaFrag al = build_nfa(bctx, node.left, flags)!;
+			NfaFrag ar = build_nfa(bctx, node.right, flags)!;
+			return frag_alt(bctx, al, ar);
+		case AST_STAR:
+			NfaFrag se = build_nfa(bctx, node.left, flags)!;
+			return frag_star(bctx, se, node.lazy);
+		case AST_PLUS:
+			NfaFrag pe = build_nfa(bctx, node.left, flags)!;
+			return frag_plus(bctx, pe, node.lazy);
+		case AST_QUEST:
+			NfaFrag qe = build_nfa(bctx, node.left, flags)!;
+			return frag_quest(bctx, qe, node.lazy);
+		case AST_REPEAT:
+			int min_v = node.repeat_min;
+			int max_v = node.repeat_max;
+			const int MAX_REPEAT = 1000;
+			if (min_v > MAX_REPEAT || (max_v > MAX_REPEAT && max_v != -1)) return COMPILE_ERROR~;
+			if (min_v == 0 && max_v == 0)
+			{
+				return frag_epsilon(bctx);
+			}
+			NfaFrag rep_result;
+			bool rep_first = true;
+			for (int i = 0; i < min_v; i++)
+			{
+				NfaFrag copy = build_nfa(bctx, node.left, flags)!;
+				if (rep_first) { rep_result = copy; rep_first = false; }
+				else { rep_result = frag_concat(rep_result, copy); }
+			}
+			if (max_v == -1)
+			{
+				NfaFrag tail = build_nfa(bctx, node.left, flags)!;
+				tail = frag_star(bctx, tail, node.lazy);
+				if (rep_first) { rep_result = tail; }
+				else { rep_result = frag_concat(rep_result, tail); }
+			}
+			else
+			{
+				for (int i = min_v; i < max_v; i++)
+				{
+					NfaFrag opt = build_nfa(bctx, node.left, flags)!;
+					opt = frag_quest(bctx, opt, node.lazy);
+					if (rep_first) { rep_result = opt; rep_first = false; }
+					else { rep_result = frag_concat(rep_result, opt); }
+				}
+			}
+			if (rep_first)
+			{
+				NfaFrag base0 = build_nfa(bctx, node.left, flags)!;
+				rep_result = frag_quest(bctx, base0, node.lazy);
+			}
+			return rep_result;
+		case AST_GROUP:
+			int gid = node.group_id;
+			NfaState* cs = nfa_new(bctx, STATE_CAPTURE_START);
+			cs.group_id = gid;
+			NfaFrag gi = build_nfa(bctx, node.left, flags)!;
+			NfaState* ce = nfa_new(bctx, STATE_CAPTURE_END);
+			ce.group_id = gid;
+			NfaFrag csf = frag_make(cs);
+			csf.out.tinit(1);
+			csf.out.push(&cs.out1);
+			NfaFrag cef = frag_make(ce);
+			cef.out.tinit(1);
+			cef.out.push(&ce.out1);
+			return frag_concat(frag_concat(csf, gi), cef);
+		case AST_NCGROUP:
+			if (node.left == null) return frag_epsilon(bctx);
+			return build_nfa(bctx, node.left, flags);
+		case AST_LOOKAHEAD_POS:
+		case AST_LOOKAHEAD_NEG:
+		case AST_LOOKBEHIND_POS:
+		case AST_LOOKBEHIND_NEG:
+			NfaFrag la_f = build_nfa(bctx, node.left, flags)!;
+			NfaState* la_match = nfa_new(bctx, STATE_MATCH);
+			frag_patch(&la_f, la_match);
+			la_f.out.free();
+			StateKind la_kind;
+			switch (node.kind)
+			{
+				case AST_LOOKAHEAD_POS: la_kind = STATE_LOOKAHEAD_POS;
+				case AST_LOOKAHEAD_NEG: la_kind = STATE_LOOKAHEAD_NEG;
+				case AST_LOOKBEHIND_POS: la_kind = STATE_LOOKBEHIND_POS;
+				case AST_LOOKBEHIND_NEG: la_kind = STATE_LOOKBEHIND_NEG;
+				default: unreachable();
+			}
+			NfaState* la_s = nfa_new(bctx, la_kind);
+			la_s.lookaround_start = la_f.start;
+			if (node.kind == AST_LOOKBEHIND_POS || node.kind == AST_LOOKBEHIND_NEG)
+			{
+				usz? w = ast_fixed_width(node.left);
+				if (try w)
+				{
+					la_s.lookbehind_len = w;
+					la_s.lookbehind_variable = false;
+				}
+				else
+				{
+					la_s.lookbehind_len = 0;
+					la_s.lookbehind_variable = true;
+				}
+			}
+			NfaFrag la_res = frag_make(la_s);
+			la_res.out.tinit(1);
+			la_res.out.push(&la_s.out1);
+			return la_res;
+		case AST_ANCHOR_START:
+			NfaState* anc_s = nfa_new(bctx, STATE_ANCHOR_START);
+			NfaFrag asf = frag_make(anc_s);
+			asf.out.tinit(1); asf.out.push(&anc_s.out1);
+			return asf;
+		case AST_ANCHOR_END:
+			NfaState* anc_e = nfa_new(bctx, STATE_ANCHOR_END);
+			NfaFrag aef = frag_make(anc_e);
+			aef.out.tinit(1); aef.out.push(&anc_e.out1);
+			return aef;
+		case AST_ANCHOR_ABSOLUTE_START:
+			NfaState* abs_s = nfa_new(bctx, STATE_ANCHOR_ABSOLUTE_START);
+			NfaFrag absf = frag_make(abs_s);
+			absf.out.tinit(1); absf.out.push(&abs_s.out1);
+			return absf;
+		case AST_ANCHOR_ABSOLUTE_END:
+			NfaState* abs_e = nfa_new(bctx, STATE_ANCHOR_ABSOLUTE_END);
+			NfaFrag abef = frag_make(abs_e);
+			abef.out.tinit(1); abef.out.push(&abs_e.out1);
+			return abef;
+		case AST_ANCHOR_ABSOLUTE_END_NL:
+			NfaState* abs_enl = nfa_new(bctx, STATE_ANCHOR_ABSOLUTE_END_NL);
+			NfaFrag abenlf = frag_make(abs_enl);
+			abenlf.out.tinit(1); abenlf.out.push(&abs_enl.out1);
+			return abenlf;
+		case AST_WORD_BOUND:
+			NfaState* wb = nfa_new(bctx, STATE_WORD_BOUND);
+			NfaFrag wbf = frag_make(wb);
+			wbf.out.tinit(1); wbf.out.push(&wb.out1);
+			return wbf;
+		case AST_WORD_NBOUND:
+			NfaState* wn = nfa_new(bctx, STATE_WORD_NBOUND);
+			NfaFrag wnf = frag_make(wn);
+			wnf.out.tinit(1); wnf.out.push(&wn.out1);
+			return wnf;
+		case AST_LINEBREAK:
+			return COMPILE_ERROR~;
+		case AST_KEEP:
+			NfaState* ks = nfa_new(bctx, STATE_KEEP);
+			NfaFrag kf = frag_make(ks);
+			kf.out.tinit(1); kf.out.push(&ks.out1);
+			return kf;
+		case AST_NON_NEWLINE:
+			return frag_charset(bctx, CLASS_DOT);
+		case AST_BACKREF:
+			NfaState* brs = nfa_new(bctx, STATE_BACKREF);
+			brs.backref_id = node.group_id;
+			NfaFrag brf = frag_make(brs);
+			brf.out.tinit(1); brf.out.push(&brs.out1);
+			return brf;
+		case AST_ATOMIC:
+			NfaFrag atm_f = build_nfa(bctx, node.left, flags)!;
+			NfaState* atm_match = nfa_new(bctx, STATE_MATCH);
+			frag_patch(&atm_f, atm_match);
+			atm_f.out.free();
+			NfaState* atm_s = nfa_new(bctx, STATE_ATOMIC);
+			atm_s.lookaround_start = atm_f.start;
+			NfaFrag atm_res = frag_make(atm_s);
+			atm_res.out.tinit(1); atm_res.out.push(&atm_s.out1);
+			return atm_res;
+		case AST_ANCHOR_GPOS:
+			NfaState* gpos_s = nfa_new(bctx, STATE_ANCHOR_GPOS);
+			NfaFrag gposf = frag_make(gpos_s);
+			gposf.out.tinit(1); gposf.out.push(&gpos_s.out1);
+			return gposf;
+		case AST_BRANCH_RESET:
+			if (node.left == null) return frag_epsilon(bctx);
+			return build_nfa(bctx, node.left, flags);
+		case AST_COND_GROUP:
+			NfaFrag cond_yes_f = build_nfa(bctx, node.left, flags)!;
+			NfaState* cond_yes_m = nfa_new(bctx, STATE_MATCH);
+			frag_patch(&cond_yes_f, cond_yes_m);
+			cond_yes_f.out.free();
+
+			NfaState* cond_no_entry;
+			if (node.right != null)
+			{
+				NfaFrag cond_no_f = build_nfa(bctx, node.right, flags)!;
+				NfaState* cond_no_m = nfa_new(bctx, STATE_MATCH);
+				frag_patch(&cond_no_f, cond_no_m);
+				cond_no_f.out.free();
+				cond_no_entry = cond_no_f.start;
+			}
+			else
+			{
+				NfaFrag cond_eps = frag_epsilon(bctx);
+				NfaState* cond_eps_m = nfa_new(bctx, STATE_MATCH);
+				frag_patch(&cond_eps, cond_eps_m);
+				cond_eps.out.free();
+				cond_no_entry = cond_eps.start;
+			}
+			NfaState* cond_s = nfa_new(bctx, STATE_COND_GROUP);
+			cond_s.backref_id = node.group_id;
+			cond_s.lookaround_start = cond_yes_f.start;
+			cond_s.out2 = cond_no_entry;
+			NfaFrag cond_res = frag_make(cond_s);
+			cond_res.out.tinit(1); cond_res.out.push(&cond_s.out1);
+			return cond_res;
+	}
+}

--- a/lib/std/regex/nfa.c3
+++ b/lib/std/regex/nfa.c3
@@ -4,73 +4,73 @@ module std::regex;
 // NFA construction — Thompson fragment model
 // ============================================================
 
-fn NfaState* nfa_new(BuildCtx* bctx, StateKind kind)
+fn RegexNfaState* nfa_new(RegexBuildCtx* bctx, RegexStateKind kind)
 {
-	NfaState* s = alloc::new(bctx.alloc, NfaState);
+	RegexNfaState* s = alloc::new(bctx.alloc, RegexNfaState);
 	s.kind = kind;
 	s.index = bctx.all_states.size;
 	bctx.all_states.push(s);
 	return s;
 }
 
-fn NfaFrag frag_make(NfaState* start)
+fn RegexNfaFrag frag_make(RegexNfaState* start)
 {
-	NfaFrag f;
+	RegexNfaFrag f;
 	f.start = start;
 	f.out.tinit(4);
 	return f;
 }
 
-fn NfaFrag frag_literal(BuildCtx* bctx, Char32 c)
+fn RegexNfaFrag frag_literal(RegexBuildCtx* bctx, Char32 c)
 {
-	NfaState* s = nfa_new(bctx, STATE_LITERAL);
+	RegexNfaState* s = nfa_new(bctx, STATE_LITERAL);
 	s.codepoint = c;
-	NfaFrag f = frag_make(s);
+	RegexNfaFrag f = frag_make(s);
 	f.out.push(&s.out1);
 	return f;
 }
 
-fn NfaFrag frag_charset(BuildCtx* bctx, CharClass cls)
+fn RegexNfaFrag frag_charset(RegexBuildCtx* bctx, RegexCharClass cls)
 {
-	NfaState* s = nfa_new(bctx, STATE_CHARSET);
+	RegexNfaState* s = nfa_new(bctx, STATE_CHARSET);
 	if (cls.ranges_count > 0)
 	{
 		usz pool_offset = bctx.range_pool.size;
 		for (usz i = 0; i < cls.ranges_count; i++) bctx.range_pool.push(cls.ranges[i]);
 		s.char_class = cls;
-		s.char_class.ranges = (UnicodeRange*)(uptr)pool_offset;
+		s.char_class.ranges = (RegexUnicodeRange*)(uptr)pool_offset;
 	}
 	else
 	{
 		s.char_class = cls;
 		s.char_class.ranges = null;
 	}
-	NfaFrag f = frag_make(s);
+	RegexNfaFrag f = frag_make(s);
 	f.out.push(&s.out1);
 	return f;
 }
 
-fn void frag_patch(NfaFrag* f, NfaState* target)
+fn void frag_patch(RegexNfaFrag* f, RegexNfaState* target)
 {
 	foreach (pp : f.out.array_view()) *pp = target;
 }
 
-fn NfaFrag frag_concat(NfaFrag e1, NfaFrag e2)
+fn RegexNfaFrag frag_concat(RegexNfaFrag e1, RegexNfaFrag e2)
 {
 	frag_patch(&e1, e2.start);
 	e1.out.free();
-	NfaFrag result;
+	RegexNfaFrag result;
 	result.start = e1.start;
 	result.out = e2.out;
 	return result;
 }
 
-fn NfaFrag frag_alt(BuildCtx* bctx, NfaFrag e1, NfaFrag e2)
+fn RegexNfaFrag frag_alt(RegexBuildCtx* bctx, RegexNfaFrag e1, RegexNfaFrag e2)
 {
-	NfaState* split = nfa_new(bctx, STATE_SPLIT);
+	RegexNfaState* split = nfa_new(bctx, STATE_SPLIT);
 	split.out1 = e1.start;
 	split.out2 = e2.start;
-	NfaFrag result;
+	RegexNfaFrag result;
 	result.start = split;
 	result.out.tinit(e1.out.size + e2.out.size);
 	foreach (pp : e1.out.array_view()) result.out.push(pp);
@@ -80,13 +80,13 @@ fn NfaFrag frag_alt(BuildCtx* bctx, NfaFrag e1, NfaFrag e2)
 	return result;
 }
 
-fn NfaFrag frag_star(BuildCtx* bctx, NfaFrag e, bool lazy)
+fn RegexNfaFrag frag_star(RegexBuildCtx* bctx, RegexNfaFrag e, bool lazy)
 {
-	NfaState* split = nfa_new(bctx, STATE_SPLIT);
+	RegexNfaState* split = nfa_new(bctx, STATE_SPLIT);
 	split.lazy = lazy;
 	frag_patch(&e, split);
 	e.out.free();
-	NfaFrag result;
+	RegexNfaFrag result;
 	result.start = split;
 	result.out.tinit(2);
 	if (lazy)
@@ -102,12 +102,12 @@ fn NfaFrag frag_star(BuildCtx* bctx, NfaFrag e, bool lazy)
 	return result;
 }
 
-fn NfaFrag frag_plus(BuildCtx* bctx, NfaFrag e, bool lazy)
+fn RegexNfaFrag frag_plus(RegexBuildCtx* bctx, RegexNfaFrag e, bool lazy)
 {
-	NfaState* split = nfa_new(bctx, STATE_SPLIT);
+	RegexNfaState* split = nfa_new(bctx, STATE_SPLIT);
 	split.lazy = lazy;
 	frag_patch(&e, split);
-	NfaFrag result;
+	RegexNfaFrag result;
 	result.start = e.start;
 	e.out.free();
 	result.out.tinit(2);
@@ -124,11 +124,11 @@ fn NfaFrag frag_plus(BuildCtx* bctx, NfaFrag e, bool lazy)
 	return result;
 }
 
-fn NfaFrag frag_quest(BuildCtx* bctx, NfaFrag e, bool lazy)
+fn RegexNfaFrag frag_quest(RegexBuildCtx* bctx, RegexNfaFrag e, bool lazy)
 {
-	NfaState* split = nfa_new(bctx, STATE_SPLIT);
+	RegexNfaState* split = nfa_new(bctx, STATE_SPLIT);
 	split.lazy = lazy;
-	NfaFrag result;
+	RegexNfaFrag result;
 	result.start = split;
 	result.out.tinit(e.out.size + 1);
 	if (lazy)
@@ -148,16 +148,16 @@ fn NfaFrag frag_quest(BuildCtx* bctx, NfaFrag e, bool lazy)
 
 // Epsilon fragment: a SPLIT state with one dangling out (out1) and null out2.
 // Use instead of STATE_MATCH for transparent pass-through nodes (empty groups, comments).
-fn NfaFrag frag_epsilon(BuildCtx* bctx)
+fn RegexNfaFrag frag_epsilon(RegexBuildCtx* bctx)
 {
-	NfaState* s = nfa_new(bctx, STATE_SPLIT);
-	NfaFrag f = frag_make(s);
+	RegexNfaState* s = nfa_new(bctx, STATE_SPLIT);
+	RegexNfaFrag f = frag_make(s);
 	f.out.tinit(1);
 	f.out.push(&s.out1);
 	return f;
 }
 
-fn usz? ast_fixed_width(AstNode* node)
+fn usz? ast_fixed_width(RegexAstNode* node)
 {
 	if (node == null) return 0;
 	switch (node.kind)
@@ -220,7 +220,7 @@ fn usz? ast_fixed_width(AstNode* node)
 	}
 }
 
-fn NfaFrag? build_nfa(BuildCtx* bctx, AstNode* node, RegexFlags flags)
+fn RegexNfaFrag? build_nfa(RegexBuildCtx* bctx, RegexAstNode* node, RegexFlags flags)
 {
 	if (node == null) return frag_epsilon(bctx);
 
@@ -234,7 +234,7 @@ fn NfaFrag? build_nfa(BuildCtx* bctx, AstNode* node, RegexFlags flags)
 				&& node.char_class.ranges_count == 0
 				&& !node.char_class.negated)
 			{
-				CharClass all = { .ascii_bits = ~(AsciiCharset)0 };
+				RegexCharClass all = { .ascii_bits = ~(AsciiCharset)0 };
 				return frag_charset(bctx, all);
 			}
 			return frag_charset(bctx, node.char_class);
@@ -243,21 +243,21 @@ fn NfaFrag? build_nfa(BuildCtx* bctx, AstNode* node, RegexFlags flags)
 			{
 				return frag_epsilon(bctx);
 			}
-			NfaFrag cl = build_nfa(bctx, node.left, flags)!;
-			NfaFrag cr = build_nfa(bctx, node.right, flags)!;
+			RegexNfaFrag cl = build_nfa(bctx, node.left, flags)!;
+			RegexNfaFrag cr = build_nfa(bctx, node.right, flags)!;
 			return frag_concat(cl, cr);
 		case AST_ALT:
-			NfaFrag al = build_nfa(bctx, node.left, flags)!;
-			NfaFrag ar = build_nfa(bctx, node.right, flags)!;
+			RegexNfaFrag al = build_nfa(bctx, node.left, flags)!;
+			RegexNfaFrag ar = build_nfa(bctx, node.right, flags)!;
 			return frag_alt(bctx, al, ar);
 		case AST_STAR:
-			NfaFrag se = build_nfa(bctx, node.left, flags)!;
+			RegexNfaFrag se = build_nfa(bctx, node.left, flags)!;
 			return frag_star(bctx, se, node.lazy);
 		case AST_PLUS:
-			NfaFrag pe = build_nfa(bctx, node.left, flags)!;
+			RegexNfaFrag pe = build_nfa(bctx, node.left, flags)!;
 			return frag_plus(bctx, pe, node.lazy);
 		case AST_QUEST:
-			NfaFrag qe = build_nfa(bctx, node.left, flags)!;
+			RegexNfaFrag qe = build_nfa(bctx, node.left, flags)!;
 			return frag_quest(bctx, qe, node.lazy);
 		case AST_REPEAT:
 			int min_v = node.repeat_min;
@@ -268,17 +268,17 @@ fn NfaFrag? build_nfa(BuildCtx* bctx, AstNode* node, RegexFlags flags)
 			{
 				return frag_epsilon(bctx);
 			}
-			NfaFrag rep_result;
+			RegexNfaFrag rep_result;
 			bool rep_first = true;
 			for (int i = 0; i < min_v; i++)
 			{
-				NfaFrag copy = build_nfa(bctx, node.left, flags)!;
+				RegexNfaFrag copy = build_nfa(bctx, node.left, flags)!;
 				if (rep_first) { rep_result = copy; rep_first = false; }
 				else { rep_result = frag_concat(rep_result, copy); }
 			}
 			if (max_v == -1)
 			{
-				NfaFrag tail = build_nfa(bctx, node.left, flags)!;
+				RegexNfaFrag tail = build_nfa(bctx, node.left, flags)!;
 				tail = frag_star(bctx, tail, node.lazy);
 				if (rep_first) { rep_result = tail; }
 				else { rep_result = frag_concat(rep_result, tail); }
@@ -287,7 +287,7 @@ fn NfaFrag? build_nfa(BuildCtx* bctx, AstNode* node, RegexFlags flags)
 			{
 				for (int i = min_v; i < max_v; i++)
 				{
-					NfaFrag opt = build_nfa(bctx, node.left, flags)!;
+					RegexNfaFrag opt = build_nfa(bctx, node.left, flags)!;
 					opt = frag_quest(bctx, opt, node.lazy);
 					if (rep_first) { rep_result = opt; rep_first = false; }
 					else { rep_result = frag_concat(rep_result, opt); }
@@ -295,21 +295,21 @@ fn NfaFrag? build_nfa(BuildCtx* bctx, AstNode* node, RegexFlags flags)
 			}
 			if (rep_first)
 			{
-				NfaFrag base0 = build_nfa(bctx, node.left, flags)!;
+				RegexNfaFrag base0 = build_nfa(bctx, node.left, flags)!;
 				rep_result = frag_quest(bctx, base0, node.lazy);
 			}
 			return rep_result;
 		case AST_GROUP:
 			int gid = node.group_id;
-			NfaState* cs = nfa_new(bctx, STATE_CAPTURE_START);
+			RegexNfaState* cs = nfa_new(bctx, STATE_CAPTURE_START);
 			cs.group_id = gid;
-			NfaFrag gi = build_nfa(bctx, node.left, flags)!;
-			NfaState* ce = nfa_new(bctx, STATE_CAPTURE_END);
+			RegexNfaFrag gi = build_nfa(bctx, node.left, flags)!;
+			RegexNfaState* ce = nfa_new(bctx, STATE_CAPTURE_END);
 			ce.group_id = gid;
-			NfaFrag csf = frag_make(cs);
+			RegexNfaFrag csf = frag_make(cs);
 			csf.out.tinit(1);
 			csf.out.push(&cs.out1);
-			NfaFrag cef = frag_make(ce);
+			RegexNfaFrag cef = frag_make(ce);
 			cef.out.tinit(1);
 			cef.out.push(&ce.out1);
 			return frag_concat(frag_concat(csf, gi), cef);
@@ -320,11 +320,11 @@ fn NfaFrag? build_nfa(BuildCtx* bctx, AstNode* node, RegexFlags flags)
 		case AST_LOOKAHEAD_NEG:
 		case AST_LOOKBEHIND_POS:
 		case AST_LOOKBEHIND_NEG:
-			NfaFrag la_f = build_nfa(bctx, node.left, flags)!;
-			NfaState* la_match = nfa_new(bctx, STATE_MATCH);
+			RegexNfaFrag la_f = build_nfa(bctx, node.left, flags)!;
+			RegexNfaState* la_match = nfa_new(bctx, STATE_MATCH);
 			frag_patch(&la_f, la_match);
 			la_f.out.free();
-			StateKind la_kind;
+			RegexStateKind la_kind;
 			switch (node.kind)
 			{
 				case AST_LOOKAHEAD_POS: la_kind = STATE_LOOKAHEAD_POS;
@@ -333,7 +333,7 @@ fn NfaFrag? build_nfa(BuildCtx* bctx, AstNode* node, RegexFlags flags)
 				case AST_LOOKBEHIND_NEG: la_kind = STATE_LOOKBEHIND_NEG;
 				default: unreachable();
 			}
-			NfaState* la_s = nfa_new(bctx, la_kind);
+			RegexNfaState* la_s = nfa_new(bctx, la_kind);
 			la_s.lookaround_start = la_f.start;
 			if (node.kind == AST_LOOKBEHIND_POS || node.kind == AST_LOOKBEHIND_NEG)
 			{
@@ -349,106 +349,106 @@ fn NfaFrag? build_nfa(BuildCtx* bctx, AstNode* node, RegexFlags flags)
 					la_s.lookbehind_variable = true;
 				}
 			}
-			NfaFrag la_res = frag_make(la_s);
+			RegexNfaFrag la_res = frag_make(la_s);
 			la_res.out.tinit(1);
 			la_res.out.push(&la_s.out1);
 			return la_res;
 		case AST_ANCHOR_START:
-			NfaState* anc_s = nfa_new(bctx, STATE_ANCHOR_START);
-			NfaFrag asf = frag_make(anc_s);
+			RegexNfaState* anc_s = nfa_new(bctx, STATE_ANCHOR_START);
+			RegexNfaFrag asf = frag_make(anc_s);
 			asf.out.tinit(1); asf.out.push(&anc_s.out1);
 			return asf;
 		case AST_ANCHOR_END:
-			NfaState* anc_e = nfa_new(bctx, STATE_ANCHOR_END);
-			NfaFrag aef = frag_make(anc_e);
+			RegexNfaState* anc_e = nfa_new(bctx, STATE_ANCHOR_END);
+			RegexNfaFrag aef = frag_make(anc_e);
 			aef.out.tinit(1); aef.out.push(&anc_e.out1);
 			return aef;
 		case AST_ANCHOR_ABSOLUTE_START:
-			NfaState* abs_s = nfa_new(bctx, STATE_ANCHOR_ABSOLUTE_START);
-			NfaFrag absf = frag_make(abs_s);
+			RegexNfaState* abs_s = nfa_new(bctx, STATE_ANCHOR_ABSOLUTE_START);
+			RegexNfaFrag absf = frag_make(abs_s);
 			absf.out.tinit(1); absf.out.push(&abs_s.out1);
 			return absf;
 		case AST_ANCHOR_ABSOLUTE_END:
-			NfaState* abs_e = nfa_new(bctx, STATE_ANCHOR_ABSOLUTE_END);
-			NfaFrag abef = frag_make(abs_e);
+			RegexNfaState* abs_e = nfa_new(bctx, STATE_ANCHOR_ABSOLUTE_END);
+			RegexNfaFrag abef = frag_make(abs_e);
 			abef.out.tinit(1); abef.out.push(&abs_e.out1);
 			return abef;
 		case AST_ANCHOR_ABSOLUTE_END_NL:
-			NfaState* abs_enl = nfa_new(bctx, STATE_ANCHOR_ABSOLUTE_END_NL);
-			NfaFrag abenlf = frag_make(abs_enl);
+			RegexNfaState* abs_enl = nfa_new(bctx, STATE_ANCHOR_ABSOLUTE_END_NL);
+			RegexNfaFrag abenlf = frag_make(abs_enl);
 			abenlf.out.tinit(1); abenlf.out.push(&abs_enl.out1);
 			return abenlf;
 		case AST_WORD_BOUND:
-			NfaState* wb = nfa_new(bctx, STATE_WORD_BOUND);
-			NfaFrag wbf = frag_make(wb);
+			RegexNfaState* wb = nfa_new(bctx, STATE_WORD_BOUND);
+			RegexNfaFrag wbf = frag_make(wb);
 			wbf.out.tinit(1); wbf.out.push(&wb.out1);
 			return wbf;
 		case AST_WORD_NBOUND:
-			NfaState* wn = nfa_new(bctx, STATE_WORD_NBOUND);
-			NfaFrag wnf = frag_make(wn);
+			RegexNfaState* wn = nfa_new(bctx, STATE_WORD_NBOUND);
+			RegexNfaFrag wnf = frag_make(wn);
 			wnf.out.tinit(1); wnf.out.push(&wn.out1);
 			return wnf;
 		case AST_LINEBREAK:
 			return COMPILE_ERROR~;
 		case AST_KEEP:
-			NfaState* ks = nfa_new(bctx, STATE_KEEP);
-			NfaFrag kf = frag_make(ks);
+			RegexNfaState* ks = nfa_new(bctx, STATE_KEEP);
+			RegexNfaFrag kf = frag_make(ks);
 			kf.out.tinit(1); kf.out.push(&ks.out1);
 			return kf;
 		case AST_NON_NEWLINE:
 			return frag_charset(bctx, CLASS_DOT);
 		case AST_BACKREF:
-			NfaState* brs = nfa_new(bctx, STATE_BACKREF);
+			RegexNfaState* brs = nfa_new(bctx, STATE_BACKREF);
 			brs.backref_id = node.group_id;
-			NfaFrag brf = frag_make(brs);
+			RegexNfaFrag brf = frag_make(brs);
 			brf.out.tinit(1); brf.out.push(&brs.out1);
 			return brf;
 		case AST_ATOMIC:
-			NfaFrag atm_f = build_nfa(bctx, node.left, flags)!;
-			NfaState* atm_match = nfa_new(bctx, STATE_MATCH);
+			RegexNfaFrag atm_f = build_nfa(bctx, node.left, flags)!;
+			RegexNfaState* atm_match = nfa_new(bctx, STATE_MATCH);
 			frag_patch(&atm_f, atm_match);
 			atm_f.out.free();
-			NfaState* atm_s = nfa_new(bctx, STATE_ATOMIC);
+			RegexNfaState* atm_s = nfa_new(bctx, STATE_ATOMIC);
 			atm_s.lookaround_start = atm_f.start;
-			NfaFrag atm_res = frag_make(atm_s);
+			RegexNfaFrag atm_res = frag_make(atm_s);
 			atm_res.out.tinit(1); atm_res.out.push(&atm_s.out1);
 			return atm_res;
 		case AST_ANCHOR_GPOS:
-			NfaState* gpos_s = nfa_new(bctx, STATE_ANCHOR_GPOS);
-			NfaFrag gposf = frag_make(gpos_s);
+			RegexNfaState* gpos_s = nfa_new(bctx, STATE_ANCHOR_GPOS);
+			RegexNfaFrag gposf = frag_make(gpos_s);
 			gposf.out.tinit(1); gposf.out.push(&gpos_s.out1);
 			return gposf;
 		case AST_BRANCH_RESET:
 			if (node.left == null) return frag_epsilon(bctx);
 			return build_nfa(bctx, node.left, flags);
 		case AST_COND_GROUP:
-			NfaFrag cond_yes_f = build_nfa(bctx, node.left, flags)!;
-			NfaState* cond_yes_m = nfa_new(bctx, STATE_MATCH);
+			RegexNfaFrag cond_yes_f = build_nfa(bctx, node.left, flags)!;
+			RegexNfaState* cond_yes_m = nfa_new(bctx, STATE_MATCH);
 			frag_patch(&cond_yes_f, cond_yes_m);
 			cond_yes_f.out.free();
 
-			NfaState* cond_no_entry;
+			RegexNfaState* cond_no_entry;
 			if (node.right != null)
 			{
-				NfaFrag cond_no_f = build_nfa(bctx, node.right, flags)!;
-				NfaState* cond_no_m = nfa_new(bctx, STATE_MATCH);
+				RegexNfaFrag cond_no_f = build_nfa(bctx, node.right, flags)!;
+				RegexNfaState* cond_no_m = nfa_new(bctx, STATE_MATCH);
 				frag_patch(&cond_no_f, cond_no_m);
 				cond_no_f.out.free();
 				cond_no_entry = cond_no_f.start;
 			}
 			else
 			{
-				NfaFrag cond_eps = frag_epsilon(bctx);
-				NfaState* cond_eps_m = nfa_new(bctx, STATE_MATCH);
+				RegexNfaFrag cond_eps = frag_epsilon(bctx);
+				RegexNfaState* cond_eps_m = nfa_new(bctx, STATE_MATCH);
 				frag_patch(&cond_eps, cond_eps_m);
 				cond_eps.out.free();
 				cond_no_entry = cond_eps.start;
 			}
-			NfaState* cond_s = nfa_new(bctx, STATE_COND_GROUP);
+			RegexNfaState* cond_s = nfa_new(bctx, STATE_COND_GROUP);
 			cond_s.backref_id = node.group_id;
 			cond_s.lookaround_start = cond_yes_f.start;
 			cond_s.out2 = cond_no_entry;
-			NfaFrag cond_res = frag_make(cond_s);
+			RegexNfaFrag cond_res = frag_make(cond_s);
 			cond_res.out.tinit(1); cond_res.out.push(&cond_s.out1);
 			return cond_res;
 	}

--- a/lib/std/regex/parser.c3
+++ b/lib/std/regex/parser.c3
@@ -1,0 +1,897 @@
+module std::regex;
+import std::core::string::conv;
+import std::core::string::iterator;
+import std::core::ascii;
+
+// ============================================================
+// Parser helpers
+// ============================================================
+
+macro bool @at_end(ParseCtx* ctx) => ctx.pos >= ctx.pattern.len;
+
+macro char @peek(ParseCtx* ctx)
+{
+	if (ctx.pos >= ctx.pattern.len) return 0;
+	return ctx.pattern[ctx.pos];
+}
+
+macro char @peek2(ParseCtx* ctx)
+{
+	if (ctx.pos + 1 >= ctx.pattern.len) return 0;
+	return ctx.pattern[ctx.pos + 1];
+}
+
+macro char @consume(ParseCtx* ctx)
+{
+	char c = ctx.pattern[ctx.pos];
+	ctx.pos++;
+	return c;
+}
+
+macro bool @try_consume(ParseCtx* ctx, char c)
+{
+	if (ctx.pos < ctx.pattern.len && ctx.pattern[ctx.pos] == c)
+	{
+		ctx.pos++;
+		return true;
+	}
+	return false;
+}
+
+fn void skip_freespacing(ParseCtx* ctx) @local @inline
+{
+	if ((ctx.flags & FLAG_EXTENDED) == FLAG_NONE) return;
+	while (!@at_end(ctx))
+	{
+		char c = ctx.pattern[ctx.pos];
+		if (c == '#')
+		{
+			// Skip to end of line
+			while (!@at_end(ctx) && ctx.pattern[ctx.pos] != '\n') ctx.pos++;
+		}
+		else if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+		{
+			ctx.pos++;
+		}
+		else
+		{
+			break;
+		}
+	}
+}
+
+fn AstNode* ast_new(AstKind kind)
+{
+	AstNode* n = alloc::new(tmem, AstNode);
+	n.kind = kind;
+	n.group_id = -1;
+	return n;
+}
+
+fn void ctx_push_named_group(ParseCtx* ctx, NamedGroupEntry entry)
+{
+	if (ctx.named_groups_count >= ctx.named_groups_cap)
+	{
+		usz new_cap = ctx.named_groups_cap ? ctx.named_groups_cap * 2 : 8;
+		NamedGroupEntry* buf = alloc::new_array(tmem, NamedGroupEntry, new_cap);
+		if (ctx.named_groups_buf)
+		{
+			mem::copy(buf, ctx.named_groups_buf, ctx.named_groups_count * NamedGroupEntry.sizeof);
+		}
+		ctx.named_groups_buf = buf;
+		ctx.named_groups_cap = new_cap;
+	}
+	ctx.named_groups_buf[ctx.named_groups_count++] = entry;
+}
+
+// ============================================================
+// Parse hex digits for \uXXXX / \UXXXXXXXX
+// ============================================================
+
+// Read the next full Unicode codepoint from ctx.pattern at ctx.pos (UTF-8 aware).
+fn Char32? parse_codepoint(ParseCtx* ctx) @local @inline
+{
+	if (ctx.pos >= ctx.pattern.len) return INVALID_PATTERN~;
+	StringIterator it = { .utf8 = ctx.pattern, .current = ctx.pos };
+	Char32 cp = it.next()!;
+	ctx.pos = it.current;
+	return cp;
+}
+
+// Parse \x{HH...} braced hex escape (1+ hex digits). Caller must have already consumed '{'.
+fn Char32? parse_hex_escape_braced(ParseCtx* ctx) @local
+{
+	if (@at_end(ctx) || @peek(ctx) == '}') return INVALID_PATTERN~;
+	Char32 val = 0;
+	bool has_digits = false;
+	while (!@at_end(ctx) && @peek(ctx) != '}')
+	{
+		char hc = @consume(ctx);
+		if (!ascii::is_xdigit(hc)) return INVALID_PATTERN~;
+		val = val * 16 + (Char32)hc.from_hex();
+		has_digits = true;
+	}
+	if (!has_digits || !@try_consume(ctx, '}')) return INVALID_PATTERN~;
+	if (val > 0x10FFFF) return INVALID_PATTERN~;
+	return val;
+}
+
+fn Char32? parse_hex_escape(ParseCtx* ctx, int digits)
+{
+	uint val = 0;
+	for (int i = 0; i < digits; i++)
+	{
+		if (@at_end(ctx)) return INVALID_PATTERN~;
+		char c = @consume(ctx);
+		if (!ascii::is_xdigit(c)) return INVALID_PATTERN~;
+		val = val * 16 + (uint)c.from_hex();
+	}
+	return (Char32)val;
+}
+
+fn Char32? parse_classchar(ParseCtx* ctx)
+{
+	if (@at_end(ctx)) return INVALID_PATTERN~;
+	char c = ctx.pattern[ctx.pos];
+	if (c != '\\')
+	{
+		return parse_codepoint(ctx)!;
+	}
+	ctx.pos++;
+	if (@at_end(ctx)) return INVALID_PATTERN~;
+	char esc = @consume(ctx);
+	switch (esc)
+	{
+		case 'n': return '\n';
+		case 'r': return '\r';
+		case 't': return '\t';
+		case 'f': return '\f';
+		case 'v': return '\v';
+		case 'a': return '\a';
+		case 'e': return 0x1B;
+		case '\\': return '\\';
+		case ']': return ']';
+		case '-': return '-';
+		case '^': return '^';
+		case 'u': return parse_hex_escape(ctx, 4);
+		case 'U': return parse_hex_escape(ctx, 8);
+		case 'x':
+			if (@peek(ctx) == '{') { ctx.pos++; return parse_hex_escape_braced(ctx); }
+			return parse_hex_escape(ctx, 2);
+		case 'c':
+			if (@at_end(ctx)) return INVALID_PATTERN~;
+			char ctrl_cc = @consume(ctx);
+			if (ctrl_cc >= '@' && ctrl_cc <= '_') return (Char32)(ctrl_cc ^ 64);
+			if (ctrl_cc >= 'a' && ctrl_cc <= 'z') return (Char32)((ctrl_cc - 0x20) ^ 64);
+			return INVALID_PATTERN~;
+		case '0': return 0;
+		default:  return (Char32)esc;
+	}
+}
+
+fn void charclass_add_range(CharClass* cls, TempRangeList* unicode, Char32 lo, Char32 hi)
+{
+	if (lo < 128)
+	{
+		Char32 ascii_hi = hi < 127 ? hi : 127;
+		for (Char32 cp = lo; cp <= ascii_hi; cp++) cls.ascii_bits |= (AsciiCharset)1 << (char)cp;
+		if (hi < 128) return;
+		lo = 128;
+	}
+	unicode.push({ .lo = lo, .hi = hi });
+}
+
+fn void charclass_merge_set(CharClass* cls, AsciiCharset set)
+{
+	cls.ascii_bits |= set;
+}
+
+fn void charclass_merge_property(CharClass* cls, UnicodePropMask prop)
+{
+	cls.props |= prop;
+}
+
+fn void charclass_merge_complement_property(CharClass* cls, UnicodePropMask prop)
+{
+	cls.complement_props |= prop;
+}
+
+fn UnicodePropMask? parse_unicode_property_name(ParseCtx* ctx)
+{
+	if (!@try_consume(ctx, '{')) return INVALID_PATTERN~;
+	usz name_start = ctx.pos;
+	while (!@at_end(ctx) && @peek(ctx) != '}') ctx.pos++;
+	if (!@try_consume(ctx, '}')) return INVALID_PATTERN~;
+	String name = ctx.pattern[name_start : ctx.pos - name_start - 1];
+	switch (name)
+	{
+		case "ASCII": return PROP_ASCII;
+		case "White_Space":
+		case "space":
+		case "Space":
+		case "Xps": return PROP_WHITE_SPACE;
+		case "Horiz_Space":
+		case "HSpace":
+		case "hspace": return PROP_HSPACE;
+		case "Vert_Space":
+		case "VSpace":
+		case "vspace": return PROP_VSPACE;
+		case "Word":
+		case "word":
+		case "Xwd": return PROP_WORD;
+		default: return INVALID_PATTERN~;
+	}
+}
+
+fn CharClass? parse_property_charclass(ParseCtx* ctx, bool negated)
+{
+	UnicodePropMask prop = parse_unicode_property_name(ctx)!;
+	CharClass cls = { .props = prop, .negated = negated };
+	if (prop == PROP_ASCII) cls.ascii_bits = ~(AsciiCharset)0;
+	return cls;
+}
+
+fn bool? parse_posix_bracket(ParseCtx* ctx, CharClass* cls)
+{
+	if (@peek(ctx) != ':') return false;
+	usz saved = ctx.pos;
+	ctx.pos++;
+	usz name_start = ctx.pos;
+	while (!@at_end(ctx) && @peek(ctx) != ':' && @peek(ctx) != ']') ctx.pos++;
+	if (@at_end(ctx) || @peek(ctx) != ':') { ctx.pos = saved; return false; }
+	String name = ctx.pattern[name_start : ctx.pos - name_start];
+	ctx.pos++;
+	if (@at_end(ctx) || @peek(ctx) != ']') { ctx.pos = saved; return false; }
+	ctx.pos++;
+
+	switch (name)
+	{
+		case "alpha":  charclass_merge_set(cls, ascii::ALPHA_SET);
+		case "digit":  charclass_merge_set(cls, ascii::NUMBER_SET);
+		case "lower":  charclass_merge_set(cls, ascii::ALPHA_LOWER_SET);
+		case "upper":  charclass_merge_set(cls, ascii::ALPHA_UPPER_SET);
+		case "space":  charclass_merge_set(cls, ascii::WHITESPACE_SET);
+		case "alnum":  charclass_merge_set(cls, ascii::ALPHANUMERIC_SET);
+		case "blank":  charclass_merge_set(cls, BLANK_SET);
+		case "punct":  charclass_merge_set(cls, PUNCT_SET);
+		case "cntrl":  charclass_merge_set(cls, CNTRL_SET);
+		case "graph":  charclass_merge_set(cls, GRAPH_SET);
+		case "print":  charclass_merge_set(cls, PRINT_SET);
+		case "xdigit": charclass_merge_set(cls, XDIGIT_SET);
+		case "word":   charclass_merge_set(cls, WORD_SET);
+		default:       ctx.pos = saved; return false;
+	}
+	return true;
+}
+
+fn AstNode*? parse_charclass_body(ParseCtx* ctx)
+{
+	CharClass cls = {};
+	TempRangeList unicode;
+	unicode.tinit(4);
+	defer unicode.free();
+
+	bool negated = false;
+	if (@try_consume(ctx, '^')) negated = true;
+
+	bool first = true;
+	while (true)
+	{
+		if (@at_end(ctx)) return INVALID_PATTERN~;
+		char c = @peek(ctx);
+		if (c == ']' && !first) break;
+		first = false;
+
+		if (c == '[')
+		{
+			ctx.pos++;
+			bool? matched = parse_posix_bracket(ctx, &cls);
+			if (catch matched) return INVALID_PATTERN~;
+			if (matched) continue;
+			charclass_add_range(&cls, &unicode, '[', '[');
+			continue;
+		}
+
+		if (c == '\\' && ctx.pos + 1 < ctx.pattern.len)
+		{
+			char esc = ctx.pattern[ctx.pos + 1];
+			switch (esc)
+			{
+				case 'd': charclass_merge_set(&cls, ascii::NUMBER_SET);         charclass_merge_property(&cls, PROP_DIGIT);       ctx.pos += 2; continue;
+				case 'D': charclass_merge_complement_property(&cls, PROP_DIGIT);                                                       ctx.pos += 2; continue;
+				case 'w': charclass_merge_set(&cls, WORD_SET);                  charclass_merge_property(&cls, PROP_WORD);        ctx.pos += 2; continue;
+				case 'W': charclass_merge_complement_property(&cls, PROP_WORD);                                                        ctx.pos += 2; continue;
+				case 's': charclass_merge_set(&cls, ascii::WHITESPACE_SET);     charclass_merge_property(&cls, PROP_WHITE_SPACE); ctx.pos += 2; continue;
+				case 'S': charclass_merge_complement_property(&cls, PROP_WHITE_SPACE);                                                 ctx.pos += 2; continue;
+				case 'h': charclass_merge_set(&cls, HSPACE_SET);                charclass_merge_property(&cls, PROP_HSPACE);      ctx.pos += 2; continue;
+				case 'H': charclass_merge_complement_property(&cls, PROP_HSPACE);                                                     ctx.pos += 2; continue;
+				case 'v': charclass_merge_set(&cls, VSPACE_SET);                charclass_merge_property(&cls, PROP_VSPACE);      ctx.pos += 2; continue;
+				case 'V': charclass_merge_complement_property(&cls, PROP_VSPACE);                                                     ctx.pos += 2; continue;
+				case 'p':
+					ctx.pos += 2;
+					CharClass pcls = parse_property_charclass(ctx, false)!;
+					cls.ascii_bits |= pcls.ascii_bits;
+					cls.props |= pcls.props;
+					continue;
+				case 'P':
+					ctx.pos += 2;
+					CharClass p_inv = parse_property_charclass(ctx, true)!;
+					cls.complement_props |= p_inv.props;
+					continue;
+				default: break;
+			}
+		}
+
+		Char32 lo = parse_classchar(ctx)!;
+		if (@peek(ctx) == '-' && ctx.pos + 1 < ctx.pattern.len && ctx.pattern[ctx.pos + 1] != ']')
+		{
+			ctx.pos++;
+			Char32 hi = parse_classchar(ctx)!;
+			if (hi < lo) return INVALID_PATTERN~;
+			charclass_add_range(&cls, &unicode, lo, hi);
+		}
+		else
+		{
+			charclass_add_range(&cls, &unicode, lo, lo);
+		}
+	}
+	ctx.pos++;
+	cls.negated = negated;
+
+	// Copy unicode ranges into tmem (moved to range_pool during NFA build)
+	UnicodeRange* tmp_ranges = null;
+	usz tmp_count = unicode.size;
+	if (tmp_count > 0)
+	{
+		tmp_ranges = alloc::new_array(tmem, UnicodeRange, tmp_count);
+		mem::copy(tmp_ranges, unicode.entries, tmp_count * UnicodeRange.sizeof);
+	}
+	cls.ranges = tmp_ranges;
+	cls.ranges_count = tmp_count;
+
+	AstNode* n = ast_new(AST_CHARCLASS);
+	n.char_class = cls;
+	return n;
+}
+
+// ============================================================
+// Recursive descent parser
+// ============================================================
+
+fn AstNode*? parse_expr(ParseCtx* ctx) => parse_alt(ctx);
+
+fn AstNode*? parse_alt(ParseCtx* ctx)
+{
+	AstNode* left = parse_concat(ctx)!;
+	skip_freespacing(ctx);
+	while (@peek(ctx) == '|')
+	{
+		ctx.pos++;
+		AstNode* right = parse_concat(ctx)!;
+		AstNode* n = ast_new(AST_ALT);
+		n.left  = left;
+		n.right = right;
+		left = n;
+		skip_freespacing(ctx);
+	}
+	return left;
+}
+
+fn AstNode*? parse_concat(ParseCtx* ctx)
+{
+	AstNode* result = null;
+	while (true)
+	{
+		skip_freespacing(ctx);
+		char c = @peek(ctx);
+		if (c == '|' || c == ')' || c == 0) break;
+		AstNode* atom = parse_quantifier(ctx)!;
+		if (result == null)
+		{
+			result = atom;
+		}
+		else
+		{
+			AstNode* n = ast_new(AST_CONCAT);
+			n.left  = result;
+			n.right = atom;
+			result = n;
+		}
+	}
+	if (result == null)
+	{
+		// Empty alternative — epsilon node
+		result = ast_new(AST_CONCAT);
+		result.left = null;
+		result.right = null;
+	}
+	return result;
+}
+
+fn bool ast_can_consume(AstNode* node) @local
+{
+	if (node == null) return false;
+	switch (node.kind)
+	{
+		case AST_LITERAL:
+		case AST_CHARCLASS:
+		case AST_LINEBREAK:
+		case AST_NON_NEWLINE:
+		case AST_BACKREF:
+			return true;
+		case AST_CONCAT:
+		case AST_ALT:
+			return ast_can_consume(node.left) || ast_can_consume(node.right);
+		case AST_GROUP:
+		case AST_NCGROUP:
+		case AST_ATOMIC:
+		case AST_BRANCH_RESET:
+			return ast_can_consume(node.left);
+		case AST_REPEAT:
+			return node.repeat_max != 0 && ast_can_consume(node.left);
+		case AST_STAR:
+		case AST_PLUS:
+		case AST_QUEST:
+			return ast_can_consume(node.left);
+		case AST_COND_GROUP:
+			return ast_can_consume(node.left) || (node.right != null && ast_can_consume(node.right));
+		case AST_ANCHOR_START:
+		case AST_ANCHOR_END:
+		case AST_ANCHOR_ABSOLUTE_START:
+		case AST_ANCHOR_ABSOLUTE_END:
+		case AST_ANCHOR_ABSOLUTE_END_NL:
+		case AST_WORD_BOUND:
+		case AST_WORD_NBOUND:
+		case AST_LOOKAHEAD_POS:
+		case AST_LOOKAHEAD_NEG:
+		case AST_LOOKBEHIND_POS:
+		case AST_LOOKBEHIND_NEG:
+		case AST_KEEP:
+		case AST_ANCHOR_GPOS:
+			return false;
+		default:
+			return false;
+	}
+}
+
+fn AstNode*? parse_quantifier(ParseCtx* ctx)
+{
+	AstNode* atom = parse_atom(ctx)!;
+	skip_freespacing(ctx);
+	char c = @peek(ctx);
+	AstNode* q = null;
+	switch (c)
+	{
+		case '*':
+			if (!ast_can_consume(atom)) return INVALID_PATTERN~;
+			ctx.pos++;
+			q = ast_new(AST_STAR);
+			q.left = atom;
+		case '+':
+			if (!ast_can_consume(atom)) return INVALID_PATTERN~;
+			ctx.pos++;
+			q = ast_new(AST_PLUS);
+			q.left = atom;
+		case '?':
+			if (!ast_can_consume(atom)) return INVALID_PATTERN~;
+			ctx.pos++;
+			q = ast_new(AST_QUEST);
+			q.left = atom;
+		case '{':
+			if (!ast_can_consume(atom)) return INVALID_PATTERN~;
+			q = parse_repeat_quantifier(ctx, atom)!;
+		default:
+			return atom;
+	}
+	// Check for possessive + suffix (before lazy ?) — wraps the quantifier in an atomic group
+	if (@peek(ctx) == '+')
+	{
+		ctx.pos++;
+		AstNode* poss = ast_new(AST_ATOMIC);
+		poss.left = q;
+		return poss;
+	}
+	bool has_lazy_suffix = @try_consume(ctx, '?');
+	bool ungreedy = (ctx.flags & FLAG_UNGREEDY) != FLAG_NONE;
+	q.lazy = has_lazy_suffix ^ ungreedy;
+	return q;
+}
+
+fn AstNode*? parse_repeat_quantifier(ParseCtx* ctx, AstNode* atom)
+{
+	usz saved = ctx.pos;
+	ctx.pos++;
+
+	int min_val = 0;
+	bool has_digits = false;
+	while (@peek(ctx) >= '0' && @peek(ctx) <= '9')
+	{
+		min_val = min_val * 10 + (@consume(ctx) - '0');
+		has_digits = true;
+		if (min_val > 1000) return COMPILE_ERROR~;
+	}
+	if (!has_digits) { ctx.pos = saved; return INVALID_PATTERN~; }
+
+	int max_val;
+	if (@try_consume(ctx, ','))
+	{
+		if (@peek(ctx) == '}')
+		{
+			max_val = -1;
+		}
+		else
+		{
+			max_val = 0;
+			bool has_max = false;
+			while (@peek(ctx) >= '0' && @peek(ctx) <= '9')
+			{
+				max_val = max_val * 10 + (@consume(ctx) - '0');
+				has_max = true;
+				if (max_val > 1000) return COMPILE_ERROR~;
+			}
+			if (!has_max) { ctx.pos = saved; return INVALID_PATTERN~; }
+		}
+	}
+	else
+	{
+		max_val = min_val;
+	}
+
+	if (@peek(ctx) != '}') { ctx.pos = saved; return INVALID_PATTERN~; }
+	ctx.pos++;
+	if (max_val != -1 && max_val < min_val) return INVALID_PATTERN~;
+
+	AstNode* n = ast_new(AST_REPEAT);
+	n.left       = atom;
+	n.repeat_min = min_val;
+	n.repeat_max = max_val;
+	return n;
+}
+
+fn AstNode*? parse_atom(ParseCtx* ctx)
+{
+	if (@at_end(ctx)) return INVALID_PATTERN~;
+	char c = @consume(ctx);
+	switch (c)
+	{
+		case '(':
+			return parse_group(ctx);
+		case '[':
+			return parse_charclass_body(ctx);
+		case '.':
+			AstNode* dot = ast_new(AST_CHARCLASS);
+			dot.char_class = CLASS_DOT;
+			return dot;
+		case '^':
+			return ast_new(AST_ANCHOR_START);
+		case '$':
+			return ast_new(AST_ANCHOR_END);
+		case '\\':
+			return parse_escape_atom(ctx);
+		default:
+			// Back up and re-read as full UTF-8 codepoint (handles multi-byte sequences)
+			ctx.pos--;
+			AstNode* lit = ast_new(AST_LITERAL);
+			lit.codepoint = parse_codepoint(ctx)!;
+			return lit;
+	}
+}
+
+fn AstNode*? parse_group(ParseCtx* ctx)
+{
+	char c = @peek(ctx);
+	if (c == '?')
+	{
+		ctx.pos++;
+		char kind = @peek(ctx);
+		switch (kind)
+		{
+			case '#':
+				// (?#comment) — skip to closing )
+				ctx.pos++;
+				while (!@at_end(ctx) && @peek(ctx) != ')') ctx.pos++;
+				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+				AstNode* comment_eps = ast_new(AST_NCGROUP);
+				comment_eps.left = null;
+				return comment_eps;
+			case ':':
+				ctx.pos++;
+				AstNode* inner = parse_expr(ctx)!;
+				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+				AstNode* ncg = ast_new(AST_NCGROUP);
+				ncg.left = inner;
+				return ncg;
+			case '=':
+				ctx.pos++;
+				AstNode* la_inner = parse_expr(ctx)!;
+				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+				AstNode* lap = ast_new(AST_LOOKAHEAD_POS);
+				lap.left = la_inner;
+				return lap;
+			case '!':
+				ctx.pos++;
+				AstNode* lna_inner = parse_expr(ctx)!;
+				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+				AstNode* lan = ast_new(AST_LOOKAHEAD_NEG);
+				lan.left = lna_inner;
+				return lan;
+			case '|':
+				// (?|...) — branch reset group: each alternative reuses the same group IDs
+				ctx.pos++;
+				int breset_base = ctx.next_group_id;
+				int breset_max = breset_base;
+				AstNode* br_result = null;
+				while (true)
+				{
+					ctx.next_group_id = breset_base;
+					AstNode* br_branch = parse_concat(ctx)!;
+					if (ctx.next_group_id > breset_max) breset_max = ctx.next_group_id;
+					if (br_result == null) { br_result = br_branch; }
+					else { AstNode* bra = ast_new(AST_ALT); bra.left = br_result; bra.right = br_branch; br_result = bra; }
+					if (!@try_consume(ctx, '|')) break;
+				}
+				ctx.next_group_id = breset_max;
+				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+				AstNode* br_ncg = ast_new(AST_BRANCH_RESET); br_ncg.left = br_result; return br_ncg;
+			case '(':
+				// (?(N)yes|no) or (?(name)yes|no) — conditional pattern
+				ctx.pos++;
+				int cond_gid = -1;
+				if (@peek(ctx) >= '1' && @peek(ctx) <= '9')
+				{
+					cond_gid = 0;
+					while (@peek(ctx) >= '0' && @peek(ctx) <= '9') { cond_gid = cond_gid * 10 + (@consume(ctx) - '0'); }
+				}
+				else
+				{
+					usz cond_name_start = ctx.pos;
+					while (!@at_end(ctx) && @peek(ctx) != ')') ctx.pos++;
+					String cond_name = ctx.pattern[cond_name_start : ctx.pos - cond_name_start];
+					if (cond_name.len == 0) return INVALID_PATTERN~;
+					for (usz ci = 0; ci < ctx.named_groups_count; ci++)
+					{
+						if (ctx.named_groups_buf[ci].name == cond_name) { cond_gid = ctx.named_groups_buf[ci].group_id; break; }
+					}
+					if (cond_gid < 0) return INVALID_PATTERN~;
+				}
+				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+				AstNode* cond_yes = parse_concat(ctx)!;
+				AstNode* cond_no = null;
+				if (@try_consume(ctx, '|')) cond_no = parse_concat(ctx)!;
+				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+				AstNode* cond_node = ast_new(AST_COND_GROUP);
+				cond_node.group_id = cond_gid;
+				cond_node.left = cond_yes;
+				cond_node.right = cond_no;
+				return cond_node;
+			case '>':
+				// (?>...) — atomic group
+				ctx.pos++;
+				AstNode* atm_inner = parse_expr(ctx)!;
+				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+				AstNode* atm = ast_new(AST_ATOMIC);
+				atm.left = atm_inner;
+				return atm;
+			case '<':
+				ctx.pos++;
+				char next = @peek(ctx);
+				if (next == '=')
+				{
+					ctx.pos++;
+					AstNode* lb_inner = parse_expr(ctx)!;
+					if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+					AstNode* lbp = ast_new(AST_LOOKBEHIND_POS);
+					lbp.left = lb_inner;
+					return lbp;
+				}
+				else if (next == '!')
+				{
+					ctx.pos++;
+					AstNode* lbn_inner = parse_expr(ctx)!;
+					if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+					AstNode* lbn = ast_new(AST_LOOKBEHIND_NEG);
+					lbn.left = lbn_inner;
+					return lbn;
+				}
+				else
+				{
+					return parse_named_group(ctx);
+				}
+			case 'i':
+			case 'm':
+			case 's':
+			case 'U':
+			case 'x':
+			case '-':
+				return parse_inline_flags(ctx);
+			default:
+				return INVALID_PATTERN~;
+		}
+	}
+
+	int id = ++ctx.next_group_id;
+	AstNode* inner = parse_expr(ctx)!;
+	if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+	AstNode* grp = ast_new(AST_GROUP);
+	grp.left = inner;
+	grp.group_id = id;
+	return grp;
+}
+
+fn AstNode*? parse_named_group(ParseCtx* ctx)
+{
+	usz name_start = ctx.pos;
+	while (!@at_end(ctx) && @peek(ctx) != '>') ctx.pos++;
+	if (@at_end(ctx)) return INVALID_PATTERN~;
+	String name = ctx.pattern[name_start : ctx.pos - name_start];
+	if (name.len == 0) return INVALID_PATTERN~;
+	ctx.pos++;
+
+	int id = ++ctx.next_group_id;
+	AstNode* inner = parse_expr(ctx)!;
+	if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
+	AstNode* grp = ast_new(AST_GROUP);
+	grp.left = inner;
+	grp.group_id = id;
+	grp.group_name = name;
+	ctx_push_named_group(ctx, { .name = name, .group_id = id });
+	return grp;
+}
+
+fn AstNode*? parse_inline_flags(ParseCtx* ctx)
+{
+	bool adding = true;
+	RegexFlags new_flags = ctx.flags;
+	while (!@at_end(ctx))
+	{
+		char c = @consume(ctx);
+		switch (c)
+		{
+			case 'i': if (adding) { new_flags |= FLAG_IGNORECASE; } else { new_flags &= ~FLAG_IGNORECASE; }
+			case 'm': if (adding) { new_flags |= FLAG_MULTILINE;  } else { new_flags &= ~FLAG_MULTILINE; }
+			case 's': if (adding) { new_flags |= FLAG_DOTALL;     } else { new_flags &= ~FLAG_DOTALL; }
+			case 'U': if (adding) { new_flags |= FLAG_UNGREEDY;   } else { new_flags &= ~FLAG_UNGREEDY; }
+			case 'x': if (adding) { new_flags |= FLAG_EXTENDED;   } else { new_flags &= ~FLAG_EXTENDED; }
+			case '-': adding = false;
+			case ')':
+				ctx.flags = new_flags;
+				AstNode* n = ast_new(AST_NCGROUP);
+				n.left = null;
+				return n;
+			default:
+				return INVALID_PATTERN~;
+		}
+	}
+	return INVALID_PATTERN~;
+}
+
+fn AstNode*? parse_escape_atom(ParseCtx* ctx)
+{
+	if (@at_end(ctx)) return INVALID_PATTERN~;
+	char esc = @consume(ctx);
+	switch (esc)
+	{
+		case 'd':
+			AstNode* nd = ast_new(AST_CHARCLASS); nd.char_class = CLASS_DIGIT; return nd;
+		case 'D':
+			AstNode* nD = ast_new(AST_CHARCLASS); nD.char_class = CLASS_DIGIT_INV; return nD;
+		case 'w':
+			AstNode* nw = ast_new(AST_CHARCLASS); nw.char_class = CLASS_WORD; return nw;
+		case 'W':
+			AstNode* nW = ast_new(AST_CHARCLASS); nW.char_class = CLASS_WORD_INV; return nW;
+		case 's':
+			AstNode* ns = ast_new(AST_CHARCLASS); ns.char_class = CLASS_SPACE; return ns;
+		case 'S':
+			AstNode* nS = ast_new(AST_CHARCLASS); nS.char_class = CLASS_SPACE_INV; return nS;
+		case 'p':
+			AstNode* np = ast_new(AST_CHARCLASS); np.char_class = parse_property_charclass(ctx, false)!; return np;
+		case 'P':
+			AstNode* nP = ast_new(AST_CHARCLASS); nP.char_class = parse_property_charclass(ctx, true)!; return nP;
+		case 'A': return ast_new(AST_ANCHOR_ABSOLUTE_START);
+		case 'z': return ast_new(AST_ANCHOR_ABSOLUTE_END);
+		case 'Z': return ast_new(AST_ANCHOR_ABSOLUTE_END_NL);
+		case 'R':
+			// \R: matches \r\n | [\r\n\v\f\x85\u2028\u2029]
+			AstNode* r_lit  = ast_new(AST_LITERAL); r_lit.codepoint = '\r';
+			AstNode* n_lit  = ast_new(AST_LITERAL); n_lit.codepoint = '\n';
+			AstNode* rn_seq = ast_new(AST_CONCAT); rn_seq.left = r_lit; rn_seq.right = n_lit;
+			AstNode* lb_cls_node = ast_new(AST_CHARCLASS);
+			AsciiCharset lb_ascii = (AsciiCharset)0;
+			lb_ascii |= (AsciiCharset)1 << '\n';
+			lb_ascii |= (AsciiCharset)1 << '\r';
+			lb_ascii |= (AsciiCharset)1 << '\v';
+			lb_ascii |= (AsciiCharset)1 << '\f';
+			UnicodeRange* lb_ranges = alloc::new_array(tmem, UnicodeRange, 2);
+			lb_ranges[0] = { .lo = 0x85, .hi = 0x85 };
+			lb_ranges[1] = { .lo = 0x2028, .hi = 0x2029 };
+			lb_cls_node.char_class = { .ascii_bits = lb_ascii, .ranges = lb_ranges, .ranges_count = 2 };
+			AstNode* lb_alt = ast_new(AST_ALT); lb_alt.left = rn_seq; lb_alt.right = lb_cls_node;
+			AstNode* lb_ncg = ast_new(AST_NCGROUP); lb_ncg.left = lb_alt;
+			return lb_ncg;
+		case 'b': return ast_new(AST_WORD_BOUND);
+		case 'B': return ast_new(AST_WORD_NBOUND);
+		case 'K': return ast_new(AST_KEEP);
+		case 'N': return ast_new(AST_NON_NEWLINE);
+		case 'h': AstNode* nh = ast_new(AST_CHARCLASS); nh.char_class = CLASS_HSPACE; return nh;
+		case 'H': AstNode* nH = ast_new(AST_CHARCLASS); nH.char_class = CLASS_HSPACE_INV; return nH;
+		case 'v': AstNode* nv = ast_new(AST_CHARCLASS); nv.char_class = CLASS_VSPACE; return nv;
+		case 'V': AstNode* nV = ast_new(AST_CHARCLASS); nV.char_class = CLASS_VSPACE_INV; return nV;
+		case 'n': AstNode* nl = ast_new(AST_LITERAL); nl.codepoint = '\n'; return nl;
+		case 'r': AstNode* cr = ast_new(AST_LITERAL); cr.codepoint = '\r'; return cr;
+		case 't': AstNode* ht = ast_new(AST_LITERAL); ht.codepoint = '\t'; return ht;
+		case 'f': AstNode* ff = ast_new(AST_LITERAL); ff.codepoint = '\f'; return ff;
+		case 'a': AstNode* bell = ast_new(AST_LITERAL); bell.codepoint = '\a'; return bell;
+		case 'u':
+			Char32 u4 = parse_hex_escape(ctx, 4)!;
+			AstNode* u4n = ast_new(AST_LITERAL); u4n.codepoint = u4; return u4n;
+		case 'U':
+			Char32 u8 = parse_hex_escape(ctx, 8)!;
+			AstNode* u8n = ast_new(AST_LITERAL); u8n.codepoint = u8; return u8n;
+		case 'e':
+			AstNode* esc_lit = ast_new(AST_LITERAL); esc_lit.codepoint = 0x1B; return esc_lit;
+		case 'G':
+			return ast_new(AST_ANCHOR_GPOS);
+		case 'c':
+			if (@at_end(ctx)) return INVALID_PATTERN~;
+			char ctrl_c = @consume(ctx);
+			Char32 ctrl_cp;
+			if (ctrl_c >= '@' && ctrl_c <= '_') { ctrl_cp = (Char32)(ctrl_c ^ 64); }
+			else if (ctrl_c >= 'a' && ctrl_c <= 'z') { ctrl_cp = (Char32)((ctrl_c - 0x20) ^ 64); }
+			else { return INVALID_PATTERN~; }
+			AstNode* ctrl_node = ast_new(AST_LITERAL); ctrl_node.codepoint = ctrl_cp; return ctrl_node;
+		case 'x':
+			if (@peek(ctx) == '{')
+			{
+				ctx.pos++;
+				Char32 xhv = parse_hex_escape_braced(ctx)!;
+				AstNode* xhn = ast_new(AST_LITERAL); xhn.codepoint = xhv; return xhn;
+			}
+			Char32 x2h = parse_hex_escape(ctx, 2)!;
+			AstNode* x2n = ast_new(AST_LITERAL); x2n.codepoint = x2h; return x2n;
+		case 'Q':
+			// \Q...\E — literal quoting: treat everything until \E as literal characters
+			AstNode* qlast = null;
+			while (!@at_end(ctx))
+			{
+				if (@peek(ctx) == '\\' && ctx.pos + 1 < ctx.pattern.len && ctx.pattern[ctx.pos + 1] == 'E')
+				{
+					ctx.pos += 2;
+					break;
+				}
+				Char32 qcp = parse_codepoint(ctx)!;
+				AstNode* qlit = ast_new(AST_LITERAL); qlit.codepoint = qcp;
+				if (qlast == null) { qlast = qlit; }
+				else { AstNode* qcon = ast_new(AST_CONCAT); qcon.left = qlast; qcon.right = qlit; qlast = qcon; }
+			}
+			if (qlast == null) { AstNode* qeps = ast_new(AST_NCGROUP); qeps.left = null; return qeps; }
+			return qlast;
+		case 'k':
+			// \k<name> named backreference
+			if (@peek(ctx) != '<') return INVALID_PATTERN~;
+			ctx.pos++;
+			usz kname_start = ctx.pos;
+			while (!@at_end(ctx) && @peek(ctx) != '>') ctx.pos++;
+			if (@at_end(ctx)) return INVALID_PATTERN~;
+			String kname = ctx.pattern[kname_start : ctx.pos - kname_start];
+			ctx.pos++;
+			int kgid = -1;
+			for (usz ki = 0; ki < ctx.named_groups_count; ki++)
+			{
+				if (ctx.named_groups_buf[ki].name == kname) { kgid = ctx.named_groups_buf[ki].group_id; break; }
+			}
+			if (kgid < 0) return INVALID_PATTERN~;
+			AstNode* br_k = ast_new(AST_BACKREF);
+			br_k.group_id = kgid;
+			return br_k;
+		default:
+			if (esc >= '1' && esc <= '9')
+			{
+				AstNode* br = ast_new(AST_BACKREF);
+				br.group_id = (int)(esc - '0');
+				return br;
+			}
+			AstNode* lit = ast_new(AST_LITERAL);
+			lit.codepoint = (Char32)esc;
+			return lit;
+	}
+}

--- a/lib/std/regex/parser.c3
+++ b/lib/std/regex/parser.c3
@@ -2,33 +2,34 @@ module std::regex;
 import std::core::string::conv;
 import std::core::string::iterator;
 import std::core::ascii;
+import std::collections::list;
 
 // ============================================================
 // Parser helpers
 // ============================================================
 
-macro bool @at_end(ParseCtx* ctx) => ctx.pos >= ctx.pattern.len;
+macro bool @at_end(RegexParseCtx* ctx) => ctx.pos >= ctx.pattern.len;
 
-macro char @peek(ParseCtx* ctx)
+macro char @peek(RegexParseCtx* ctx)
 {
 	if (ctx.pos >= ctx.pattern.len) return 0;
 	return ctx.pattern[ctx.pos];
 }
 
-macro char @peek2(ParseCtx* ctx)
+macro char @peek2(RegexParseCtx* ctx)
 {
 	if (ctx.pos + 1 >= ctx.pattern.len) return 0;
 	return ctx.pattern[ctx.pos + 1];
 }
 
-macro char @consume(ParseCtx* ctx)
+macro char @consume(RegexParseCtx* ctx)
 {
 	char c = ctx.pattern[ctx.pos];
 	ctx.pos++;
 	return c;
 }
 
-macro bool @try_consume(ParseCtx* ctx, char c)
+macro bool @try_consume(RegexParseCtx* ctx, char c)
 {
 	if (ctx.pos < ctx.pattern.len && ctx.pattern[ctx.pos] == c)
 	{
@@ -38,7 +39,7 @@ macro bool @try_consume(ParseCtx* ctx, char c)
 	return false;
 }
 
-fn void skip_freespacing(ParseCtx* ctx) @local @inline
+fn void skip_freespacing(RegexParseCtx* ctx) @local @inline
 {
 	if ((ctx.flags & FLAG_EXTENDED) == FLAG_NONE) return;
 	while (!@at_end(ctx))
@@ -60,23 +61,37 @@ fn void skip_freespacing(ParseCtx* ctx) @local @inline
 	}
 }
 
-fn AstNode* ast_new(AstKind kind)
+fn RegexAstNode* ast_new(RegexAstKind kind)
 {
-	AstNode* n = alloc::new(tmem, AstNode);
+	RegexAstNode* n = alloc::new(tmem, RegexAstNode);
 	n.kind = kind;
 	n.group_id = -1;
 	return n;
 }
 
-fn void ctx_push_named_group(ParseCtx* ctx, NamedGroupEntry entry)
+alias RegexAstNodeList = List{RegexAstNode*};
+
+fn RegexAstNode* ast_build_balanced(RegexAstKind kind, RegexAstNode*[] nodes)
+{
+	assert(nodes.len > 0);
+	if (nodes.len == 1) return nodes[0];
+
+	usz mid = nodes.len / 2;
+	RegexAstNode* n = ast_new(kind);
+	n.left = ast_build_balanced(kind, nodes[:mid]);
+	n.right = ast_build_balanced(kind, nodes[mid : nodes.len - mid]);
+	return n;
+}
+
+fn void ctx_push_named_group(RegexParseCtx* ctx, RegexNamedGroupEntry entry)
 {
 	if (ctx.named_groups_count >= ctx.named_groups_cap)
 	{
 		usz new_cap = ctx.named_groups_cap ? ctx.named_groups_cap * 2 : 8;
-		NamedGroupEntry* buf = alloc::new_array(tmem, NamedGroupEntry, new_cap);
+		RegexNamedGroupEntry* buf = alloc::new_array(tmem, RegexNamedGroupEntry, new_cap);
 		if (ctx.named_groups_buf)
 		{
-			mem::copy(buf, ctx.named_groups_buf, ctx.named_groups_count * NamedGroupEntry.sizeof);
+			mem::copy(buf, ctx.named_groups_buf, ctx.named_groups_count * RegexNamedGroupEntry.sizeof);
 		}
 		ctx.named_groups_buf = buf;
 		ctx.named_groups_cap = new_cap;
@@ -89,7 +104,7 @@ fn void ctx_push_named_group(ParseCtx* ctx, NamedGroupEntry entry)
 // ============================================================
 
 // Read the next full Unicode codepoint from ctx.pattern at ctx.pos (UTF-8 aware).
-fn Char32? parse_codepoint(ParseCtx* ctx) @local @inline
+fn Char32? parse_codepoint(RegexParseCtx* ctx) @local @inline
 {
 	if (ctx.pos >= ctx.pattern.len) return INVALID_PATTERN~;
 	StringIterator it = { .utf8 = ctx.pattern, .current = ctx.pos };
@@ -99,7 +114,7 @@ fn Char32? parse_codepoint(ParseCtx* ctx) @local @inline
 }
 
 // Parse \x{HH...} braced hex escape (1+ hex digits). Caller must have already consumed '{'.
-fn Char32? parse_hex_escape_braced(ParseCtx* ctx) @local
+fn Char32? parse_hex_escape_braced(RegexParseCtx* ctx) @local
 {
 	if (@at_end(ctx) || @peek(ctx) == '}') return INVALID_PATTERN~;
 	Char32 val = 0;
@@ -116,7 +131,7 @@ fn Char32? parse_hex_escape_braced(ParseCtx* ctx) @local
 	return val;
 }
 
-fn Char32? parse_hex_escape(ParseCtx* ctx, int digits)
+fn Char32? parse_hex_escape(RegexParseCtx* ctx, int digits)
 {
 	uint val = 0;
 	for (int i = 0; i < digits; i++)
@@ -129,7 +144,7 @@ fn Char32? parse_hex_escape(ParseCtx* ctx, int digits)
 	return (Char32)val;
 }
 
-fn Char32? parse_classchar(ParseCtx* ctx)
+fn Char32? parse_classchar(RegexParseCtx* ctx)
 {
 	if (@at_end(ctx)) return INVALID_PATTERN~;
 	char c = ctx.pattern[ctx.pos];
@@ -169,7 +184,7 @@ fn Char32? parse_classchar(ParseCtx* ctx)
 	}
 }
 
-fn void charclass_add_range(CharClass* cls, TempRangeList* unicode, Char32 lo, Char32 hi)
+fn void charclass_add_range(RegexCharClass* cls, RegexTempRangeList* unicode, Char32 lo, Char32 hi)
 {
 	if (lo < 128)
 	{
@@ -181,22 +196,22 @@ fn void charclass_add_range(CharClass* cls, TempRangeList* unicode, Char32 lo, C
 	unicode.push({ .lo = lo, .hi = hi });
 }
 
-fn void charclass_merge_set(CharClass* cls, AsciiCharset set)
+fn void charclass_merge_set(RegexCharClass* cls, AsciiCharset set)
 {
 	cls.ascii_bits |= set;
 }
 
-fn void charclass_merge_property(CharClass* cls, UnicodePropMask prop)
+fn void charclass_merge_property(RegexCharClass* cls, RegexUnicodePropMask prop)
 {
 	cls.props |= prop;
 }
 
-fn void charclass_merge_complement_property(CharClass* cls, UnicodePropMask prop)
+fn void charclass_merge_complement_property(RegexCharClass* cls, RegexUnicodePropMask prop)
 {
 	cls.complement_props |= prop;
 }
 
-fn UnicodePropMask? parse_unicode_property_name(ParseCtx* ctx)
+fn RegexUnicodePropMask? parse_unicode_property_name(RegexParseCtx* ctx)
 {
 	if (!@try_consume(ctx, '{')) return INVALID_PATTERN~;
 	usz name_start = ctx.pos;
@@ -223,15 +238,15 @@ fn UnicodePropMask? parse_unicode_property_name(ParseCtx* ctx)
 	}
 }
 
-fn CharClass? parse_property_charclass(ParseCtx* ctx, bool negated)
+fn RegexCharClass? parse_property_charclass(RegexParseCtx* ctx, bool negated)
 {
-	UnicodePropMask prop = parse_unicode_property_name(ctx)!;
-	CharClass cls = { .props = prop, .negated = negated };
+	RegexUnicodePropMask prop = parse_unicode_property_name(ctx)!;
+	RegexCharClass cls = { .props = prop, .negated = negated };
 	if (prop == PROP_ASCII) cls.ascii_bits = ~(AsciiCharset)0;
 	return cls;
 }
 
-fn bool? parse_posix_bracket(ParseCtx* ctx, CharClass* cls)
+fn bool? parse_posix_bracket(RegexParseCtx* ctx, RegexCharClass* cls)
 {
 	if (@peek(ctx) != ':') return false;
 	usz saved = ctx.pos;
@@ -264,10 +279,10 @@ fn bool? parse_posix_bracket(ParseCtx* ctx, CharClass* cls)
 	return true;
 }
 
-fn AstNode*? parse_charclass_body(ParseCtx* ctx)
+fn RegexAstNode*? parse_charclass_body(RegexParseCtx* ctx)
 {
-	CharClass cls = {};
-	TempRangeList unicode;
+	RegexCharClass cls = {};
+	RegexTempRangeList unicode;
 	unicode.tinit(4);
 	defer unicode.free();
 
@@ -309,13 +324,13 @@ fn AstNode*? parse_charclass_body(ParseCtx* ctx)
 				case 'V': charclass_merge_complement_property(&cls, PROP_VSPACE);                                                     ctx.pos += 2; continue;
 				case 'p':
 					ctx.pos += 2;
-					CharClass pcls = parse_property_charclass(ctx, false)!;
+					RegexCharClass pcls = parse_property_charclass(ctx, false)!;
 					cls.ascii_bits |= pcls.ascii_bits;
 					cls.props |= pcls.props;
 					continue;
 				case 'P':
 					ctx.pos += 2;
-					CharClass p_inv = parse_property_charclass(ctx, true)!;
+					RegexCharClass p_inv = parse_property_charclass(ctx, true)!;
 					cls.complement_props |= p_inv.props;
 					continue;
 				default: break;
@@ -339,17 +354,17 @@ fn AstNode*? parse_charclass_body(ParseCtx* ctx)
 	cls.negated = negated;
 
 	// Copy unicode ranges into tmem (moved to range_pool during NFA build)
-	UnicodeRange* tmp_ranges = null;
+	RegexUnicodeRange* tmp_ranges = null;
 	usz tmp_count = unicode.size;
 	if (tmp_count > 0)
 	{
-		tmp_ranges = alloc::new_array(tmem, UnicodeRange, tmp_count);
-		mem::copy(tmp_ranges, unicode.entries, tmp_count * UnicodeRange.sizeof);
+		tmp_ranges = alloc::new_array(tmem, RegexUnicodeRange, tmp_count);
+		mem::copy(tmp_ranges, unicode.entries, tmp_count * RegexUnicodeRange.sizeof);
 	}
 	cls.ranges = tmp_ranges;
 	cls.ranges_count = tmp_count;
 
-	AstNode* n = ast_new(AST_CHARCLASS);
+	RegexAstNode* n = ast_new(AST_CHARCLASS);
 	n.char_class = cls;
 	return n;
 }
@@ -358,57 +373,46 @@ fn AstNode*? parse_charclass_body(ParseCtx* ctx)
 // Recursive descent parser
 // ============================================================
 
-fn AstNode*? parse_expr(ParseCtx* ctx) => parse_alt(ctx);
+fn RegexAstNode*? parse_expr(RegexParseCtx* ctx) => parse_alt(ctx);
 
-fn AstNode*? parse_alt(ParseCtx* ctx)
+fn RegexAstNode*? parse_alt(RegexParseCtx* ctx)
 {
-	AstNode* left = parse_concat(ctx)!;
+	RegexAstNodeList branches;
+	branches.tinit(4);
+	branches.push(parse_concat(ctx)!);
 	skip_freespacing(ctx);
 	while (@peek(ctx) == '|')
 	{
 		ctx.pos++;
-		AstNode* right = parse_concat(ctx)!;
-		AstNode* n = ast_new(AST_ALT);
-		n.left  = left;
-		n.right = right;
-		left = n;
+		branches.push(parse_concat(ctx)!);
 		skip_freespacing(ctx);
 	}
-	return left;
+	return ast_build_balanced(AST_ALT, branches.array_view());
 }
 
-fn AstNode*? parse_concat(ParseCtx* ctx)
+fn RegexAstNode*? parse_concat(RegexParseCtx* ctx)
 {
-	AstNode* result = null;
+	RegexAstNodeList atoms;
+	atoms.tinit(4);
 	while (true)
 	{
 		skip_freespacing(ctx);
 		char c = @peek(ctx);
 		if (c == '|' || c == ')' || c == 0) break;
-		AstNode* atom = parse_quantifier(ctx)!;
-		if (result == null)
-		{
-			result = atom;
-		}
-		else
-		{
-			AstNode* n = ast_new(AST_CONCAT);
-			n.left  = result;
-			n.right = atom;
-			result = n;
-		}
+		atoms.push(parse_quantifier(ctx)!);
 	}
-	if (result == null)
+	if (atoms.size == 0)
 	{
 		// Empty alternative — epsilon node
-		result = ast_new(AST_CONCAT);
-		result.left = null;
-		result.right = null;
+		RegexAstNode* epsilon = ast_new(AST_CONCAT);
+		epsilon.left = null;
+		epsilon.right = null;
+		return epsilon;
 	}
-	return result;
+	return ast_build_balanced(AST_CONCAT, atoms.array_view());
 }
 
-fn bool ast_can_consume(AstNode* node) @local
+fn bool ast_can_consume(RegexAstNode* node) @local
 {
 	if (node == null) return false;
 	switch (node.kind)
@@ -454,12 +458,12 @@ fn bool ast_can_consume(AstNode* node) @local
 	}
 }
 
-fn AstNode*? parse_quantifier(ParseCtx* ctx)
+fn RegexAstNode*? parse_quantifier(RegexParseCtx* ctx)
 {
-	AstNode* atom = parse_atom(ctx)!;
+	RegexAstNode* atom = parse_atom(ctx)!;
 	skip_freespacing(ctx);
 	char c = @peek(ctx);
-	AstNode* q = null;
+	RegexAstNode* q = null;
 	switch (c)
 	{
 		case '*':
@@ -487,7 +491,7 @@ fn AstNode*? parse_quantifier(ParseCtx* ctx)
 	if (@peek(ctx) == '+')
 	{
 		ctx.pos++;
-		AstNode* poss = ast_new(AST_ATOMIC);
+		RegexAstNode* poss = ast_new(AST_ATOMIC);
 		poss.left = q;
 		return poss;
 	}
@@ -497,7 +501,7 @@ fn AstNode*? parse_quantifier(ParseCtx* ctx)
 	return q;
 }
 
-fn AstNode*? parse_repeat_quantifier(ParseCtx* ctx, AstNode* atom)
+fn RegexAstNode*? parse_repeat_quantifier(RegexParseCtx* ctx, RegexAstNode* atom)
 {
 	usz saved = ctx.pos;
 	ctx.pos++;
@@ -541,14 +545,14 @@ fn AstNode*? parse_repeat_quantifier(ParseCtx* ctx, AstNode* atom)
 	ctx.pos++;
 	if (max_val != -1 && max_val < min_val) return INVALID_PATTERN~;
 
-	AstNode* n = ast_new(AST_REPEAT);
+	RegexAstNode* n = ast_new(AST_REPEAT);
 	n.left       = atom;
 	n.repeat_min = min_val;
 	n.repeat_max = max_val;
 	return n;
 }
 
-fn AstNode*? parse_atom(ParseCtx* ctx)
+fn RegexAstNode*? parse_atom(RegexParseCtx* ctx)
 {
 	if (@at_end(ctx)) return INVALID_PATTERN~;
 	char c = @consume(ctx);
@@ -559,7 +563,7 @@ fn AstNode*? parse_atom(ParseCtx* ctx)
 		case '[':
 			return parse_charclass_body(ctx);
 		case '.':
-			AstNode* dot = ast_new(AST_CHARCLASS);
+			RegexAstNode* dot = ast_new(AST_CHARCLASS);
 			dot.char_class = CLASS_DOT;
 			return dot;
 		case '^':
@@ -571,13 +575,13 @@ fn AstNode*? parse_atom(ParseCtx* ctx)
 		default:
 			// Back up and re-read as full UTF-8 codepoint (handles multi-byte sequences)
 			ctx.pos--;
-			AstNode* lit = ast_new(AST_LITERAL);
+			RegexAstNode* lit = ast_new(AST_LITERAL);
 			lit.codepoint = parse_codepoint(ctx)!;
 			return lit;
 	}
 }
 
-fn AstNode*? parse_group(ParseCtx* ctx)
+fn RegexAstNode*? parse_group(RegexParseCtx* ctx)
 {
 	char c = @peek(ctx);
 	if (c == '?')
@@ -591,28 +595,28 @@ fn AstNode*? parse_group(ParseCtx* ctx)
 				ctx.pos++;
 				while (!@at_end(ctx) && @peek(ctx) != ')') ctx.pos++;
 				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-				AstNode* comment_eps = ast_new(AST_NCGROUP);
+				RegexAstNode* comment_eps = ast_new(AST_NCGROUP);
 				comment_eps.left = null;
 				return comment_eps;
 			case ':':
 				ctx.pos++;
-				AstNode* inner = parse_expr(ctx)!;
+				RegexAstNode* inner = parse_expr(ctx)!;
 				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-				AstNode* ncg = ast_new(AST_NCGROUP);
+				RegexAstNode* ncg = ast_new(AST_NCGROUP);
 				ncg.left = inner;
 				return ncg;
 			case '=':
 				ctx.pos++;
-				AstNode* la_inner = parse_expr(ctx)!;
+				RegexAstNode* la_inner = parse_expr(ctx)!;
 				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-				AstNode* lap = ast_new(AST_LOOKAHEAD_POS);
+				RegexAstNode* lap = ast_new(AST_LOOKAHEAD_POS);
 				lap.left = la_inner;
 				return lap;
 			case '!':
 				ctx.pos++;
-				AstNode* lna_inner = parse_expr(ctx)!;
+				RegexAstNode* lna_inner = parse_expr(ctx)!;
 				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-				AstNode* lan = ast_new(AST_LOOKAHEAD_NEG);
+				RegexAstNode* lan = ast_new(AST_LOOKAHEAD_NEG);
 				lan.left = lna_inner;
 				return lan;
 			case '|':
@@ -620,19 +624,21 @@ fn AstNode*? parse_group(ParseCtx* ctx)
 				ctx.pos++;
 				int breset_base = ctx.next_group_id;
 				int breset_max = breset_base;
-				AstNode* br_result = null;
+				RegexAstNodeList branches;
+				branches.tinit(4);
 				while (true)
 				{
 					ctx.next_group_id = breset_base;
-					AstNode* br_branch = parse_concat(ctx)!;
+					RegexAstNode* br_branch = parse_concat(ctx)!;
 					if (ctx.next_group_id > breset_max) breset_max = ctx.next_group_id;
-					if (br_result == null) { br_result = br_branch; }
-					else { AstNode* bra = ast_new(AST_ALT); bra.left = br_result; bra.right = br_branch; br_result = bra; }
+					branches.push(br_branch);
 					if (!@try_consume(ctx, '|')) break;
 				}
 				ctx.next_group_id = breset_max;
 				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-				AstNode* br_ncg = ast_new(AST_BRANCH_RESET); br_ncg.left = br_result; return br_ncg;
+				RegexAstNode* br_ncg = ast_new(AST_BRANCH_RESET);
+				br_ncg.left = ast_build_balanced(AST_ALT, branches.array_view());
+				return br_ncg;
 			case '(':
 				// (?(N)yes|no) or (?(name)yes|no) — conditional pattern
 				ctx.pos++;
@@ -655,11 +661,11 @@ fn AstNode*? parse_group(ParseCtx* ctx)
 					if (cond_gid < 0) return INVALID_PATTERN~;
 				}
 				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-				AstNode* cond_yes = parse_concat(ctx)!;
-				AstNode* cond_no = null;
+				RegexAstNode* cond_yes = parse_concat(ctx)!;
+				RegexAstNode* cond_no = null;
 				if (@try_consume(ctx, '|')) cond_no = parse_concat(ctx)!;
 				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-				AstNode* cond_node = ast_new(AST_COND_GROUP);
+				RegexAstNode* cond_node = ast_new(AST_COND_GROUP);
 				cond_node.group_id = cond_gid;
 				cond_node.left = cond_yes;
 				cond_node.right = cond_no;
@@ -667,9 +673,9 @@ fn AstNode*? parse_group(ParseCtx* ctx)
 			case '>':
 				// (?>...) — atomic group
 				ctx.pos++;
-				AstNode* atm_inner = parse_expr(ctx)!;
+				RegexAstNode* atm_inner = parse_expr(ctx)!;
 				if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-				AstNode* atm = ast_new(AST_ATOMIC);
+				RegexAstNode* atm = ast_new(AST_ATOMIC);
 				atm.left = atm_inner;
 				return atm;
 			case '<':
@@ -678,18 +684,18 @@ fn AstNode*? parse_group(ParseCtx* ctx)
 				if (next == '=')
 				{
 					ctx.pos++;
-					AstNode* lb_inner = parse_expr(ctx)!;
+					RegexAstNode* lb_inner = parse_expr(ctx)!;
 					if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-					AstNode* lbp = ast_new(AST_LOOKBEHIND_POS);
+					RegexAstNode* lbp = ast_new(AST_LOOKBEHIND_POS);
 					lbp.left = lb_inner;
 					return lbp;
 				}
 				else if (next == '!')
 				{
 					ctx.pos++;
-					AstNode* lbn_inner = parse_expr(ctx)!;
+					RegexAstNode* lbn_inner = parse_expr(ctx)!;
 					if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-					AstNode* lbn = ast_new(AST_LOOKBEHIND_NEG);
+					RegexAstNode* lbn = ast_new(AST_LOOKBEHIND_NEG);
 					lbn.left = lbn_inner;
 					return lbn;
 				}
@@ -710,15 +716,15 @@ fn AstNode*? parse_group(ParseCtx* ctx)
 	}
 
 	int id = ++ctx.next_group_id;
-	AstNode* inner = parse_expr(ctx)!;
+	RegexAstNode* inner = parse_expr(ctx)!;
 	if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-	AstNode* grp = ast_new(AST_GROUP);
+	RegexAstNode* grp = ast_new(AST_GROUP);
 	grp.left = inner;
 	grp.group_id = id;
 	return grp;
 }
 
-fn AstNode*? parse_named_group(ParseCtx* ctx)
+fn RegexAstNode*? parse_named_group(RegexParseCtx* ctx)
 {
 	usz name_start = ctx.pos;
 	while (!@at_end(ctx) && @peek(ctx) != '>') ctx.pos++;
@@ -728,9 +734,9 @@ fn AstNode*? parse_named_group(ParseCtx* ctx)
 	ctx.pos++;
 
 	int id = ++ctx.next_group_id;
-	AstNode* inner = parse_expr(ctx)!;
+	RegexAstNode* inner = parse_expr(ctx)!;
 	if (!@try_consume(ctx, ')')) return INVALID_PATTERN~;
-	AstNode* grp = ast_new(AST_GROUP);
+	RegexAstNode* grp = ast_new(AST_GROUP);
 	grp.left = inner;
 	grp.group_id = id;
 	grp.group_name = name;
@@ -738,7 +744,7 @@ fn AstNode*? parse_named_group(ParseCtx* ctx)
 	return grp;
 }
 
-fn AstNode*? parse_inline_flags(ParseCtx* ctx)
+fn RegexAstNode*? parse_inline_flags(RegexParseCtx* ctx)
 {
 	bool adding = true;
 	RegexFlags new_flags = ctx.flags;
@@ -755,7 +761,7 @@ fn AstNode*? parse_inline_flags(ParseCtx* ctx)
 			case '-': adding = false;
 			case ')':
 				ctx.flags = new_flags;
-				AstNode* n = ast_new(AST_NCGROUP);
+				RegexAstNode* n = ast_new(AST_NCGROUP);
 				n.left = null;
 				return n;
 			default:
@@ -765,70 +771,70 @@ fn AstNode*? parse_inline_flags(ParseCtx* ctx)
 	return INVALID_PATTERN~;
 }
 
-fn AstNode*? parse_escape_atom(ParseCtx* ctx)
+fn RegexAstNode*? parse_escape_atom(RegexParseCtx* ctx)
 {
 	if (@at_end(ctx)) return INVALID_PATTERN~;
 	char esc = @consume(ctx);
 	switch (esc)
 	{
 		case 'd':
-			AstNode* nd = ast_new(AST_CHARCLASS); nd.char_class = CLASS_DIGIT; return nd;
+			RegexAstNode* nd = ast_new(AST_CHARCLASS); nd.char_class = CLASS_DIGIT; return nd;
 		case 'D':
-			AstNode* nD = ast_new(AST_CHARCLASS); nD.char_class = CLASS_DIGIT_INV; return nD;
+			RegexAstNode* nD = ast_new(AST_CHARCLASS); nD.char_class = CLASS_DIGIT_INV; return nD;
 		case 'w':
-			AstNode* nw = ast_new(AST_CHARCLASS); nw.char_class = CLASS_WORD; return nw;
+			RegexAstNode* nw = ast_new(AST_CHARCLASS); nw.char_class = CLASS_WORD; return nw;
 		case 'W':
-			AstNode* nW = ast_new(AST_CHARCLASS); nW.char_class = CLASS_WORD_INV; return nW;
+			RegexAstNode* nW = ast_new(AST_CHARCLASS); nW.char_class = CLASS_WORD_INV; return nW;
 		case 's':
-			AstNode* ns = ast_new(AST_CHARCLASS); ns.char_class = CLASS_SPACE; return ns;
+			RegexAstNode* ns = ast_new(AST_CHARCLASS); ns.char_class = CLASS_SPACE; return ns;
 		case 'S':
-			AstNode* nS = ast_new(AST_CHARCLASS); nS.char_class = CLASS_SPACE_INV; return nS;
+			RegexAstNode* nS = ast_new(AST_CHARCLASS); nS.char_class = CLASS_SPACE_INV; return nS;
 		case 'p':
-			AstNode* np = ast_new(AST_CHARCLASS); np.char_class = parse_property_charclass(ctx, false)!; return np;
+			RegexAstNode* np = ast_new(AST_CHARCLASS); np.char_class = parse_property_charclass(ctx, false)!; return np;
 		case 'P':
-			AstNode* nP = ast_new(AST_CHARCLASS); nP.char_class = parse_property_charclass(ctx, true)!; return nP;
+			RegexAstNode* nP = ast_new(AST_CHARCLASS); nP.char_class = parse_property_charclass(ctx, true)!; return nP;
 		case 'A': return ast_new(AST_ANCHOR_ABSOLUTE_START);
 		case 'z': return ast_new(AST_ANCHOR_ABSOLUTE_END);
 		case 'Z': return ast_new(AST_ANCHOR_ABSOLUTE_END_NL);
 		case 'R':
 			// \R: matches \r\n | [\r\n\v\f\x85\u2028\u2029]
-			AstNode* r_lit  = ast_new(AST_LITERAL); r_lit.codepoint = '\r';
-			AstNode* n_lit  = ast_new(AST_LITERAL); n_lit.codepoint = '\n';
-			AstNode* rn_seq = ast_new(AST_CONCAT); rn_seq.left = r_lit; rn_seq.right = n_lit;
-			AstNode* lb_cls_node = ast_new(AST_CHARCLASS);
+			RegexAstNode* r_lit  = ast_new(AST_LITERAL); r_lit.codepoint = '\r';
+			RegexAstNode* n_lit  = ast_new(AST_LITERAL); n_lit.codepoint = '\n';
+			RegexAstNode* rn_seq = ast_new(AST_CONCAT); rn_seq.left = r_lit; rn_seq.right = n_lit;
+			RegexAstNode* lb_cls_node = ast_new(AST_CHARCLASS);
 			AsciiCharset lb_ascii = (AsciiCharset)0;
 			lb_ascii |= (AsciiCharset)1 << '\n';
 			lb_ascii |= (AsciiCharset)1 << '\r';
 			lb_ascii |= (AsciiCharset)1 << '\v';
 			lb_ascii |= (AsciiCharset)1 << '\f';
-			UnicodeRange* lb_ranges = alloc::new_array(tmem, UnicodeRange, 2);
+			RegexUnicodeRange* lb_ranges = alloc::new_array(tmem, RegexUnicodeRange, 2);
 			lb_ranges[0] = { .lo = 0x85, .hi = 0x85 };
 			lb_ranges[1] = { .lo = 0x2028, .hi = 0x2029 };
 			lb_cls_node.char_class = { .ascii_bits = lb_ascii, .ranges = lb_ranges, .ranges_count = 2 };
-			AstNode* lb_alt = ast_new(AST_ALT); lb_alt.left = rn_seq; lb_alt.right = lb_cls_node;
-			AstNode* lb_ncg = ast_new(AST_NCGROUP); lb_ncg.left = lb_alt;
+			RegexAstNode* lb_alt = ast_new(AST_ALT); lb_alt.left = rn_seq; lb_alt.right = lb_cls_node;
+			RegexAstNode* lb_ncg = ast_new(AST_NCGROUP); lb_ncg.left = lb_alt;
 			return lb_ncg;
 		case 'b': return ast_new(AST_WORD_BOUND);
 		case 'B': return ast_new(AST_WORD_NBOUND);
 		case 'K': return ast_new(AST_KEEP);
 		case 'N': return ast_new(AST_NON_NEWLINE);
-		case 'h': AstNode* nh = ast_new(AST_CHARCLASS); nh.char_class = CLASS_HSPACE; return nh;
-		case 'H': AstNode* nH = ast_new(AST_CHARCLASS); nH.char_class = CLASS_HSPACE_INV; return nH;
-		case 'v': AstNode* nv = ast_new(AST_CHARCLASS); nv.char_class = CLASS_VSPACE; return nv;
-		case 'V': AstNode* nV = ast_new(AST_CHARCLASS); nV.char_class = CLASS_VSPACE_INV; return nV;
-		case 'n': AstNode* nl = ast_new(AST_LITERAL); nl.codepoint = '\n'; return nl;
-		case 'r': AstNode* cr = ast_new(AST_LITERAL); cr.codepoint = '\r'; return cr;
-		case 't': AstNode* ht = ast_new(AST_LITERAL); ht.codepoint = '\t'; return ht;
-		case 'f': AstNode* ff = ast_new(AST_LITERAL); ff.codepoint = '\f'; return ff;
-		case 'a': AstNode* bell = ast_new(AST_LITERAL); bell.codepoint = '\a'; return bell;
+		case 'h': RegexAstNode* nh = ast_new(AST_CHARCLASS); nh.char_class = CLASS_HSPACE; return nh;
+		case 'H': RegexAstNode* nH = ast_new(AST_CHARCLASS); nH.char_class = CLASS_HSPACE_INV; return nH;
+		case 'v': RegexAstNode* nv = ast_new(AST_CHARCLASS); nv.char_class = CLASS_VSPACE; return nv;
+		case 'V': RegexAstNode* nV = ast_new(AST_CHARCLASS); nV.char_class = CLASS_VSPACE_INV; return nV;
+		case 'n': RegexAstNode* nl = ast_new(AST_LITERAL); nl.codepoint = '\n'; return nl;
+		case 'r': RegexAstNode* cr = ast_new(AST_LITERAL); cr.codepoint = '\r'; return cr;
+		case 't': RegexAstNode* ht = ast_new(AST_LITERAL); ht.codepoint = '\t'; return ht;
+		case 'f': RegexAstNode* ff = ast_new(AST_LITERAL); ff.codepoint = '\f'; return ff;
+		case 'a': RegexAstNode* bell = ast_new(AST_LITERAL); bell.codepoint = '\a'; return bell;
 		case 'u':
 			Char32 u4 = parse_hex_escape(ctx, 4)!;
-			AstNode* u4n = ast_new(AST_LITERAL); u4n.codepoint = u4; return u4n;
+			RegexAstNode* u4n = ast_new(AST_LITERAL); u4n.codepoint = u4; return u4n;
 		case 'U':
 			Char32 u8 = parse_hex_escape(ctx, 8)!;
-			AstNode* u8n = ast_new(AST_LITERAL); u8n.codepoint = u8; return u8n;
+			RegexAstNode* u8n = ast_new(AST_LITERAL); u8n.codepoint = u8; return u8n;
 		case 'e':
-			AstNode* esc_lit = ast_new(AST_LITERAL); esc_lit.codepoint = 0x1B; return esc_lit;
+			RegexAstNode* esc_lit = ast_new(AST_LITERAL); esc_lit.codepoint = 0x1B; return esc_lit;
 		case 'G':
 			return ast_new(AST_ANCHOR_GPOS);
 		case 'c':
@@ -838,19 +844,19 @@ fn AstNode*? parse_escape_atom(ParseCtx* ctx)
 			if (ctrl_c >= '@' && ctrl_c <= '_') { ctrl_cp = (Char32)(ctrl_c ^ 64); }
 			else if (ctrl_c >= 'a' && ctrl_c <= 'z') { ctrl_cp = (Char32)((ctrl_c - 0x20) ^ 64); }
 			else { return INVALID_PATTERN~; }
-			AstNode* ctrl_node = ast_new(AST_LITERAL); ctrl_node.codepoint = ctrl_cp; return ctrl_node;
+			RegexAstNode* ctrl_node = ast_new(AST_LITERAL); ctrl_node.codepoint = ctrl_cp; return ctrl_node;
 		case 'x':
 			if (@peek(ctx) == '{')
 			{
 				ctx.pos++;
 				Char32 xhv = parse_hex_escape_braced(ctx)!;
-				AstNode* xhn = ast_new(AST_LITERAL); xhn.codepoint = xhv; return xhn;
+				RegexAstNode* xhn = ast_new(AST_LITERAL); xhn.codepoint = xhv; return xhn;
 			}
 			Char32 x2h = parse_hex_escape(ctx, 2)!;
-			AstNode* x2n = ast_new(AST_LITERAL); x2n.codepoint = x2h; return x2n;
+			RegexAstNode* x2n = ast_new(AST_LITERAL); x2n.codepoint = x2h; return x2n;
 		case 'Q':
 			// \Q...\E — literal quoting: treat everything until \E as literal characters
-			AstNode* qlast = null;
+			RegexAstNode* qlast = null;
 			while (!@at_end(ctx))
 			{
 				if (@peek(ctx) == '\\' && ctx.pos + 1 < ctx.pattern.len && ctx.pattern[ctx.pos + 1] == 'E')
@@ -859,11 +865,11 @@ fn AstNode*? parse_escape_atom(ParseCtx* ctx)
 					break;
 				}
 				Char32 qcp = parse_codepoint(ctx)!;
-				AstNode* qlit = ast_new(AST_LITERAL); qlit.codepoint = qcp;
+				RegexAstNode* qlit = ast_new(AST_LITERAL); qlit.codepoint = qcp;
 				if (qlast == null) { qlast = qlit; }
-				else { AstNode* qcon = ast_new(AST_CONCAT); qcon.left = qlast; qcon.right = qlit; qlast = qcon; }
+				else { RegexAstNode* qcon = ast_new(AST_CONCAT); qcon.left = qlast; qcon.right = qlit; qlast = qcon; }
 			}
-			if (qlast == null) { AstNode* qeps = ast_new(AST_NCGROUP); qeps.left = null; return qeps; }
+			if (qlast == null) { RegexAstNode* qeps = ast_new(AST_NCGROUP); qeps.left = null; return qeps; }
 			return qlast;
 		case 'k':
 			// \k<name> named backreference
@@ -880,17 +886,17 @@ fn AstNode*? parse_escape_atom(ParseCtx* ctx)
 				if (ctx.named_groups_buf[ki].name == kname) { kgid = ctx.named_groups_buf[ki].group_id; break; }
 			}
 			if (kgid < 0) return INVALID_PATTERN~;
-			AstNode* br_k = ast_new(AST_BACKREF);
+			RegexAstNode* br_k = ast_new(AST_BACKREF);
 			br_k.group_id = kgid;
 			return br_k;
 		default:
 			if (esc >= '1' && esc <= '9')
 			{
-				AstNode* br = ast_new(AST_BACKREF);
+				RegexAstNode* br = ast_new(AST_BACKREF);
 				br.group_id = (int)(esc - '0');
 				return br;
 			}
-			AstNode* lit = ast_new(AST_LITERAL);
+			RegexAstNode* lit = ast_new(AST_LITERAL);
 			lit.codepoint = (Char32)esc;
 			return lit;
 	}

--- a/lib/std/regex/regex.c3
+++ b/lib/std/regex/regex.c3
@@ -1,0 +1,1148 @@
+<*
+ A compact stdlib regex engine with a hybrid execution model.
+
+ Positioning / compatibility:
+ - This module aims for a practical, PCRE-like feature set inside the stdlib, but it is not
+   a drop-in compatibility target for PCRE2, Oniguruma, .NET, Java, Python, or ECMAScript.
+ - The documented semantics in this header are the compatibility contract for C3 regexes.
+   When another engine behaves differently, prefer the behavior described here and covered by
+   the stdlib tests.
+
+ Matching semantics:
+ - `is_match`, `find`, `replace`, and `replace_all` search unanchored by default.
+   Anchors such as `^`, `$`, `\A`, `\z`, and `\G` are required for anchored behavior.
+ - Search is leftmost-first by start position; when multiple paths match at the same start,
+   the engine keeps the longest match that survives the NFA/backtracking execution.
+ - UTF-8 literals, escapes, and captures operate on byte offsets but decode codepoints
+   when matching.
+ - `FLAG_IGNORECASE` performs ASCII folding plus the explicit Latin-1, Greek, and
+   Cyrillic pairs handled by `unicode_case_fold`; it is not full Unicode case folding.
+ - `\d` and POSIX bracket classes are ASCII-defined.
+ - `\s`, `\h`, and `\v` use exact Unicode whitespace tables.
+ - `\w`, `\W`, `\b`, and `\B` treat ASCII word characters plus Latin-1 letters as word
+   characters.
+ - ASCII range classes such as `[A-Z]` remain explicit codepoint ranges, even under
+   `FLAG_IGNORECASE`.
+ - `\p{...}` / `\P{...}` currently support `ASCII`, `White_Space`, `Horiz_Space`,
+   `Vert_Space`, and `Word`.
+ - Bare inline `(?x)` and `(?U)` toggles affect parsing and greediness for the remainder
+   of the pattern. Bare inline `(?i)`, `(?m)`, `(?s)`, and their `(?-...)` forms are
+   accepted for surface compatibility but do not currently alter runtime matching; use the
+   corresponding compile flags for ignore-case, multiline, and dotall behavior. Scoped
+   inline flag groups are not supported.
+ - Variable-width lookbehind scans all prior UTF-8 character boundaries before the current
+   position when searching for a valid start.
+ - Replacement syntax supports `$$`, `$&`, `$0`..`$9`, `${N}`, and `${name}`. Unknown or
+   unmatched capture references expand to the empty string.
+
+ Supported syntax overview:
+ - Literals, `.`, alternation `|`, grouping `(...)`, non-capturing `(?:...)`, comments
+   `(?#...)`, named groups `(?<name>...)`, and branch reset `(?|...)`.
+ - Quantifiers `*`, `+`, `?`, `{n}`, `{n,}`, `{n,m}` with lazy suffixes and possessive
+   suffixes where supported.
+ - Anchors `^`, `$`, `\A`, `\z`, `\Z`, `\b`, `\B`, `\G`, and linebreak escape `\R`.
+ - Lookahead/lookbehind, atomic groups `(?>...)`, backreferences, conditionals, and `\K`.
+ - Replacement references `$$`, `$&`, `$0`..`$9`, `${N}`, and `${name}`.
+
+ Ownership / lifetime:
+ - `compile` returns a heap-owned `Regex*`; call `Regex.free()` when done.
+ - `find` / `find_at` / `MatchIter.next` return heap-owned `Match` values whose capture
+   buffers must be released with `Match.free()`.
+ - `replace` / `replace_all` return newly allocated strings owned by the caller.
+
+ Limitations / compatibility notes:
+ - This engine is intentionally PCRE-like rather than bug-for-bug PCRE-compatible.
+ - Unicode support is partial: property support is currently limited to `ASCII`,
+   `White_Space`, `Horiz_Space`, `Vert_Space`, and `Word`, and ignore-case matching
+   uses explicit folding tables rather than full Unicode case folding.
+ - Bare inline `(?i)`, `(?m)`, and `(?s)` are accepted for compatibility but do not
+   currently toggle runtime matching; use compile flags instead.
+
+ Examples:
+ - Compile and search:
+     Regex* re = regex::compile(mem, "\\d+")!!;
+     defer re.free();
+     Match m = re.find(mem, "abc123")!!;
+     defer m.free();
+     assert(m.full() == "123");
+ - Named captures:
+     Regex* re = regex::compile(mem, "(?<key>\\w+)=(?<value>\\d+)")!!;
+     defer re.free();
+     Match m = re.find(mem, "port=8080")!!;
+     defer m.free();
+     assert(m.named_group("key")!! == "port");
+     assert(m.named_group("value")!! == "8080");
+ - Replace all:
+     Regex* re = regex::compile(mem, "\\d+")!!;
+     defer re.free();
+     String out = re.replace_all(mem, "v1 v22", "<$0>")!!;
+     defer alloc::free(mem, out.ptr);
+     assert(out == "v<1> v<22>");
+ - Fixed-width lookbehind:
+     Regex* re = regex::compile(mem, "(?<=\\$)\\d+")!!;
+     defer re.free();
+     Match m = re.find(mem, "price $42")!!;
+     defer m.free();
+     assert(m.full() == "42");
+
+ Unsupported / intentionally omitted syntax:
+ - No scoped inline-flag groups such as `(?i:foo)`.
+ - No general Unicode property categories such as `\p{L}` / `\P{Nd}` yet.
+*>
+module std::regex;
+import std::io;
+import std::core::string::iterator;
+import std::core::ascii;
+import std::collections::list;
+
+// ============================================================
+// Public faults
+// ============================================================
+
+<*
+ Public regex faults:
+ - `INVALID_PATTERN`: pattern syntax was rejected while parsing.
+ - `COMPILE_ERROR`: the pattern parsed, but could not be lowered to an executable regex.
+ - `NO_MATCH`: no match was found for the requested operation.
+ - `GROUP_NOT_FOUND`: a requested numbered or named capture does not exist or did not match.
+*>
+faultdef INVALID_PATTERN, COMPILE_ERROR, NO_MATCH, GROUP_NOT_FOUND;
+
+// ============================================================
+// Public flags
+// ============================================================
+
+typedef RegexFlags = uint;
+const RegexFlags FLAG_NONE        = (RegexFlags)0;
+const RegexFlags FLAG_IGNORECASE  = (RegexFlags)1;   // i — case-insensitive matching with explicit ASCII/Latin-1/Greek/Cyrillic folding
+const RegexFlags FLAG_MULTILINE   = (RegexFlags)2;   // m — ^ and $ match line boundaries
+const RegexFlags FLAG_DOTALL      = (RegexFlags)4;   // s — . matches \n too
+const RegexFlags FLAG_UNGREEDY    = (RegexFlags)8;   // U — all quantifiers lazy by default
+const RegexFlags FLAG_EXTENDED    = (RegexFlags)16;  // x — free-spacing: ignore whitespace and # comments in pattern
+
+// ============================================================
+// CharClass — hybrid ASCII bitmask + Unicode codepoint ranges
+// ============================================================
+
+struct UnicodeRange
+{
+	Char32 lo;
+	Char32 hi;
+}
+
+typedef UnicodePropMask = uint;
+const UnicodePropMask PROP_NONE        = (UnicodePropMask)0;
+const UnicodePropMask PROP_DIGIT       = (UnicodePropMask)1;
+const UnicodePropMask PROP_WORD        = (UnicodePropMask)2;
+const UnicodePropMask PROP_WHITE_SPACE = (UnicodePropMask)4;
+const UnicodePropMask PROP_HSPACE      = (UnicodePropMask)8;
+const UnicodePropMask PROP_VSPACE      = (UnicodePropMask)16;
+const UnicodePropMask PROP_ASCII       = (UnicodePropMask)32;
+
+struct CharClass
+{
+	AsciiCharset ascii_bits;   // bitmask for codepoints 0–127
+	UnicodeRange* ranges;      // sorted [lo, hi] pairs for codepoints >= 128; not owned
+	usz ranges_count;
+	UnicodePropMask props;     // union of special predicate-backed classes
+	UnicodePropMask complement_props; // union of predicates whose complements were added inside [...]
+	bool negated;
+}
+
+alias TempRangeList = List{UnicodeRange};
+
+// Fold a Unicode codepoint to lowercase for case-insensitive comparison.
+// Covers ASCII, Latin-1 supplement, basic Greek, and basic Cyrillic one-to-one folds.
+fn Char32 unicode_case_fold(Char32 c) @inline
+{
+	if (c < 0x80) return (c >= 'A' && c <= 'Z') ? c + 0x20 : c;
+	if ((c >= 0xC0 && c <= 0xD6) || (c >= 0xD8 && c <= 0xDE)) return c + 0x20;
+	if (c == 0x0178) return 0x00FF; // Ÿ -> ÿ
+	if (c >= 0x0391 && c <= 0x03A1) return c + 0x20;
+	if (c >= 0x03A3 && c <= 0x03AB) return c + 0x20;
+	if (c == 0x03C2) return 0x03C3; // final sigma -> sigma
+	if (c == 0x0401) return 0x0451; // Ё -> ё
+	if (c >= 0x0410 && c <= 0x042F) return c + 0x20;
+	return c;
+}
+
+// Fold a Unicode codepoint to uppercase (inverse of unicode_case_fold for supported ranges).
+fn Char32 unicode_case_unfold(Char32 c) @inline
+{
+	if (c < 0x80) return (c >= 'a' && c <= 'z') ? c - 0x20 : c;
+	if ((c >= 0xE0 && c <= 0xF6) || (c >= 0xF8 && c <= 0xFE)) return c - 0x20;
+	if (c == 0x00FF) return 0x0178; // ÿ -> Ÿ
+	if (c >= 0x03B1 && c <= 0x03C1) return c - 0x20;
+	if (c == 0x03C2) return 0x03A3; // final sigma -> Σ
+	if (c >= 0x03C3 && c <= 0x03CB) return c - 0x20;
+	if (c == 0x0451) return 0x0401; // ё -> Ё
+	if (c >= 0x0430 && c <= 0x044F) return c - 0x20;
+	return c;
+}
+
+fn bool unicode_is_white_space(Char32 c) @local @inline
+{
+	switch (c)
+	{
+		case '\t':
+		case '\n':
+		case '\v':
+		case '\f':
+		case '\r':
+		case ' ':
+		case 0x85:
+		case 0xA0:
+		case 0x1680:
+		case 0x2028:
+		case 0x2029:
+		case 0x202F:
+		case 0x205F:
+		case 0x3000:
+			return true;
+		default:
+			return c >= 0x2000 && c <= 0x200A;
+	}
+}
+
+fn bool unicode_is_hspace(Char32 c) @local @inline
+{
+	switch (c)
+	{
+		case '\t':
+		case ' ':
+		case 0xA0:
+		case 0x1680:
+		case 0x202F:
+		case 0x205F:
+		case 0x3000:
+			return true;
+		default:
+			return c >= 0x2000 && c <= 0x200A;
+	}
+}
+
+fn bool unicode_is_vspace(Char32 c) @local @inline
+{
+	switch (c)
+	{
+		case '\n':
+		case '\v':
+		case '\f':
+		case '\r':
+		case 0x85:
+		case 0x2028:
+		case 0x2029:
+			return true;
+		default:
+			return false;
+	}
+}
+
+fn bool unicode_prop_matches(Char32 c, UnicodePropMask prop) @local @inline
+{
+	switch (prop)
+	{
+		case PROP_DIGIT:
+			return c < 128 && ascii::NUMBER_SET.contains((char)c);
+		case PROP_WORD:
+			return is_word_char(c);
+		case PROP_WHITE_SPACE:
+			return unicode_is_white_space(c);
+		case PROP_HSPACE:
+			return unicode_is_hspace(c);
+		case PROP_VSPACE:
+			return unicode_is_vspace(c);
+		case PROP_ASCII:
+			return c < 128;
+		default:
+			return false;
+	}
+}
+
+fn bool unicode_props_match_any(Char32 c, UnicodePropMask mask) @local @inline
+{
+	if (mask == PROP_NONE) return false;
+	if ((mask & PROP_DIGIT) != PROP_NONE && unicode_prop_matches(c, PROP_DIGIT)) return true;
+	if ((mask & PROP_WORD) != PROP_NONE && unicode_prop_matches(c, PROP_WORD)) return true;
+	if ((mask & PROP_WHITE_SPACE) != PROP_NONE && unicode_prop_matches(c, PROP_WHITE_SPACE)) return true;
+	if ((mask & PROP_HSPACE) != PROP_NONE && unicode_prop_matches(c, PROP_HSPACE)) return true;
+	if ((mask & PROP_VSPACE) != PROP_NONE && unicode_prop_matches(c, PROP_VSPACE)) return true;
+	if ((mask & PROP_ASCII) != PROP_NONE && unicode_prop_matches(c, PROP_ASCII)) return true;
+	return false;
+}
+
+fn bool unicode_props_match_all(Char32 c, UnicodePropMask mask) @local @inline
+{
+	if (mask == PROP_NONE) return false;
+	if ((mask & PROP_DIGIT) != PROP_NONE && !unicode_prop_matches(c, PROP_DIGIT)) return false;
+	if ((mask & PROP_WORD) != PROP_NONE && !unicode_prop_matches(c, PROP_WORD)) return false;
+	if ((mask & PROP_WHITE_SPACE) != PROP_NONE && !unicode_prop_matches(c, PROP_WHITE_SPACE)) return false;
+	if ((mask & PROP_HSPACE) != PROP_NONE && !unicode_prop_matches(c, PROP_HSPACE)) return false;
+	if ((mask & PROP_VSPACE) != PROP_NONE && !unicode_prop_matches(c, PROP_VSPACE)) return false;
+	if ((mask & PROP_ASCII) != PROP_NONE && !unicode_prop_matches(c, PROP_ASCII)) return false;
+	return true;
+}
+
+fn bool CharClass.matches(self, Char32 c, bool icase)
+{
+	bool hit;
+	if (c < 128)
+	{
+		char ac = (char)c;
+		hit = self.ascii_bits.contains(ac);
+		if (icase && !hit)
+		{
+			char lower = ascii::@to_lower(ac);
+			char upper = ascii::@to_upper(ac);
+			hit = self.ascii_bits.contains(lower) || self.ascii_bits.contains(upper);
+		}
+	}
+	else
+	{
+		// Try the character as-is, then its case-folded and case-unfolded forms
+		Char32[3] forms = { c, unicode_case_fold(c), unicode_case_unfold(c) };
+		int n_forms = icase ? 3 : 1;
+		hit = false;
+		for (int fi = 0; fi < n_forms && !hit; fi++)
+		{
+			Char32 cv = forms[fi];
+			usz lo = 0;
+			usz hi = self.ranges_count;
+			while (lo < hi)
+			{
+				usz mid = lo + (hi - lo) / 2;
+				UnicodeRange r = self.ranges[mid];
+				if (cv < r.lo)      { hi = mid; }
+				else if (cv > r.hi) { lo = mid + 1; }
+				else                { hit = true; break; }
+			}
+		}
+	}
+	if (!hit && unicode_props_match_any(c, (UnicodePropMask)self.props))
+	{
+		hit = true;
+	}
+	if (self.complement_props != PROP_NONE && !unicode_props_match_all(c, (UnicodePropMask)self.complement_props))
+	{
+		hit = true;
+	}
+	return self.negated ? !hit : hit;
+}
+
+fn usz utf8_codepoint_width(Char32 c) @inline
+{
+	if (c <= 0x7F) return 1;
+	if (c <= 0x7FF) return 2;
+	if (c <= 0xFFFF) return 3;
+	return 4;
+}
+
+fn bool is_utf8_continuation_byte(char c) @local @inline => (c & 0xC0) == 0x80;
+
+fn usz next_utf8_codepoint_start(String input, usz pos, usz limit) @inline
+{
+	pos++;
+	while (pos < limit && is_utf8_continuation_byte(input[pos])) pos++;
+	return pos;
+}
+
+fn usz prev_utf8_codepoint_start(String input, usz pos) @local @inline
+{
+	if (pos == 0) return 0;
+	pos--;
+	while (pos > 0 && is_utf8_continuation_byte(input[pos])) pos--;
+	return pos;
+}
+
+fn Char32 codepoint_at(String input, usz pos)
+{
+	if (pos >= input.len) return 0;
+	StringIterator it = { .utf8 = input, .current = pos };
+	Char32? cp = it.next();
+	if (catch cp) return 0;
+	return cp;
+}
+
+fn Char32 previous_codepoint_before(String input, usz pos)
+{
+	if (pos == 0) return 0;
+	return codepoint_at(input, prev_utf8_codepoint_start(input, pos));
+}
+
+fn bool is_word_position(String input, usz pos)
+{
+	return pos < input.len && is_word_char(codepoint_at(input, pos));
+}
+
+fn usz? charclass_fixed_width(CharClass cls)
+{
+	if (cls.negated) return INVALID_PATTERN~;
+	if (cls.complement_props != PROP_NONE) return INVALID_PATTERN~;
+
+	usz width = 0;
+	bool has_any = false;
+	if (cls.ascii_bits != (AsciiCharset)0)
+	{
+		width = 1;
+		has_any = true;
+	}
+	for (usz i = 0; i < cls.ranges_count; i++)
+	{
+		UnicodeRange r = cls.ranges[i];
+		usz lo_w = utf8_codepoint_width(r.lo);
+		usz hi_w = utf8_codepoint_width(r.hi);
+		if (lo_w != hi_w) return INVALID_PATTERN~;
+		if (has_any && width != lo_w) return INVALID_PATTERN~;
+		width = lo_w;
+		has_any = true;
+	}
+	UnicodePropMask prop_mask = (UnicodePropMask)cls.props;
+	if ((prop_mask & (PROP_WHITE_SPACE | PROP_HSPACE | PROP_VSPACE)) != PROP_NONE) return INVALID_PATTERN~;
+	if ((prop_mask & (PROP_DIGIT | PROP_WORD | PROP_ASCII)) != PROP_NONE)
+	{
+		if (has_any && width != 1) return INVALID_PATTERN~;
+		width = 1;
+		has_any = true;
+	}
+	return has_any ? width : INVALID_PATTERN~;
+}
+
+// Build a charset for a contiguous ASCII range [lo, hi]
+macro AsciiCharset @ascii_range_set(int $lo, int $hi) @const
+{
+	var $s = (AsciiCharset)0;
+	$for var $c = $lo; $c <= $hi; $c++:
+		$s |= (AsciiCharset)1 << $c;
+	$endfor
+	return $s;
+}
+
+// POSIX-class charsets
+const AsciiCharset XDIGIT_SET   = ascii::@create_set("0123456789abcdefABCDEF");
+const AsciiCharset BLANK_SET    = ascii::@create_set(" \t");
+const AsciiCharset WORD_SET     = ascii::ALPHANUMERIC_SET | ((AsciiCharset)1 << '_');
+// ASCII subset of horizontal whitespace; Unicode handling is provided by PROP_HSPACE.
+const AsciiCharset HSPACE_SET   = ascii::@create_set(" \t");
+// ASCII subset of vertical whitespace; Unicode handling is provided by PROP_VSPACE.
+const AsciiCharset VSPACE_SET   = ascii::@create_set("\n\v\f\r");
+// Print: ASCII 32..126
+const AsciiCharset PRINT_SET    = @ascii_range_set(32, 126);
+// Graph: ASCII 33..126 (printable non-space)
+const AsciiCharset GRAPH_SET    = @ascii_range_set(33, 126);
+// Cntrl: ASCII 0..31 + 127
+const AsciiCharset CNTRL_LOW    = @ascii_range_set(0, 31);
+const AsciiCharset CNTRL_SET    = CNTRL_LOW | ((AsciiCharset)1 << 127);
+// Punct: graph but not alnum
+const AsciiCharset PUNCT_SET    = ascii::@create_set("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
+
+// Predefined CharClass constants
+const CharClass CLASS_DIGIT      = { .ascii_bits = ascii::NUMBER_SET,      .props = PROP_DIGIT };
+const CharClass CLASS_DIGIT_INV  = { .ascii_bits = ascii::NUMBER_SET,      .props = PROP_DIGIT,       .negated = true };
+const CharClass CLASS_WORD       = { .ascii_bits = WORD_SET,               .props = PROP_WORD };
+const CharClass CLASS_WORD_INV   = { .ascii_bits = WORD_SET,               .props = PROP_WORD,        .negated = true };
+const CharClass CLASS_SPACE      = { .ascii_bits = ascii::WHITESPACE_SET,  .props = PROP_WHITE_SPACE };
+const CharClass CLASS_SPACE_INV  = { .ascii_bits = ascii::WHITESPACE_SET,  .props = PROP_WHITE_SPACE, .negated = true };
+// DOT: matches everything except '\n'; compared by ascii_bits value in simulation
+const CharClass CLASS_DOT        = { .ascii_bits = ~((AsciiCharset)1 << '\n') };
+// Horizontal/vertical whitespace classes
+const CharClass CLASS_HSPACE     = { .ascii_bits = HSPACE_SET, .props = PROP_HSPACE };
+const CharClass CLASS_HSPACE_INV = { .ascii_bits = HSPACE_SET, .props = PROP_HSPACE, .negated = true };
+const CharClass CLASS_VSPACE     = { .ascii_bits = VSPACE_SET, .props = PROP_VSPACE };
+const CharClass CLASS_VSPACE_INV = { .ascii_bits = VSPACE_SET, .props = PROP_VSPACE, .negated = true };
+
+// ============================================================
+// AST nodes — temporary; allocated from tmem during compile
+// ============================================================
+
+enum AstKind : char
+{
+	AST_LITERAL,
+	AST_CHARCLASS,
+	AST_CONCAT,
+	AST_ALT,
+	AST_STAR,
+	AST_PLUS,
+	AST_QUEST,
+	AST_REPEAT,
+	AST_GROUP,
+	AST_NCGROUP,
+	AST_LOOKAHEAD_POS,
+	AST_LOOKAHEAD_NEG,
+	AST_LOOKBEHIND_POS,
+	AST_LOOKBEHIND_NEG,
+	AST_ANCHOR_START,
+	AST_ANCHOR_END,
+	AST_ANCHOR_ABSOLUTE_START,  // \A — always matches start of input
+	AST_ANCHOR_ABSOLUTE_END,    // \z — always matches end of input
+	AST_ANCHOR_ABSOLUTE_END_NL, // \Z — matches end of input or before final \n
+	AST_WORD_BOUND,
+	AST_WORD_NBOUND,
+	AST_LINEBREAK,              // \R — generic line break (\r\n or single Unicode newline)
+	AST_KEEP,                   // \K — reset match start to current position
+	AST_NON_NEWLINE,            // \N — non-newline (like . but ignores FLAG_DOTALL)
+	AST_BACKREF,                // \1-\9 or \k<name> — backreference to capture group
+	AST_ATOMIC,                 // (?>...) — atomic group (no backtracking into sub-expr)
+	AST_ANCHOR_GPOS,            // \G — match at start_pos of current find_at call
+	AST_COND_GROUP,             // (?(N)yes|no) / (?(name)yes|no) — conditional pattern
+	AST_BRANCH_RESET,           // (?|...) — branch reset group (groups reuse IDs across alts)
+}
+
+struct AstNode
+{
+	AstKind kind;
+	AstNode* left;
+	AstNode* right;
+	Char32 codepoint;
+	CharClass char_class;
+	int group_id;
+	String group_name;   // slice into pattern; non-owning
+	int repeat_min;
+	int repeat_max;      // -1 = unlimited
+	bool lazy;
+}
+
+// ============================================================
+// NFA states
+// ============================================================
+
+enum StateKind : char
+{
+	STATE_LITERAL,
+	STATE_CHARSET,
+	STATE_SPLIT,
+	STATE_MATCH,
+	STATE_CAPTURE_START,
+	STATE_CAPTURE_END,
+	STATE_LOOKAHEAD_POS,
+	STATE_LOOKAHEAD_NEG,
+	STATE_LOOKBEHIND_POS,
+	STATE_LOOKBEHIND_NEG,
+	STATE_ANCHOR_START,
+	STATE_ANCHOR_END,
+	STATE_ANCHOR_ABSOLUTE_START,  // \A
+	STATE_ANCHOR_ABSOLUTE_END,    // \z
+	STATE_ANCHOR_ABSOLUTE_END_NL, // \Z
+	STATE_WORD_BOUND,
+	STATE_WORD_NBOUND,
+	STATE_KEEP,            // \K — resets match start to current position
+	STATE_BACKREF,         // \1-\9 or \k<name> — compare captured text at current pos
+	STATE_ATOMIC,          // (?>...) — run sub-NFA, commit to first match (no retry)
+	STATE_ANCHOR_GPOS,     // \G — match at re.gpos (start_pos of current find_at call)
+	STATE_COND_GROUP,      // (?(N)yes|no) — conditional; backref_id=group, lookaround_start=yes, out2=no
+}
+
+struct NfaState
+{
+	StateKind kind;
+	NfaState* out1;
+	NfaState* out2;             // SPLIT only
+	usz index;                  // position in flat states[] array
+	Char32 codepoint;           // STATE_LITERAL
+	CharClass char_class;       // STATE_CHARSET
+	int group_id;               // CAPTURE_START/END
+	NfaState* lookaround_start;   // lookahead/lookbehind sub-NFA entry
+	usz lookbehind_len;           // fixed-width lookbehind byte count
+	bool lookbehind_variable;     // true = variable-width; scan all start positions
+	int backref_id;               // STATE_BACKREF: capture group index (1-based)
+	bool lazy;                    // SPLIT only: lazy quantifier
+}
+
+// Thompson construction fragment: a start state + dangling output pointers
+alias PatchList = List{NfaState**};
+
+struct NfaFrag
+{
+	NfaState* start;
+	PatchList  out;
+}
+
+// ============================================================
+// Named group entry
+// ============================================================
+
+struct NamedGroupEntry
+{
+	String name;      // owned by Regex.allocator
+	int group_id;
+}
+
+// ============================================================
+// Public types
+// ============================================================
+
+struct Regex
+{
+	Allocator       allocator;
+	NfaState*       states;
+	usz             state_count;
+	usz             start_idx;     // index of NFA start state in states[]
+	int             group_count;
+	NamedGroupEntry* named_groups;
+	usz             named_group_count;
+	UnicodeRange*   range_pool;
+	usz             range_pool_count;
+	RegexFlags      flags;
+	bool            has_backref;   // pattern contains \1-\9; routes to BT engine
+	bool            has_atomic;    // pattern contains (?>...); routes to BT engine
+	bool            has_gpos;      // pattern contains \G; routes to BT engine
+	bool            has_cond;      // pattern contains (?(N)...); routes to BT engine
+	bool            has_start_filter; // first consumed codepoint must match start_filter
+	CharClass       start_filter;
+	usz             gpos;          // set to start_pos before each BT match attempt (for \G)
+}
+
+struct MatchGroup
+{
+	usz  start;
+	usz  end;
+	bool matched;
+}
+
+struct Match
+{
+	Regex*      regex;
+	String      input;
+	MatchGroup* groups;     // groups[0] = full match; groups[1..] = captures; owned
+	usz         group_count;
+	Allocator   allocator;
+}
+
+struct MatchIter
+{
+	Regex*    regex;
+	String    input;
+	usz       pos;
+	Allocator allocator;
+}
+
+// ============================================================
+// Match methods
+// ============================================================
+
+<*
+ Returns the full matched substring.
+
+ @return "The full matched substring."
+*>
+fn String Match.full(self)
+{
+	MatchGroup g = self.groups[0];
+	return self.input[g.start : g.end - g.start];
+}
+
+<*
+ Returns the byte offset of the start of the full match.
+
+ @return "The byte offset of the start of the full match."
+*>
+fn usz Match.start(self) => self.groups[0].start;
+
+<*
+ Returns the byte offset one past the end of the full match.
+
+ @return "The byte offset one past the end of the full match."
+*>
+fn usz Match.end(self)   => self.groups[0].end;
+
+<*
+ Returns capture group `index`.
+
+ Group `0` is the full match. Returns `GROUP_NOT_FOUND` when the group index is out of
+ range or when that capture did not participate in this match.
+
+ @param index : "The capture index. Group 0 is the full match."
+ @return "The substring captured by the requested group."
+ @return? GROUP_NOT_FOUND : "If the group index is out of range or did not participate in this match."
+*>
+fn String? Match.group(self, usz index)
+{
+	if (index >= self.group_count) return GROUP_NOT_FOUND~;
+	MatchGroup g = self.groups[index];
+	if (!g.matched) return GROUP_NOT_FOUND~;
+	return self.input[g.start : g.end - g.start];
+}
+
+<*
+ Returns the named capture `name`.
+
+ Returns `GROUP_NOT_FOUND` when the name is unknown or when the capture did not
+ participate in this match.
+
+ @param name : "The capture name to look up."
+ @return "The substring captured by the requested named group."
+ @return? GROUP_NOT_FOUND : "If the capture name is unknown or did not participate in this match."
+*>
+fn String? Match.named_group(self, String name)
+{
+	Regex* re = self.regex;
+	for (usz i = 0; i < re.named_group_count; i++)
+	{
+		if (re.named_groups[i].name == name)
+		{
+			return self.group((usz)re.named_groups[i].group_id);
+		}
+	}
+	return GROUP_NOT_FOUND~;
+}
+
+<*
+ Releases the capture buffer owned by this match.
+*>
+fn void Match.free(&self)
+{
+	if (self.groups)
+	{
+		alloc::free(self.allocator, self.groups);
+		self.groups = null;
+	}
+}
+
+// ============================================================
+// MatchIter
+// ============================================================
+
+<*
+ Returns the next non-overlapping match from the iterator.
+
+ Zero-length matches advance by one UTF-8 codepoint to guarantee forward progress.
+ Returns `NO_MATCH` when the iterator is exhausted.
+
+ @return "The next non-overlapping match."
+ @return? NO_MATCH : "If the iterator is exhausted."
+*>
+fn Match? MatchIter.next(&self)
+{
+	if (self.pos > self.input.len) return NO_MATCH~;
+	Match? m = self.regex.find_at(self.allocator, self.input, self.pos);
+	if (catch err = m) return err~;
+	usz start = m.start();
+	usz end = m.end();
+	if (end == start)
+	{
+		// Zero-length match: advance past the codepoint at the match start.
+		// This avoids repeating zero-length matches that were found ahead of
+		// the current scan position when find_at() searched forward.
+		self.pos = start + 1;
+		while (self.pos < self.input.len && (self.input[self.pos] & 0xC0) == 0x80) self.pos++;
+	}
+	else
+	{
+		self.pos = end;
+	}
+	return m;
+}
+
+// ============================================================
+// Public compile API
+// ============================================================
+
+<*
+ Compile a regex pattern.
+
+ Returns a heap-owned `Regex*` that must be released with `Regex.free()`.
+ Can fault with `INVALID_PATTERN` or `COMPILE_ERROR`.
+
+ @param [&inout] allocator : "Allocator for the Regex object and its data"
+ @param pattern : "The regex pattern string"
+ @param flags : "Optional flags"
+ @return "A compiled regex that must be released with Regex.free()."
+ @return? INVALID_PATTERN, COMPILE_ERROR : "If parsing or compilation fails."
+*>
+fn Regex*? compile(Allocator allocator, String pattern, RegexFlags flags = FLAG_NONE)
+{
+	Regex* re = alloc::new(allocator, Regex);
+	re.allocator = allocator;
+	re.flags = flags;
+	defer catch re.free();
+
+	@pool()
+	{
+		ParseCtx ctx = {
+			.pattern = pattern,
+			.pos = 0,
+			.next_group_id = 0,
+			.regex_alloc = allocator,
+			.flags = flags
+		};
+
+		AstNode* ast = parse_expr(&ctx)!;
+		if (ctx.pos != pattern.len) return INVALID_PATTERN~;
+		re.group_count = ctx.next_group_id;
+
+		BuildCtx bctx = { .alloc = allocator };
+		bctx.all_states.tinit(64);
+		bctx.range_pool.tinit(16);
+
+		NfaFrag frag = build_nfa(&bctx, ast, flags)!;
+
+		NfaState* match_s = nfa_new(&bctx, STATE_MATCH);
+		frag_patch(&frag, match_s);
+		frag.out.free();
+
+		usz n = bctx.all_states.size;
+		NfaState* state_arr = alloc::new_array(allocator, NfaState, n);
+		for (usz i = 0; i < n; i++)
+		{
+			state_arr[i] = *bctx.all_states.entries[i];
+			state_arr[i].index = i;
+		}
+		for (usz i = 0; i < n; i++)
+		{
+			NfaState* old = bctx.all_states.entries[i];
+			if (old.out1 != null) state_arr[i].out1 = &state_arr[old.out1.index];
+			if (old.out2 != null) state_arr[i].out2 = &state_arr[old.out2.index];
+			if (old.lookaround_start != null) state_arr[i].lookaround_start = &state_arr[old.lookaround_start.index];
+		}
+
+		re.states = state_arr;
+		re.state_count = n;
+		re.start_idx = frag.start.index;
+
+		for (usz i = 0; i < n; i++)
+		{
+			if (state_arr[i].kind == STATE_BACKREF) re.has_backref = true;
+			if (state_arr[i].kind == STATE_ATOMIC) re.has_atomic = true;
+			if (state_arr[i].kind == STATE_ANCHOR_GPOS) re.has_gpos = true;
+			if (state_arr[i].kind == STATE_COND_GROUP) re.has_cond = true;
+		}
+
+		usz pool_size = bctx.range_pool.size;
+		if (pool_size > 0)
+		{
+			UnicodeRange* pool = alloc::new_array(allocator, UnicodeRange, pool_size);
+			for (usz i = 0; i < pool_size; i++) pool[i] = bctx.range_pool.entries[i];
+			re.range_pool = pool;
+			re.range_pool_count = pool_size;
+			for (usz i = 0; i < n; i++)
+			{
+				if (state_arr[i].kind == STATE_CHARSET && state_arr[i].char_class.ranges_count > 0)
+				{
+					usz offset = (usz)(uptr)state_arr[i].char_class.ranges;
+					state_arr[i].char_class.ranges = &pool[offset];
+				}
+			}
+		}
+		re.compute_start_filter();
+
+		usz ng = ctx.named_groups_count;
+		if (ng > 0)
+		{
+			re.named_groups = alloc::new_array(allocator, NamedGroupEntry, ng);
+			for (usz i = 0; i < ng; i++)
+			{
+				NamedGroupEntry src = ctx.named_groups_buf[i];
+				char* nbuf = alloc::new_array(allocator, char, src.name.len);
+				mem::copy(nbuf, src.name.ptr, src.name.len);
+				re.named_groups[i] = { .name = (String)nbuf[:src.name.len], .group_id = src.group_id };
+			}
+			re.named_group_count = ng;
+		}
+
+		for (usz i = 0; i < n; i++) alloc::free(allocator, bctx.all_states.entries[i]);
+		bctx.all_states.free();
+		bctx.range_pool.free();
+	};
+	return re;
+}
+
+<*
+ Compile a regex using the temp allocator.
+
+ The returned regex still owns heap state and should be freed with `Regex.free()` before
+ the temp allocator is reset.
+
+ @return "A compiled regex using the temp allocator."
+*>
+fn Regex* tcompile(String pattern, RegexFlags flags = FLAG_NONE) => compile(tmem, pattern, flags)!!;
+
+<*
+ Free all resources owned by the Regex.
+*>
+fn void Regex.free(&self)
+{
+	if (self.states != null)
+	{
+		alloc::free(self.allocator, self.states);
+		self.states = null;
+	}
+	if (self.range_pool != null)
+	{
+		alloc::free(self.allocator, self.range_pool);
+		self.range_pool = null;
+	}
+	if (self.start_filter.ranges != null)
+	{
+		alloc::free(self.allocator, self.start_filter.ranges);
+		self.start_filter.ranges = null;
+	}
+	if (self.named_groups != null)
+	{
+		for (usz i = 0; i < self.named_group_count; i++)
+		{
+			alloc::free(self.allocator, self.named_groups[i].name.ptr);
+		}
+		alloc::free(self.allocator, self.named_groups);
+		self.named_groups = null;
+	}
+	alloc::free(self.allocator, self);
+}
+
+// ============================================================
+// Public find / match API
+// ============================================================
+
+<*
+ Find the first match starting at start_pos.
+
+ Returns a heap-owned `Match` that must be released with `Match.free()`.
+ Returns `NO_MATCH` when no match is found.
+
+ @param [&inout] allocator : "Allocator for Match.groups"
+ @param start_pos : "The first byte position to search from; unanchored patterns may still advance beyond this point."
+ @return "The first match at or after the requested start position."
+ @return? NO_MATCH : "If no match is found."
+*>
+fn Match? Regex.find_at(&self, Allocator allocator, String input, usz start_pos = 0)
+{
+	bool anchored = self.state_count > 0
+		&& (self.states[self.start_idx].kind == STATE_ANCHOR_ABSOLUTE_START
+			|| self.states[self.start_idx].kind == STATE_ANCHOR_GPOS
+			|| (self.states[self.start_idx].kind == STATE_ANCHOR_START
+				&& (self.flags & FLAG_MULTILINE) == FLAG_NONE));
+	usz pos = start_pos;
+	while (pos <= input.len)
+	{
+		if (!anchored && self.has_start_filter)
+		{
+			while (pos < input.len && !self.start_filter.matches(codepoint_at(input, pos), (self.flags & FLAG_IGNORECASE) != FLAG_NONE))
+			{
+				pos = next_utf8_codepoint_start(input, pos, input.len);
+			}
+			if (pos > input.len || (pos == input.len && !anchored)) break;
+		}
+		Match? m = try_match_at(self, input, pos, allocator);
+		if (try m) return m;
+		if (anchored) break;
+		if (pos >= input.len) break;
+		pos = next_utf8_codepoint_start(input, pos, input.len);
+	}
+	return NO_MATCH~;
+}
+
+<*
+ Find the first match in input.
+
+ Returns a heap-owned `Match` that must be released with `Match.free()`.
+ Returns `NO_MATCH` when no match is found.
+
+ @param [&inout] allocator : "Allocator for Match.groups"
+ @return "The first match in the input."
+ @return? NO_MATCH : "If no match is found."
+*>
+fn Match? Regex.find(&self, Allocator allocator, String input) => self.find_at(allocator, input, 0);
+
+<*
+ Returns true if the pattern matches anywhere in input.
+
+ @return "True if the pattern matches anywhere in the input."
+*>
+fn bool Regex.is_match(&self, String input)
+{
+	@pool()
+	{
+		return @ok(self.find_at(tmem, input));
+	};
+}
+
+<*
+ Returns a MatchIter over all non-overlapping matches.
+
+ Each successful `next()` call yields a heap-owned `Match` that must be freed by the caller.
+
+ @param [&inout] allocator : "Allocator for each Match returned by MatchIter.next()"
+ @return "An iterator over all non-overlapping matches."
+*>
+fn MatchIter Regex.find_all(&self, Allocator allocator, String input)
+{
+	return { .regex = self, .input = input, .pos = 0, .allocator = allocator };
+}
+
+// ============================================================
+// Replace
+// ============================================================
+
+fn usz? parse_replacement_group_index(String text) @local
+{
+	if (text.len == 0) return NO_MATCH~;
+	usz value = 0;
+	foreach (c : text)
+	{
+		if (c < '0' || c > '9') return NO_MATCH~;
+		value = value * 10 + (usz)(c - '0');
+	}
+	return value;
+}
+
+fn void apply_replacement(DString* buf, String repl, Match* m)
+{
+	usz i = 0;
+	while (i < repl.len)
+	{
+		char c = repl[i];
+		if (c == '$' && i + 1 < repl.len)
+		{
+			char next = repl[i + 1];
+			if (next == '$')
+			{
+				buf.append_char('$');
+				i += 2;
+				continue;
+			}
+			if (next == '&' || next == '0')
+			{
+				String? gs = m.group(0);
+				if (try gs) { buf.append_string(gs); }
+				i += 2;
+				continue;
+			}
+			if (next >= '1' && next <= '9')
+			{
+				usz idx = (usz)(next - '0');
+				String? gs = m.group(idx);
+				if (try gs) { buf.append_string(gs); }
+				i += 2;
+				continue;
+			}
+			if (next == '{')
+			{
+				usz j = i + 2;
+				while (j < repl.len && repl[j] != '}') j++;
+				if (j < repl.len)
+				{
+					String name = repl[i + 2 : j - i - 2];
+					String? gs;
+					if (try idx = parse_replacement_group_index(name))
+					{
+						gs = m.group(idx);
+					}
+					else
+					{
+						gs = m.named_group(name);
+					}
+					if (try gs) { buf.append_string(gs); }
+					i = j + 1;
+					continue;
+				}
+			}
+		}
+		buf.append_char(c);
+		i++;
+	}
+}
+
+<*
+ Replace the first match with replacement.
+
+ Supported replacement escapes:
+ - `$$` for a literal `$`
+ - `$&` / `$0` for the full match
+ - `$1`..`$9` for numbered captures
+ - `${N}` for any numbered capture, including `${0}`
+ - `${name}` for named captures
+
+ Unknown or unmatched capture references expand to the empty string.
+ Returns `NO_MATCH` if no match exists in the input.
+
+ @return "A newly allocated string with the first match replaced."
+ @return? NO_MATCH : "If no match exists in the input."
+*>
+fn String? Regex.replace(&self, Allocator allocator, String input, String replacement)
+{
+	Match? m = self.find(allocator, input);
+	if (catch err = m) return err~;
+	defer m.free();
+	DString buf;
+	buf.init(allocator, input.len + replacement.len);
+	defer buf.free();
+	buf.append_string(input[0 : m.start()]);
+	apply_replacement(&buf, replacement, &m);
+	buf.append_string(input[m.end() ..]);
+	return buf.copy_str(allocator);
+}
+
+<*
+ Replace all non-overlapping matches with replacement.
+
+ Supported replacement escapes:
+ - `$$` for a literal `$`
+ - `$&` / `$0` for the full match
+ - `$1`..`$9` for numbered captures
+ - `${N}` for any numbered capture, including `${0}`
+ - `${name}` for named captures
+
+ Unknown or unmatched capture references expand to the empty string.
+ Returns a newly allocated string. If there are no matches, the original input is copied.
+
+ @return "A newly allocated string with all non-overlapping matches replaced."
+*>
+fn String? Regex.replace_all(&self, Allocator allocator, String input, String replacement)
+{
+	DString buf;
+	buf.init(allocator, input.len);
+	defer buf.free();
+	usz pos = 0;
+	while (pos <= input.len)
+	{
+		Match? m = self.find_at(allocator, input, pos);
+		if (catch m) break;
+		buf.append_string(input[pos : m.start() - pos]);
+		apply_replacement(&buf, replacement, &m);
+		usz match_start = m.start();
+		usz new_pos = m.end();
+		bool zero_length = match_start == new_pos;
+		m.free();
+		if (zero_length)
+		{
+			pos = new_pos;
+			if (pos < input.len)
+			{
+				usz next_pos = next_utf8_codepoint_start(input, pos, input.len);
+				buf.append_string(input[pos : next_pos - pos]);
+				pos = next_pos;
+			}
+			else
+			{
+				pos = input.len + 1;
+			}
+		}
+		else
+		{
+			pos = new_pos;
+		}
+	}
+	if (pos <= input.len) buf.append_string(input[pos ..]);
+	return buf.copy_str(allocator);
+}
+
+// ============================================================
+// Parse / build contexts
+// ============================================================
+
+struct ParseCtx
+{
+	String    pattern;
+	usz       pos;
+	int       next_group_id;
+	Allocator regex_alloc;
+	RegexFlags flags;
+	NamedGroupEntry* named_groups_buf;
+	usz named_groups_count;
+	usz named_groups_cap;
+}
+
+struct BuildCtx
+{
+	Allocator alloc;
+	List{NfaState*} all_states;
+	List{UnicodeRange} range_pool;
+}

--- a/lib/std/regex/regex.c3
+++ b/lib/std/regex/regex.c3
@@ -124,32 +124,32 @@ const RegexFlags FLAG_EXTENDED    = (RegexFlags)16;  // x — free-spacing: igno
 // CharClass — hybrid ASCII bitmask + Unicode codepoint ranges
 // ============================================================
 
-struct UnicodeRange
+struct RegexUnicodeRange
 {
 	Char32 lo;
 	Char32 hi;
 }
 
-typedef UnicodePropMask = uint;
-const UnicodePropMask PROP_NONE        = (UnicodePropMask)0;
-const UnicodePropMask PROP_DIGIT       = (UnicodePropMask)1;
-const UnicodePropMask PROP_WORD        = (UnicodePropMask)2;
-const UnicodePropMask PROP_WHITE_SPACE = (UnicodePropMask)4;
-const UnicodePropMask PROP_HSPACE      = (UnicodePropMask)8;
-const UnicodePropMask PROP_VSPACE      = (UnicodePropMask)16;
-const UnicodePropMask PROP_ASCII       = (UnicodePropMask)32;
+typedef RegexUnicodePropMask = uint;
+const RegexUnicodePropMask PROP_NONE        = (RegexUnicodePropMask)0;
+const RegexUnicodePropMask PROP_DIGIT       = (RegexUnicodePropMask)1;
+const RegexUnicodePropMask PROP_WORD        = (RegexUnicodePropMask)2;
+const RegexUnicodePropMask PROP_WHITE_SPACE = (RegexUnicodePropMask)4;
+const RegexUnicodePropMask PROP_HSPACE      = (RegexUnicodePropMask)8;
+const RegexUnicodePropMask PROP_VSPACE      = (RegexUnicodePropMask)16;
+const RegexUnicodePropMask PROP_ASCII       = (RegexUnicodePropMask)32;
 
-struct CharClass
+struct RegexCharClass
 {
 	AsciiCharset ascii_bits;   // bitmask for codepoints 0–127
-	UnicodeRange* ranges;      // sorted [lo, hi] pairs for codepoints >= 128; not owned
+	RegexUnicodeRange* ranges;      // sorted [lo, hi] pairs for codepoints >= 128; not owned
 	usz ranges_count;
-	UnicodePropMask props;     // union of special predicate-backed classes
-	UnicodePropMask complement_props; // union of predicates whose complements were added inside [...]
+	RegexUnicodePropMask props;     // union of special predicate-backed classes
+	RegexUnicodePropMask complement_props; // union of predicates whose complements were added inside [...]
 	bool negated;
 }
 
-alias TempRangeList = List{UnicodeRange};
+alias RegexTempRangeList = List{RegexUnicodeRange};
 
 // Fold a Unicode codepoint to lowercase for case-insensitive comparison.
 // Covers ASCII, Latin-1 supplement, basic Greek, and basic Cyrillic one-to-one folds.
@@ -238,7 +238,7 @@ fn bool unicode_is_vspace(Char32 c) @local @inline
 	}
 }
 
-fn bool unicode_prop_matches(Char32 c, UnicodePropMask prop) @local @inline
+fn bool unicode_prop_matches(Char32 c, RegexUnicodePropMask prop) @local @inline
 {
 	switch (prop)
 	{
@@ -259,7 +259,7 @@ fn bool unicode_prop_matches(Char32 c, UnicodePropMask prop) @local @inline
 	}
 }
 
-fn bool unicode_props_match_any(Char32 c, UnicodePropMask mask) @local @inline
+fn bool unicode_props_match_any(Char32 c, RegexUnicodePropMask mask) @local @inline
 {
 	if (mask == PROP_NONE) return false;
 	if ((mask & PROP_DIGIT) != PROP_NONE && unicode_prop_matches(c, PROP_DIGIT)) return true;
@@ -271,7 +271,7 @@ fn bool unicode_props_match_any(Char32 c, UnicodePropMask mask) @local @inline
 	return false;
 }
 
-fn bool unicode_props_match_all(Char32 c, UnicodePropMask mask) @local @inline
+fn bool unicode_props_match_all(Char32 c, RegexUnicodePropMask mask) @local @inline
 {
 	if (mask == PROP_NONE) return false;
 	if ((mask & PROP_DIGIT) != PROP_NONE && !unicode_prop_matches(c, PROP_DIGIT)) return false;
@@ -283,7 +283,7 @@ fn bool unicode_props_match_all(Char32 c, UnicodePropMask mask) @local @inline
 	return true;
 }
 
-fn bool CharClass.matches(self, Char32 c, bool icase)
+fn bool RegexCharClass.matches(self, Char32 c, bool icase)
 {
 	bool hit;
 	if (c < 128)
@@ -311,18 +311,18 @@ fn bool CharClass.matches(self, Char32 c, bool icase)
 			while (lo < hi)
 			{
 				usz mid = lo + (hi - lo) / 2;
-				UnicodeRange r = self.ranges[mid];
+				RegexUnicodeRange r = self.ranges[mid];
 				if (cv < r.lo)      { hi = mid; }
 				else if (cv > r.hi) { lo = mid + 1; }
 				else                { hit = true; break; }
 			}
 		}
 	}
-	if (!hit && unicode_props_match_any(c, (UnicodePropMask)self.props))
+	if (!hit && unicode_props_match_any(c, (RegexUnicodePropMask)self.props))
 	{
 		hit = true;
 	}
-	if (self.complement_props != PROP_NONE && !unicode_props_match_all(c, (UnicodePropMask)self.complement_props))
+	if (self.complement_props != PROP_NONE && !unicode_props_match_all(c, (RegexUnicodePropMask)self.complement_props))
 	{
 		hit = true;
 	}
@@ -374,7 +374,7 @@ fn bool is_word_position(String input, usz pos)
 	return pos < input.len && is_word_char(codepoint_at(input, pos));
 }
 
-fn usz? charclass_fixed_width(CharClass cls)
+fn usz? charclass_fixed_width(RegexCharClass cls)
 {
 	if (cls.negated) return INVALID_PATTERN~;
 	if (cls.complement_props != PROP_NONE) return INVALID_PATTERN~;
@@ -388,7 +388,7 @@ fn usz? charclass_fixed_width(CharClass cls)
 	}
 	for (usz i = 0; i < cls.ranges_count; i++)
 	{
-		UnicodeRange r = cls.ranges[i];
+		RegexUnicodeRange r = cls.ranges[i];
 		usz lo_w = utf8_codepoint_width(r.lo);
 		usz hi_w = utf8_codepoint_width(r.hi);
 		if (lo_w != hi_w) return INVALID_PATTERN~;
@@ -396,7 +396,7 @@ fn usz? charclass_fixed_width(CharClass cls)
 		width = lo_w;
 		has_any = true;
 	}
-	UnicodePropMask prop_mask = (UnicodePropMask)cls.props;
+	RegexUnicodePropMask prop_mask = (RegexUnicodePropMask)cls.props;
 	if ((prop_mask & (PROP_WHITE_SPACE | PROP_HSPACE | PROP_VSPACE)) != PROP_NONE) return INVALID_PATTERN~;
 	if ((prop_mask & (PROP_DIGIT | PROP_WORD | PROP_ASCII)) != PROP_NONE)
 	{
@@ -436,25 +436,25 @@ const AsciiCharset CNTRL_SET    = CNTRL_LOW | ((AsciiCharset)1 << 127);
 const AsciiCharset PUNCT_SET    = ascii::@create_set("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
 
 // Predefined CharClass constants
-const CharClass CLASS_DIGIT      = { .ascii_bits = ascii::NUMBER_SET,      .props = PROP_DIGIT };
-const CharClass CLASS_DIGIT_INV  = { .ascii_bits = ascii::NUMBER_SET,      .props = PROP_DIGIT,       .negated = true };
-const CharClass CLASS_WORD       = { .ascii_bits = WORD_SET,               .props = PROP_WORD };
-const CharClass CLASS_WORD_INV   = { .ascii_bits = WORD_SET,               .props = PROP_WORD,        .negated = true };
-const CharClass CLASS_SPACE      = { .ascii_bits = ascii::WHITESPACE_SET,  .props = PROP_WHITE_SPACE };
-const CharClass CLASS_SPACE_INV  = { .ascii_bits = ascii::WHITESPACE_SET,  .props = PROP_WHITE_SPACE, .negated = true };
+const RegexCharClass CLASS_DIGIT      = { .ascii_bits = ascii::NUMBER_SET,      .props = PROP_DIGIT };
+const RegexCharClass CLASS_DIGIT_INV  = { .ascii_bits = ascii::NUMBER_SET,      .props = PROP_DIGIT,       .negated = true };
+const RegexCharClass CLASS_WORD       = { .ascii_bits = WORD_SET,               .props = PROP_WORD };
+const RegexCharClass CLASS_WORD_INV   = { .ascii_bits = WORD_SET,               .props = PROP_WORD,        .negated = true };
+const RegexCharClass CLASS_SPACE      = { .ascii_bits = ascii::WHITESPACE_SET,  .props = PROP_WHITE_SPACE };
+const RegexCharClass CLASS_SPACE_INV  = { .ascii_bits = ascii::WHITESPACE_SET,  .props = PROP_WHITE_SPACE, .negated = true };
 // DOT: matches everything except '\n'; compared by ascii_bits value in simulation
-const CharClass CLASS_DOT        = { .ascii_bits = ~((AsciiCharset)1 << '\n') };
+const RegexCharClass CLASS_DOT        = { .ascii_bits = ~((AsciiCharset)1 << '\n') };
 // Horizontal/vertical whitespace classes
-const CharClass CLASS_HSPACE     = { .ascii_bits = HSPACE_SET, .props = PROP_HSPACE };
-const CharClass CLASS_HSPACE_INV = { .ascii_bits = HSPACE_SET, .props = PROP_HSPACE, .negated = true };
-const CharClass CLASS_VSPACE     = { .ascii_bits = VSPACE_SET, .props = PROP_VSPACE };
-const CharClass CLASS_VSPACE_INV = { .ascii_bits = VSPACE_SET, .props = PROP_VSPACE, .negated = true };
+const RegexCharClass CLASS_HSPACE     = { .ascii_bits = HSPACE_SET, .props = PROP_HSPACE };
+const RegexCharClass CLASS_HSPACE_INV = { .ascii_bits = HSPACE_SET, .props = PROP_HSPACE, .negated = true };
+const RegexCharClass CLASS_VSPACE     = { .ascii_bits = VSPACE_SET, .props = PROP_VSPACE };
+const RegexCharClass CLASS_VSPACE_INV = { .ascii_bits = VSPACE_SET, .props = PROP_VSPACE, .negated = true };
 
 // ============================================================
 // AST nodes — temporary; allocated from tmem during compile
 // ============================================================
 
-enum AstKind : char
+enum RegexAstKind : char
 {
 	AST_LITERAL,
 	AST_CHARCLASS,
@@ -487,13 +487,13 @@ enum AstKind : char
 	AST_BRANCH_RESET,           // (?|...) — branch reset group (groups reuse IDs across alts)
 }
 
-struct AstNode
+struct RegexAstNode
 {
-	AstKind kind;
-	AstNode* left;
-	AstNode* right;
+	RegexAstKind kind;
+	RegexAstNode* left;
+	RegexAstNode* right;
 	Char32 codepoint;
-	CharClass char_class;
+	RegexCharClass char_class;
 	int group_id;
 	String group_name;   // slice into pattern; non-owning
 	int repeat_min;
@@ -505,7 +505,7 @@ struct AstNode
 // NFA states
 // ============================================================
 
-enum StateKind : char
+enum RegexStateKind : char
 {
 	STATE_LITERAL,
 	STATE_CHARSET,
@@ -531,16 +531,16 @@ enum StateKind : char
 	STATE_COND_GROUP,      // (?(N)yes|no) — conditional; backref_id=group, lookaround_start=yes, out2=no
 }
 
-struct NfaState
+struct RegexNfaState
 {
-	StateKind kind;
-	NfaState* out1;
-	NfaState* out2;             // SPLIT only
+	RegexStateKind kind;
+	RegexNfaState* out1;
+	RegexNfaState* out2;             // SPLIT only
 	usz index;                  // position in flat states[] array
 	Char32 codepoint;           // STATE_LITERAL
-	CharClass char_class;       // STATE_CHARSET
+	RegexCharClass char_class;       // STATE_CHARSET
 	int group_id;               // CAPTURE_START/END
-	NfaState* lookaround_start;   // lookahead/lookbehind sub-NFA entry
+	RegexNfaState* lookaround_start;   // lookahead/lookbehind sub-NFA entry
 	usz lookbehind_len;           // fixed-width lookbehind byte count
 	bool lookbehind_variable;     // true = variable-width; scan all start positions
 	int backref_id;               // STATE_BACKREF: capture group index (1-based)
@@ -548,19 +548,19 @@ struct NfaState
 }
 
 // Thompson construction fragment: a start state + dangling output pointers
-alias PatchList = List{NfaState**};
+alias RegexPatchList = List{RegexNfaState**};
 
-struct NfaFrag
+struct RegexNfaFrag
 {
-	NfaState* start;
-	PatchList  out;
+	RegexNfaState* start;
+	RegexPatchList out;
 }
 
 // ============================================================
 // Named group entry
 // ============================================================
 
-struct NamedGroupEntry
+struct RegexNamedGroupEntry
 {
 	String name;      // owned by Regex.allocator
 	int group_id;
@@ -573,13 +573,13 @@ struct NamedGroupEntry
 struct Regex
 {
 	Allocator       allocator;
-	NfaState*       states;
+	RegexNfaState*  states;
 	usz             state_count;
 	usz             start_idx;     // index of NFA start state in states[]
 	int             group_count;
-	NamedGroupEntry* named_groups;
+	RegexNamedGroupEntry* named_groups;
 	usz             named_group_count;
-	UnicodeRange*   range_pool;
+	RegexUnicodeRange* range_pool;
 	usz             range_pool_count;
 	RegexFlags      flags;
 	bool            has_backref;   // pattern contains \1-\9; routes to BT engine
@@ -587,7 +587,7 @@ struct Regex
 	bool            has_gpos;      // pattern contains \G; routes to BT engine
 	bool            has_cond;      // pattern contains (?(N)...); routes to BT engine
 	bool            has_start_filter; // first consumed codepoint must match start_filter
-	CharClass       start_filter;
+	RegexCharClass  start_filter;
 	usz             gpos;          // set to start_pos before each BT match attempt (for \G)
 }
 
@@ -757,7 +757,7 @@ fn Regex*? compile(Allocator allocator, String pattern, RegexFlags flags = FLAG_
 
 	@pool()
 	{
-		ParseCtx ctx = {
+		RegexParseCtx ctx = {
 			.pattern = pattern,
 			.pos = 0,
 			.next_group_id = 0,
@@ -765,22 +765,22 @@ fn Regex*? compile(Allocator allocator, String pattern, RegexFlags flags = FLAG_
 			.flags = flags
 		};
 
-		AstNode* ast = parse_expr(&ctx)!;
+		RegexAstNode* ast = parse_expr(&ctx)!;
 		if (ctx.pos != pattern.len) return INVALID_PATTERN~;
 		re.group_count = ctx.next_group_id;
 
-		BuildCtx bctx = { .alloc = allocator };
+		RegexBuildCtx bctx = { .alloc = allocator };
 		bctx.all_states.tinit(64);
 		bctx.range_pool.tinit(16);
 
-		NfaFrag frag = build_nfa(&bctx, ast, flags)!;
+		RegexNfaFrag frag = build_nfa(&bctx, ast, flags)!;
 
-		NfaState* match_s = nfa_new(&bctx, STATE_MATCH);
+		RegexNfaState* match_s = nfa_new(&bctx, STATE_MATCH);
 		frag_patch(&frag, match_s);
 		frag.out.free();
 
 		usz n = bctx.all_states.size;
-		NfaState* state_arr = alloc::new_array(allocator, NfaState, n);
+		RegexNfaState* state_arr = alloc::new_array(allocator, RegexNfaState, n);
 		for (usz i = 0; i < n; i++)
 		{
 			state_arr[i] = *bctx.all_states.entries[i];
@@ -788,7 +788,7 @@ fn Regex*? compile(Allocator allocator, String pattern, RegexFlags flags = FLAG_
 		}
 		for (usz i = 0; i < n; i++)
 		{
-			NfaState* old = bctx.all_states.entries[i];
+			RegexNfaState* old = bctx.all_states.entries[i];
 			if (old.out1 != null) state_arr[i].out1 = &state_arr[old.out1.index];
 			if (old.out2 != null) state_arr[i].out2 = &state_arr[old.out2.index];
 			if (old.lookaround_start != null) state_arr[i].lookaround_start = &state_arr[old.lookaround_start.index];
@@ -809,7 +809,7 @@ fn Regex*? compile(Allocator allocator, String pattern, RegexFlags flags = FLAG_
 		usz pool_size = bctx.range_pool.size;
 		if (pool_size > 0)
 		{
-			UnicodeRange* pool = alloc::new_array(allocator, UnicodeRange, pool_size);
+			RegexUnicodeRange* pool = alloc::new_array(allocator, RegexUnicodeRange, pool_size);
 			for (usz i = 0; i < pool_size; i++) pool[i] = bctx.range_pool.entries[i];
 			re.range_pool = pool;
 			re.range_pool_count = pool_size;
@@ -827,10 +827,10 @@ fn Regex*? compile(Allocator allocator, String pattern, RegexFlags flags = FLAG_
 		usz ng = ctx.named_groups_count;
 		if (ng > 0)
 		{
-			re.named_groups = alloc::new_array(allocator, NamedGroupEntry, ng);
+			re.named_groups = alloc::new_array(allocator, RegexNamedGroupEntry, ng);
 			for (usz i = 0; i < ng; i++)
 			{
-				NamedGroupEntry src = ctx.named_groups_buf[i];
+				RegexNamedGroupEntry src = ctx.named_groups_buf[i];
 				char* nbuf = alloc::new_array(allocator, char, src.name.len);
 				mem::copy(nbuf, src.name.ptr, src.name.len);
 				re.named_groups[i] = { .name = (String)nbuf[:src.name.len], .group_id = src.group_id };
@@ -1128,21 +1128,21 @@ fn String? Regex.replace_all(&self, Allocator allocator, String input, String re
 // Parse / build contexts
 // ============================================================
 
-struct ParseCtx
+struct RegexParseCtx
 {
 	String    pattern;
 	usz       pos;
 	int       next_group_id;
 	Allocator regex_alloc;
 	RegexFlags flags;
-	NamedGroupEntry* named_groups_buf;
+	RegexNamedGroupEntry* named_groups_buf;
 	usz named_groups_count;
 	usz named_groups_cap;
 }
 
-struct BuildCtx
+struct RegexBuildCtx
 {
 	Allocator alloc;
-	List{NfaState*} all_states;
-	List{UnicodeRange} range_pool;
+	List{RegexNfaState*} all_states;
+	List{RegexUnicodeRange} range_pool;
 }

--- a/test/unit/stdlib/regex/fuzz.c3
+++ b/test/unit/stdlib/regex/fuzz.c3
@@ -1,0 +1,231 @@
+module regex_fuzz;
+import std::regex;
+import std::math::random;
+
+fn void regex_corpus_fuzz() @test
+{
+	DefaultRandom rng;
+	random::seed(&rng, 0xC3C0_0001uL);
+
+	for (int i = 0; i < 250; i++)
+	{
+		@pool()
+		{
+			String pattern = build_corpus_pattern(&rng);
+			String input = build_random_input(&rng);
+			Regex*? re = regex::compile(tmem, pattern);
+			if (catch err = re)
+			{
+				assert(err == regex::INVALID_PATTERN || err == regex::COMPILE_ERROR);
+				continue;
+			}
+			assert_match_invariants(re, input, &rng);
+		};
+	}
+}
+
+fn void regex_parser_noise_fuzz() @test
+{
+	DefaultRandom rng;
+	random::seed(&rng, 0xC3C0_0002uL);
+
+	for (int i = 0; i < 400; i++)
+	{
+		@pool()
+		{
+			String pattern = build_parser_noise(&rng);
+			String input = build_random_input(&rng);
+			Regex*? re = regex::compile(tmem, pattern);
+			if (catch err = re)
+			{
+				assert(err == regex::INVALID_PATTERN || err == regex::COMPILE_ERROR);
+				continue;
+			}
+			assert_match_invariants(re, input, &rng);
+		};
+	}
+}
+
+const String[] VALID_PATTERN_CORPUS = {
+	"a",
+	"ab",
+	"abc",
+	"\u00E9",
+	"\u03A9",
+	"\u0416",
+	"\\d+",
+	"\\w+",
+	"\\s+",
+	"\\h+",
+	"\\v+",
+	"[ab]+",
+	"[^c]*",
+	"(?:ab|ba)",
+	"(a|ab)c",
+	"(?=a)a",
+	"(?!b).",
+	"(?<=a)b",
+	"(?<!b)a",
+	"(?>a|ab)c",
+	"(a)\\1",
+	"(?|(a)|(b))\\1",
+	"foo\\Kbar",
+	"\\bcat\\b",
+	"\\G\\d{2}",
+	"(?<word>\\w+)=(?<value>\\d+)",
+	"(?<=\\$)\\d+",
+	"\\p{Word}+",
+	"\\p{White_Space}+",
+	"\\R",
+	"^foo$",
+	"(?U)<.+>",
+};
+
+const String[] INPUT_CORPUS = {
+	"",
+	"a",
+	"ab",
+	"abc",
+	"abba",
+	"foo",
+	"foobar",
+	"bar",
+	"cat",
+	"dog",
+	"12",
+	"1234",
+	"hello",
+	"world",
+	" ",
+	"-",
+	"_",
+	"\u00E9",
+	"\u03C9",
+	"\u0436",
+	"\u00A0",
+	"\u2028",
+	"foo\nbar",
+	"hello world",
+	"$42",
+	"foo=123",
+};
+
+const String[] REPLACEMENT_CORPUS = {
+	"$&",
+	"$0",
+	"${0}",
+	"${1}",
+	"${9}",
+	"<$0>",
+	"<$1>",
+	"<${missing}>",
+	"$$",
+	"$$$0",
+	"${value}:${word}",
+	"X",
+	"_",
+	"",
+};
+
+const String PATTERN_NOISE_ALPHABET = "abc01[](){}?+*|\\<>:=!^$.-";
+
+fn String pick_string(String[] options, DefaultRandom* rng) @local
+{
+	usz index = (usz)random::next(rng, (int)options.len);
+	return options[index];
+}
+
+fn String build_corpus_pattern(DefaultRandom* rng) @local
+{
+	DString pattern = dstring::temp_with_capacity(96);
+	String base = pick_string(VALID_PATTERN_CORPUS, rng);
+	switch (random::next(rng, 6))
+	{
+		case 0:
+			pattern.append(base);
+		case 1:
+			pattern.append("^");
+			pattern.append(base);
+			pattern.append("$");
+		case 2:
+			pattern.append("(?:");
+			pattern.append(base);
+			pattern.append(")");
+		case 3:
+			pattern.append(base);
+			pattern.append("|");
+			pattern.append(pick_string(VALID_PATTERN_CORPUS, rng));
+		case 4:
+			pattern.append("(");
+			pattern.append(base);
+			pattern.append(")");
+			pattern.append(random::next_bool(rng) ? "+" : "?");
+		default:
+			pattern.append(random::next_bool(rng) ? "(?x)" : "(?U)");
+			pattern.append(base);
+	}
+	return pattern.str_view();
+}
+
+fn String build_random_input(DefaultRandom* rng) @local
+{
+	DString input = dstring::temp_with_capacity(64);
+	int parts = random::next_in_range(rng, 0, 6);
+	for (int i = 0; i < parts; i++) input.append(pick_string(INPUT_CORPUS, rng));
+	return input.str_view();
+}
+
+fn String build_parser_noise(DefaultRandom* rng) @local
+{
+	DString pattern = dstring::temp_with_capacity(48);
+	int len = random::next_in_range(rng, 0, 18);
+	for (int i = 0; i < len; i++)
+	{
+		usz index = (usz)random::next(rng, PATTERN_NOISE_ALPHABET.len);
+		pattern.append_char(PATTERN_NOISE_ALPHABET[index]);
+	}
+	return pattern.str_view();
+}
+
+fn void assert_match_invariants(Regex* re, String input, DefaultRandom* rng) @local
+{
+	bool matched = re.is_match(input);
+	Match? first = re.find(tmem, input);
+	assert(matched == @ok(first));
+	if (try first)
+	{
+		assert(first.full() == input[first.start() : first.end() - first.start()]);
+		first.free();
+	}
+
+	String? identity_once = re.replace(tmem, input, "$&");
+	if (matched)
+	{
+		assert(identity_once!! == input);
+	}
+	else
+	{
+		assert(@catch(identity_once) == regex::NO_MATCH);
+	}
+
+	String identity_all = re.replace_all(tmem, input, "$&")!!;
+	assert(identity_all == input);
+
+	String replacement = pick_string(REPLACEMENT_CORPUS, rng);
+	String replaced_all = re.replace_all(tmem, input, replacement)!!;
+	assert(replaced_all.len >= 0);
+
+	MatchIter it = re.find_all(tmem, input);
+	usz last_end = 0;
+	int seen = 0;
+	while (seen < 16)
+	{
+		Match? next = it.next();
+		if (catch next) break;
+		assert(next.start() >= last_end);
+		assert(next.end() >= next.start());
+		last_end = next.end();
+		next.free();
+		seen++;
+	}
+}

--- a/test/unit/stdlib/regex/matrix.c3
+++ b/test/unit/stdlib/regex/matrix.c3
@@ -1,0 +1,578 @@
+module regex_matrix_test;
+import std::regex;
+
+fn void systematic_api_matrix() @test
+{
+	ApiCase[] cases = {
+		{ .name = "literal-two-hits", .pattern = "world", .flags = regex::FLAG_NONE, .input = "hello world world", .matched = true, .start = 6, .full = "world", .find_all_count = 2 },
+		{ .name = "literal-miss", .pattern = "world", .flags = regex::FLAG_NONE, .input = "hello there", .matched = false, .start = 0, .full = "", .find_all_count = 0 },
+		{ .name = "nullable-prefix", .pattern = "a*bc", .flags = regex::FLAG_NONE, .input = "xxbcabc", .matched = true, .start = 2, .full = "bc", .find_all_count = 2 },
+		{ .name = "word-boundary-zero-length", .pattern = "\\b", .flags = regex::FLAG_NONE, .input = "ab cd", .matched = true, .start = 0, .full = "", .find_all_count = 4 },
+		{ .name = "multiline-anchor", .pattern = "^foo", .flags = regex::FLAG_MULTILINE, .input = "bar\nfoo\nfoo", .matched = true, .start = 4, .full = "foo", .find_all_count = 2 },
+		{ .name = "unicode-word-boundary", .pattern = "\\bcaf\u00E9\\b", .flags = regex::FLAG_NONE, .input = "le caf\u00E9 noir caf\u00E9!", .matched = true, .start = 3, .full = "caf\u00E9", .find_all_count = 2 },
+		{ .name = "lookahead-dollars", .pattern = "\\d+(?= dollars)", .flags = regex::FLAG_NONE, .input = "100 dollars and 250 dollars", .matched = true, .start = 0, .full = "100", .find_all_count = 2 },
+		{ .name = "lookbehind-currency", .pattern = "(?<=\\$)\\d+", .flags = regex::FLAG_NONE, .input = "price $42 and $7", .matched = true, .start = 7, .full = "42", .find_all_count = 2 },
+		{ .name = "backref-repeated-word", .pattern = "(\\w+) \\1", .flags = regex::FLAG_NONE, .input = "hello hello test test", .matched = true, .start = 0, .full = "hello hello", .find_all_count = 2 },
+		{ .name = "atomic-unanchored", .pattern = "(?>a|ab)c", .flags = regex::FLAG_NONE, .input = "abc ac", .matched = true, .start = 4, .full = "ac", .find_all_count = 1 },
+		{ .name = "conditional-no-prefix", .pattern = "^(\\d)?x(?(1)digit|other)$", .flags = regex::FLAG_NONE, .input = "xother", .matched = true, .start = 0, .full = "xother", .find_all_count = 1 },
+		{ .name = "unicode-whitespace-property", .pattern = "\\p{White_Space}+x", .flags = regex::FLAG_NONE, .input = "a\u00A0x \u2028x", .matched = true, .start = 1, .full = "\u00A0x", .find_all_count = 2 },
+		{ .name = "inline-compat-parse-only", .pattern = "ab(?i)cd", .flags = regex::FLAG_NONE, .input = "abCD abcd", .matched = true, .start = 5, .full = "abcd", .find_all_count = 1 },
+		{ .name = "dotall-runtime-flag", .pattern = "a.b", .flags = regex::FLAG_DOTALL, .input = "a\nb aXb", .matched = true, .start = 0, .full = "a\nb", .find_all_count = 2 },
+	};
+
+	foreach (c : cases) assert_api_case(c);
+}
+
+fn void systematic_find_at_matrix() @test
+{
+	FindAtCase[] cases = {
+		{ .name = "literal-forward-scan", .pattern = "world", .flags = regex::FLAG_NONE, .input = "hello world", .start_pos = 2, .matched = true, .match_start = 6, .full = "world" },
+		{ .name = "nullable-prefix-skips-earlier-hit", .pattern = "a*bc", .flags = regex::FLAG_NONE, .input = "xxbcabc", .start_pos = 3, .matched = true, .match_start = 4, .full = "abc" },
+		{ .name = "multiline-anchor-find-at", .pattern = "^foo", .flags = regex::FLAG_MULTILINE, .input = "bar\nfoo", .start_pos = 1, .matched = true, .match_start = 4, .full = "foo" },
+		{ .name = "gpos-start-zero", .pattern = "\\G\\d{2}", .flags = regex::FLAG_NONE, .input = "123456x", .start_pos = 0, .matched = true, .match_start = 0, .full = "12" },
+		{ .name = "gpos-midstream", .pattern = "\\G\\d{2}", .flags = regex::FLAG_NONE, .input = "123456x", .start_pos = 2, .matched = true, .match_start = 2, .full = "34" },
+		{ .name = "gpos-no-match", .pattern = "\\G\\d{2}", .flags = regex::FLAG_NONE, .input = "123456x", .start_pos = 5, .matched = false, .match_start = 0, .full = "" },
+		{ .name = "boundary-search-from-middle", .pattern = "\\b", .flags = regex::FLAG_NONE, .input = "ab cd", .start_pos = 1, .matched = true, .match_start = 2, .full = "" },
+		{ .name = "inline-compat-forward-scan", .pattern = "ab(?i)cd", .flags = regex::FLAG_NONE, .input = "abCD abcd", .start_pos = 1, .matched = true, .match_start = 5, .full = "abcd" },
+	};
+
+	foreach (c : cases) assert_find_at_case(c);
+}
+
+fn void systematic_capture_matrix() @test
+{
+	CaptureCase[] cases = {
+		{
+			.name = "email-numbered",
+			.pattern = "(\\w+)@(\\w+)",
+			.input = "user@example",
+			.full = "user@example",
+			.g1_present = true, .g1 = "user",
+			.g2_present = true, .g2 = "example",
+			.g3_present = false, .g3 = "",
+		},
+		{
+			.name = "date-named",
+			.pattern = "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})",
+			.input = "date: 2024-03-15",
+			.full = "2024-03-15",
+			.g1_present = true, .g1 = "2024",
+			.g2_present = true, .g2 = "03",
+			.g3_present = true, .g3 = "15",
+			.named1_name = "year", .named1_present = true, .named1_value = "2024",
+			.named2_name = "month", .named2_present = true, .named2_value = "03",
+			.named3_name = "day", .named3_present = true, .named3_value = "15",
+		},
+		{
+			.name = "branch-reset-ac",
+			.pattern = "(?|(a)|(b))(c)",
+			.input = "ac",
+			.full = "ac",
+			.g1_present = true, .g1 = "a",
+			.g2_present = true, .g2 = "c",
+			.g3_present = false, .g3 = "",
+		},
+		{
+			.name = "branch-reset-bc",
+			.pattern = "(?|(a)|(b))(c)",
+			.input = "bc",
+			.full = "bc",
+			.g1_present = true, .g1 = "b",
+			.g2_present = true, .g2 = "c",
+			.g3_present = false, .g3 = "",
+		},
+		{
+			.name = "conditional-else-branch",
+			.pattern = "^(a)?(?(1)b|c)(d)$",
+			.input = "cd",
+			.full = "cd",
+			.g1_present = false, .g1 = "",
+			.g2_present = true, .g2 = "d",
+			.g3_present = false, .g3 = "",
+		},
+		{
+			.name = "conditional-then-branch",
+			.pattern = "^(a)?(?(1)b|c)(d)$",
+			.input = "abd",
+			.full = "abd",
+			.g1_present = true, .g1 = "a",
+			.g2_present = true, .g2 = "d",
+			.g3_present = false, .g3 = "",
+		},
+		{
+			.name = "keep-preserves-capture",
+			.pattern = "(foo)\\K(bar)",
+			.input = "foobar",
+			.full = "bar",
+			.g1_present = true, .g1 = "foo",
+			.g2_present = true, .g2 = "bar",
+			.g3_present = false, .g3 = "",
+		},
+	};
+
+	foreach (c : cases) assert_capture_case(c);
+}
+
+fn void systematic_find_all_sequence_matrix() @test
+{
+	FindAllSequenceCase[] cases = {
+		{
+			.name = "literal-sequence",
+			.pattern = "world",
+			.flags = regex::FLAG_NONE,
+			.input = "hello world world",
+			.starts = { 6, 12 },
+			.fulls = { "world", "world" },
+		},
+		{
+			.name = "word-boundary-zero-length-sequence",
+			.pattern = "\\b",
+			.flags = regex::FLAG_NONE,
+			.input = "ab cd",
+			.starts = { 0, 2, 3, 5 },
+			.fulls = { "", "", "", "" },
+		},
+		{
+			.name = "gpos-sequence",
+			.pattern = "\\G\\d{2}",
+			.flags = regex::FLAG_NONE,
+			.input = "123456x",
+			.starts = { 0, 2, 4 },
+			.fulls = { "12", "34", "56" },
+		},
+		{
+			.name = "keep-sequence",
+			.pattern = "foo\\K(bar|qux)",
+			.flags = regex::FLAG_NONE,
+			.input = "foobar fooqux",
+			.starts = { 3, 10 },
+			.fulls = { "bar", "qux" },
+		},
+		{
+			.name = "unicode-boundary-sequence",
+			.pattern = "\\bcaf\u00E9\\b",
+			.flags = regex::FLAG_NONE,
+			.input = "caf\u00E9 noir caf\u00E9!",
+			.starts = { 0, 11 },
+			.fulls = { "caf\u00E9", "caf\u00E9" },
+		},
+	};
+
+	foreach (c : cases) assert_find_all_sequence_case(c);
+}
+
+fn void systematic_replace_matrix() @test
+{
+	ReplaceCase[] cases = {
+		{
+			.name = "literal-single-vs-all",
+			.pattern = "world",
+			.flags = regex::FLAG_NONE,
+			.input = "hello world world",
+			.replacement = "C3",
+			.replace_matches = true,
+			.replace_expected = "hello C3 world",
+			.replace_all_expected = "hello C3 C3",
+		},
+		{
+			.name = "digits-single-vs-all",
+			.pattern = "\\d+",
+			.flags = regex::FLAG_NONE,
+			.input = "a1b22c333",
+			.replacement = "X",
+			.replace_matches = true,
+			.replace_expected = "aXb22c333",
+			.replace_all_expected = "aXbXcX",
+		},
+		{
+			.name = "numbered-captures",
+			.pattern = "(\\w+)@(\\w+)",
+			.flags = regex::FLAG_NONE,
+			.input = "user@example admin@test",
+			.replacement = "$2/$1",
+			.replace_matches = true,
+			.replace_expected = "example/user admin@test",
+			.replace_all_expected = "example/user test/admin",
+		},
+		{
+			.name = "named-captures",
+			.pattern = "(?<first>\\w+) (?<last>\\w+)",
+			.flags = regex::FLAG_NONE,
+			.input = "John Doe Jane Roe",
+			.replacement = "${last}, ${first}",
+			.replace_matches = true,
+			.replace_expected = "Doe, John Jane Roe",
+			.replace_all_expected = "Doe, John Roe, Jane",
+		},
+		{
+			.name = "literal-dollar",
+			.pattern = "\\d+",
+			.flags = regex::FLAG_NONE,
+			.input = "a1b2",
+			.replacement = "$$$0",
+			.replace_matches = true,
+			.replace_expected = "a$1b2",
+			.replace_all_expected = "a$1b$2",
+		},
+		{
+			.name = "missing-groups-expand-empty",
+			.pattern = "(a)?b",
+			.flags = regex::FLAG_NONE,
+			.input = "b b",
+			.replacement = "<$1><${9}><${missing}>",
+			.replace_matches = true,
+			.replace_expected = "<><><> b",
+			.replace_all_expected = "<><><> <><><>",
+		},
+		{
+			.name = "replace-no-match-fault",
+			.pattern = "world",
+			.flags = regex::FLAG_NONE,
+			.input = "hello there",
+			.replacement = "C3",
+			.replace_matches = false,
+			.replace_expected = "",
+			.replace_all_expected = "hello there",
+		},
+	};
+
+	foreach (c : cases) assert_replace_case(c);
+}
+
+fn void systematic_compile_contract_matrix() @test
+{
+	String[] valid_patterns = {
+		"abc",
+		"(?x) a b c",
+		"(?U)<.+>",
+		"(?i)abc",
+		"(?-i)abc",
+		"(?m)^foo",
+		"(?s)a.b",
+		"(?|(a)|(b))(c)",
+		"(\\w+) \\1",
+		"(?>a|ab)c",
+		"^(\\d)?x(?(1)digit|other)$",
+		"\\G\\d{2}",
+		"foo\\Kbar",
+		"(?<=\\w+)\\d+",
+		"\\p{Word}+",
+	};
+	foreach (pattern : valid_patterns)
+	{
+		Regex*? re = regex::compile(mem, pattern);
+		test::@check(@ok(re), "compile matrix: expected valid pattern %s to compile", pattern);
+		if (try re) re.free();
+	}
+
+	String[] invalid_patterns = {
+		"(?i:foo)",
+		"(?x: a b c )",
+		"^*",
+		"(?=a)+",
+		"(?<!a){2}",
+		"\\p{Letter}",
+		"[\\P{Letter}]",
+		"(abc",
+	};
+	foreach (pattern : invalid_patterns)
+	{
+		Regex*? re = regex::compile(mem, pattern);
+		test::@check(!@ok(re), "compile matrix: expected invalid pattern %s to fail", pattern);
+		if (try re) re.free();
+	}
+
+	test::@check(@catch(regex::compile(mem, "a{5000}")) == regex::COMPILE_ERROR, "compile matrix: oversized repeat should be COMPILE_ERROR");
+}
+
+struct ApiCase
+{
+	String pattern;
+	RegexFlags flags;
+	String input;
+	bool matched;
+	usz start;
+	String full;
+	int find_all_count;
+	String name;
+}
+
+struct FindAtCase
+{
+	String pattern;
+	RegexFlags flags;
+	String input;
+	usz start_pos;
+	bool matched;
+	usz match_start;
+	String full;
+	String name;
+}
+
+struct FindAllSequenceCase
+{
+	String pattern;
+	RegexFlags flags;
+	String input;
+	usz[] starts;
+	String[] fulls;
+	String name;
+}
+
+struct CaptureCase
+{
+	String pattern;
+	String input;
+	String full;
+	String name;
+	bool g1_present;
+	String g1;
+	bool g2_present;
+	String g2;
+	bool g3_present;
+	String g3;
+	String named1_name;
+	bool named1_present;
+	String named1_value;
+	String named2_name;
+	bool named2_present;
+	String named2_value;
+	String named3_name;
+	bool named3_present;
+	String named3_value;
+}
+
+struct ReplaceCase
+{
+	String pattern;
+	RegexFlags flags;
+	String input;
+	String replacement;
+	bool replace_matches;
+	String replace_expected;
+	String replace_all_expected;
+	String name;
+}
+
+fn void assert_api_case(ApiCase c) @local
+{
+	Regex* re = regex::compile(mem, c.pattern, c.flags)!!;
+	defer re.free();
+
+	test::@check(re.is_match(c.input) == c.matched, "api case %s: is_match mismatch", c.name);
+
+	Match? first_find = re.find(mem, c.input);
+	if (!c.matched)
+	{
+		test::@check(@catch(first_find) == regex::NO_MATCH, "api case %s: expected find() to fail", c.name);
+	}
+	else
+	{
+		test::@check(@ok(first_find), "api case %s: expected find() to succeed", c.name);
+		if (try first_find)
+		{
+			defer first_find.free();
+			test::@check(first_find.start() == c.start, "api case %s: find() start mismatch", c.name);
+			test::@check(first_find.full() == c.full, "api case %s: find() full mismatch", c.name);
+			test::@check(first_find.end() == c.start + c.full.len, "api case %s: find() end mismatch", c.name);
+		}
+	}
+
+	Match? first_find_at = re.find_at(mem, c.input, 0);
+	if (!c.matched)
+	{
+		test::@check(@catch(first_find_at) == regex::NO_MATCH, "api case %s: expected find_at(0) to fail", c.name);
+	}
+	else
+	{
+		test::@check(@ok(first_find_at), "api case %s: expected find_at(0) to succeed", c.name);
+		if (try first_find_at)
+		{
+			defer first_find_at.free();
+			test::@check(first_find_at.start() == c.start, "api case %s: find_at(0) start mismatch", c.name);
+			test::@check(first_find_at.full() == c.full, "api case %s: find_at(0) full mismatch", c.name);
+		}
+
+		Match from_start = re.find_at(mem, c.input, c.start)!!;
+		defer from_start.free();
+		test::@check(from_start.start() == c.start, "api case %s: find_at(start) mismatch", c.name);
+		test::@check(from_start.full() == c.full, "api case %s: find_at(start) full mismatch", c.name);
+	}
+
+	String? replaced_once = re.replace(mem, c.input, "$&");
+	if (!c.matched)
+	{
+		test::@check(@catch(replaced_once) == regex::NO_MATCH, "api case %s: replace($&) should fail with NO_MATCH", c.name);
+	}
+	else
+	{
+		String replace_identity = replaced_once!!;
+		defer alloc::free(mem, replace_identity.ptr);
+		test::@check(replace_identity == c.input, "api case %s: replace($&) should preserve input", c.name);
+	}
+
+	String replaced_all = re.replace_all(mem, c.input, "$&")!!;
+	defer alloc::free(mem, replaced_all.ptr);
+	test::@check(replaced_all == c.input, "api case %s: replace_all($&) should preserve input", c.name);
+
+	MatchIter it = re.find_all(mem, c.input);
+	int count = 0;
+	bool checked_first = false;
+	usz last_end = 0;
+	while (try m = it.next())
+	{
+		defer m.free();
+		test::@check(m.start() >= last_end, "api case %s: find_all order regression", c.name);
+		test::@check(m.end() >= m.start(), "api case %s: find_all invalid range", c.name);
+		if (!checked_first)
+		{
+			test::@check(m.start() == c.start, "api case %s: find_all first start mismatch", c.name);
+			test::@check(m.full() == c.full, "api case %s: find_all first full mismatch", c.name);
+			checked_first = true;
+		}
+		last_end = m.end();
+		count++;
+		if (count > 64)
+		{
+			test::@check(false, "api case %s: find_all exceeded sanity limit", c.name);
+			break;
+		}
+	}
+	test::@check(count == c.find_all_count, "api case %s: find_all count mismatch", c.name);
+}
+
+fn void assert_find_at_case(FindAtCase c) @local
+{
+	Regex* re = regex::compile(mem, c.pattern, c.flags)!!;
+	defer re.free();
+
+	Match? m = re.find_at(mem, c.input, c.start_pos);
+	if (!c.matched)
+	{
+		test::@check(@catch(m) == regex::NO_MATCH, "find_at case %s: expected NO_MATCH", c.name);
+		return;
+	}
+
+	test::@check(@ok(m), "find_at case %s: expected match", c.name);
+	if (try m)
+	{
+		defer m.free();
+		test::@check(m.start() == c.match_start, "find_at case %s: start mismatch", c.name);
+		test::@check(m.full() == c.full, "find_at case %s: full mismatch", c.name);
+		test::@check(m.end() == c.match_start + c.full.len, "find_at case %s: end mismatch", c.name);
+	}
+}
+
+fn void assert_find_all_sequence_case(FindAllSequenceCase c) @local
+{
+	test::@check(c.starts.len == c.fulls.len, "find_all sequence %s: invalid fixture", c.name);
+
+	Regex* re = regex::compile(mem, c.pattern, c.flags)!!;
+	defer re.free();
+
+	MatchIter it = re.find_all(mem, c.input);
+	usz index = 0;
+	while (try m = it.next())
+	{
+		defer m.free();
+		test::@check(index < c.starts.len, "find_all sequence %s: unexpected extra match", c.name);
+		if (index >= c.starts.len) break;
+		test::@check(m.start() == c.starts[index], "find_all sequence %s: start mismatch at %d", c.name, index);
+		test::@check(m.full() == c.fulls[index], "find_all sequence %s: full mismatch at %d", c.name, index);
+		index++;
+	}
+	test::@check(index == c.starts.len, "find_all sequence %s: missing matches", c.name);
+}
+
+fn void assert_capture_case(CaptureCase c) @local
+{
+	Regex* re = regex::compile(mem, c.pattern)!!;
+	defer re.free();
+	Match m = re.find(mem, c.input)!!;
+	defer m.free();
+
+	test::@check(m.full() == c.full, "capture case %s: full mismatch", c.name);
+
+	if (c.g1_present)
+	{
+		test::@check(m.group(1)!! == c.g1, "capture case %s: group 1 mismatch", c.name);
+	}
+	else
+	{
+		test::@check(@catch(m.group(1)) == regex::GROUP_NOT_FOUND, "capture case %s: group 1 should be absent", c.name);
+	}
+
+	if (c.g2_present)
+	{
+		test::@check(m.group(2)!! == c.g2, "capture case %s: group 2 mismatch", c.name);
+	}
+	else
+	{
+		test::@check(@catch(m.group(2)) == regex::GROUP_NOT_FOUND, "capture case %s: group 2 should be absent", c.name);
+	}
+
+	if (c.g3_present)
+	{
+		test::@check(m.group(3)!! == c.g3, "capture case %s: group 3 mismatch", c.name);
+	}
+	else
+	{
+		test::@check(@catch(m.group(3)) == regex::GROUP_NOT_FOUND, "capture case %s: group 3 should be absent", c.name);
+	}
+
+	if (c.named1_name.len > 0)
+	{
+		if (c.named1_present)
+		{
+			test::@check(m.named_group(c.named1_name)!! == c.named1_value, "capture case %s: named group 1 mismatch", c.name);
+		}
+		else
+		{
+			test::@check(@catch(m.named_group(c.named1_name)) == regex::GROUP_NOT_FOUND, "capture case %s: named group 1 should be absent", c.name);
+		}
+	}
+	if (c.named2_name.len > 0)
+	{
+		if (c.named2_present)
+		{
+			test::@check(m.named_group(c.named2_name)!! == c.named2_value, "capture case %s: named group 2 mismatch", c.name);
+		}
+		else
+		{
+			test::@check(@catch(m.named_group(c.named2_name)) == regex::GROUP_NOT_FOUND, "capture case %s: named group 2 should be absent", c.name);
+		}
+	}
+	if (c.named3_name.len > 0)
+	{
+		if (c.named3_present)
+		{
+			test::@check(m.named_group(c.named3_name)!! == c.named3_value, "capture case %s: named group 3 mismatch", c.name);
+		}
+		else
+		{
+			test::@check(@catch(m.named_group(c.named3_name)) == regex::GROUP_NOT_FOUND, "capture case %s: named group 3 should be absent", c.name);
+		}
+	}
+}
+
+fn void assert_replace_case(ReplaceCase c) @local
+{
+	Regex* re = regex::compile(mem, c.pattern, c.flags)!!;
+	defer re.free();
+
+	String? replaced = re.replace(mem, c.input, c.replacement);
+	if (!c.replace_matches)
+	{
+		test::@check(@catch(replaced) == regex::NO_MATCH, "replace case %s: replace should return NO_MATCH", c.name);
+	}
+	else
+	{
+		String replaced_once = replaced!!;
+		defer alloc::free(mem, replaced_once.ptr);
+		test::@check(replaced_once == c.replace_expected, "replace case %s: replace mismatch", c.name);
+	}
+
+	String replaced_all = re.replace_all(mem, c.input, c.replacement)!!;
+	defer alloc::free(mem, replaced_all.ptr);
+	test::@check(replaced_all == c.replace_all_expected, "replace case %s: replace_all mismatch", c.name);
+}

--- a/test/unit/stdlib/regex/regex.c3
+++ b/test/unit/stdlib/regex/regex.c3
@@ -1,0 +1,1649 @@
+module regex_test @test;
+import std::regex;
+import std::io;
+
+// Helper: compile pattern, assert is_match result, free
+macro void @assert_match(String $pat, String $input)
+{
+	Regex* re = regex::compile(mem, $pat)!!;
+	defer re.free();
+	test::@check(re.is_match($input), "Expected /%s/ to match %s", $pat, $input);
+}
+
+macro void @assert_no_match(String $pat, String $input)
+{
+	Regex* re = regex::compile(mem, $pat)!!;
+	defer re.free();
+	test::@check(!re.is_match($input), "Expected /%s/ not to match %s", $pat, $input);
+}
+
+// ============================================================
+// Basic literals
+// ============================================================
+
+fn void test_literal_match() @test
+{
+	Regex* re = regex::compile(mem, "hello")!!;
+	defer re.free();
+	assert(re.is_match("hello"));
+	assert(re.is_match("say hello!"));
+	assert(!re.is_match("hell"));
+	assert(!re.is_match(""));
+}
+
+fn void test_literal_position() @test
+{
+	Regex* re = regex::compile(mem, "hello")!!;
+	defer re.free();
+	Match m = re.find(mem, "say hello!")!!;
+	defer m.free();
+	assert(m.start() == 4);
+	assert(m.end()   == 9);
+	assert(m.full()  == "hello");
+}
+
+fn void test_find_at_searches_forward_from_start() @test
+{
+	Regex* re = regex::compile(mem, "world")!!;
+	defer re.free();
+	Match m = re.find_at(mem, "hello world", 2)!!;
+	defer m.free();
+	assert(m.start() == 6);
+	assert(m.full() == "world");
+}
+
+fn void test_find_with_nullable_prefix() @test
+{
+	Regex* re = regex::compile(mem, "a*bc")!!;
+	defer re.free();
+	Match m = re.find(mem, "xxbc")!!;
+	defer m.free();
+	assert(m.start() == 2);
+	assert(m.full() == "bc");
+}
+
+fn void test_find_with_optional_prefix() @test
+{
+	Regex* re = regex::compile(mem, "(?:ab)?cd")!!;
+	defer re.free();
+	Match m = re.find(mem, "xcd")!!;
+	defer m.free();
+	assert(m.start() == 1);
+	assert(m.full() == "cd");
+}
+
+fn void test_find_with_zero_width_prefix() @test
+{
+	Regex* re = regex::compile(mem, "(?=ab)ab")!!;
+	defer re.free();
+	Match m = re.find(mem, "zab")!!;
+	defer m.free();
+	assert(m.start() == 1);
+	assert(m.full() == "ab");
+}
+
+fn void test_find_with_unicode_property_prefix() @test
+{
+	Regex* re = regex::compile(mem, "\\p{White_Space}+x")!!;
+	defer re.free();
+	Match m = re.find(mem, "a\u00A0x")!!;
+	defer m.free();
+	assert(m.start() == 1);
+	assert(m.full() == "\u00A0x");
+}
+
+fn void test_dot() @test
+{
+	Regex* re = regex::compile(mem, "a.b")!!;
+	defer re.free();
+	assert( re.is_match("axb"));
+	assert( re.is_match("a9b"));
+	assert(!re.is_match("ab"));
+	assert(!re.is_match("a\nb")); // dot does not match newline by default
+}
+
+fn void test_dot_dotall() @test
+{
+	Regex* re = regex::compile(mem, "a.b", regex::FLAG_DOTALL)!!;
+	defer re.free();
+	assert(re.is_match("a\nb")); // FLAG_DOTALL makes dot match \n
+}
+
+// ============================================================
+// Character classes
+// ============================================================
+
+fn void test_charclass_basic() @test
+{
+	Regex* re = regex::compile(mem, "[abc]")!!;
+	defer re.free();
+	assert( re.is_match("a"));
+	assert( re.is_match("b"));
+	assert( re.is_match("c"));
+	assert(!re.is_match("d"));
+}
+
+fn void test_charclass_range() @test
+{
+	Regex* re = regex::compile(mem, "[a-z]")!!;
+	defer re.free();
+	assert( re.is_match("m"));
+	assert(!re.is_match("A"));
+	assert(!re.is_match("0"));
+}
+
+fn void test_charclass_ascii_ignorecase() @test
+{
+	Regex* re = regex::compile(mem, "[A-Z]", regex::FLAG_IGNORECASE)!!;
+	defer re.free();
+	assert(re.is_match("A"));
+	assert(re.is_match("a"));
+	assert(!re.is_match("0"));
+}
+
+fn void test_charclass_negated() @test
+{
+	Regex* re = regex::compile(mem, "[^abc]")!!;
+	defer re.free();
+	assert(!re.is_match("a"));
+	assert( re.is_match("d"));
+}
+
+fn void test_predefined_digit() @test
+{
+	Regex* re = regex::compile(mem, "\\d+")!!;
+	defer re.free();
+	assert( re.is_match("123"));
+	assert( re.is_match("abc123"));
+	assert(!re.is_match("abc"));
+}
+
+fn void test_predefined_word() @test
+{
+	Regex* re = regex::compile(mem, "\\w+")!!;
+	defer re.free();
+	assert( re.is_match("hello_123"));
+	assert(!re.is_match("!@#"));
+}
+
+fn void test_predefined_word_unicode_latin1() @test
+{
+	Regex* re = regex::compile(mem, "\\w+")!!;
+	defer re.free();
+	assert(re.is_match("caf\u00E9"));
+	assert(re.is_match("\u00E9clair"));
+	assert(!re.is_match("\u2028"));
+}
+
+fn void test_predefined_space() @test
+{
+	Regex* re = regex::compile(mem, "\\s+")!!;
+	defer re.free();
+	assert( re.is_match("   "));
+	assert( re.is_match("\t\n"));
+	assert(!re.is_match("abc"));
+}
+
+fn void test_predefined_space_unicode_whitespace() @test
+{
+	Regex* re = regex::compile(mem, "\\s+")!!;
+	defer re.free();
+	assert(re.is_match("\u00A0"));   // NO-BREAK SPACE
+	assert(re.is_match("\u2028"));   // LINE SEPARATOR
+	assert(!re.is_match("\u00E9"));
+}
+
+fn void test_predefined_hspace_vspace_unicode_whitespace() @test
+{
+	Regex* h = regex::compile(mem, "\\h")!!;
+	defer h.free();
+	Regex* v = regex::compile(mem, "\\v")!!;
+	defer v.free();
+
+	assert(h.is_match("\u00A0"));
+	assert(!h.is_match("\u2028"));
+	assert(v.is_match("\u2028"));
+	assert(!v.is_match("\u00A0"));
+}
+
+fn void test_predefined_inverse_in_class_matches_unicode() @test
+{
+	Regex* re = regex::compile(mem, "[\\D]")!!;
+	defer re.free();
+	assert(re.is_match("a"));
+	assert(re.is_match("\u00E9"));
+	assert(!re.is_match("5"));
+}
+
+fn void test_predefined_inverse_word_in_class_matches_unicode() @test
+{
+	Regex* re = regex::compile(mem, "[\\W]")!!;
+	defer re.free();
+	assert(re.is_match("!"));
+	assert(!re.is_match("\u00E9"));
+}
+
+fn void test_predefined_inverse_space_in_class_matches_unicode() @test
+{
+	Regex* re = regex::compile(mem, "[\\S]")!!;
+	defer re.free();
+	assert(re.is_match("a"));
+	assert(!re.is_match("\u00A0"));
+	assert(!re.is_match("\u2028"));
+}
+
+fn void test_unicode_property_ascii() @test
+{
+	Regex* ascii_only = regex::compile(mem, "\\p{ASCII}+")!!;
+	defer ascii_only.free();
+	Regex* non_ascii = regex::compile(mem, "\\P{ASCII}+")!!;
+	defer non_ascii.free();
+	assert(ascii_only.is_match("AZ09_"));
+	assert(!ascii_only.is_match("\u00E9"));
+	assert(non_ascii.is_match("\u00E9"));
+	assert(!non_ascii.is_match("A"));
+}
+
+fn void test_unicode_property_whitespace() @test
+{
+	Regex* ws = regex::compile(mem, "\\p{White_Space}+")!!;
+	defer ws.free();
+	Regex* not_ws = regex::compile(mem, "\\P{White_Space}+")!!;
+	defer not_ws.free();
+	assert(ws.is_match("\u205F"));   // MEDIUM MATHEMATICAL SPACE
+	assert(ws.is_match("\u2029"));   // PARAGRAPH SEPARATOR
+	assert(!ws.is_match("x"));
+	assert(not_ws.is_match("x"));
+	assert(!not_ws.is_match("\u205F"));
+}
+
+fn void test_unicode_property_whitespace_in_class() @test
+{
+	Regex* ws = regex::compile(mem, "[\\p{White_Space}]")!!;
+	defer ws.free();
+	Regex* not_ws = regex::compile(mem, "[\\P{White_Space}]")!!;
+	defer not_ws.free();
+	assert(ws.is_match("\u00A0"));
+	assert(ws.is_match("\u2028"));
+	assert(!ws.is_match("A"));
+	assert(not_ws.is_match("A"));
+	assert(!not_ws.is_match("\u00A0"));
+}
+
+fn void test_unicode_property_hspace_vspace() @test
+{
+	Regex* hs = regex::compile(mem, "\\p{Horiz_Space}+")!!;
+	defer hs.free();
+	Regex* vs = regex::compile(mem, "\\p{Vert_Space}+")!!;
+	defer vs.free();
+	assert(hs.is_match("\u3000"));
+	assert(!hs.is_match("\u2028"));
+	assert(vs.is_match("\u2028"));
+	assert(!vs.is_match("\u3000"));
+}
+
+fn void test_unicode_property_word() @test
+{
+	Regex* word = regex::compile(mem, "\\p{Word}+")!!;
+	defer word.free();
+	assert(word.is_match("caf\u00E9"));
+	assert(word.is_match("\u00B5"));
+	assert(!word.is_match("!"));
+}
+
+fn void test_posix_alpha() @test
+{
+	Regex* re = regex::compile(mem, "[[:alpha:]]")!!;
+	defer re.free();
+	assert( re.is_match("a"));
+	assert( re.is_match("Z"));
+	assert(!re.is_match("0"));
+	assert(!re.is_match("!"));
+}
+
+fn void test_posix_digit() @test
+{
+	Regex* re = regex::compile(mem, "[[:digit:]]")!!;
+	defer re.free();
+	assert( re.is_match("5"));
+	assert(!re.is_match("a"));
+}
+
+fn void test_posix_xdigit() @test
+{
+	Regex* re = regex::compile(mem, "[[:xdigit:]]+")!!;
+	defer re.free();
+	assert( re.is_match("deadbeef"));
+	assert( re.is_match("CAFE123"));
+	assert(!re.is_match("ghij"));
+}
+
+fn void test_posix_space() @test
+{
+	Regex* re = regex::compile(mem, "[[:space:]]")!!;
+	defer re.free();
+	assert( re.is_match(" "));
+	assert( re.is_match("\t"));
+	assert(!re.is_match("a"));
+}
+
+fn void test_posix_upper_lower() @test
+{
+	Regex* re_u = regex::compile(mem, "[[:upper:]]")!!;
+	defer re_u.free();
+	Regex* re_l = regex::compile(mem, "[[:lower:]]")!!;
+	defer re_l.free();
+	assert( re_u.is_match("A"));
+	assert(!re_u.is_match("a"));
+	assert( re_l.is_match("a"));
+	assert(!re_l.is_match("A"));
+}
+
+// ============================================================
+// Anchors
+// ============================================================
+
+fn void test_anchor_start() @test
+{
+	Regex* re = regex::compile(mem, "^hello")!!;
+	defer re.free();
+	assert( re.is_match("hello world"));
+	assert(!re.is_match("say hello"));
+}
+
+fn void test_anchor_end() @test
+{
+	Regex* re = regex::compile(mem, "world$")!!;
+	defer re.free();
+	assert( re.is_match("hello world"));
+	assert(!re.is_match("world tour"));
+}
+
+fn void test_anchor_multiline() @test
+{
+	Regex* re = regex::compile(mem, "^foo", regex::FLAG_MULTILINE)!!;
+	defer re.free();
+	assert(re.is_match("bar\nfoo"));
+	assert(re.is_match("foo"));
+}
+
+fn void test_word_boundary() @test
+{
+	Regex* re = regex::compile(mem, "\\bcat\\b")!!;
+	defer re.free();
+	assert( re.is_match("the cat sat"));
+	assert(!re.is_match("catfish"));
+	assert(!re.is_match("tomcat"));
+}
+
+fn void test_word_boundary_unicode_latin1() @test
+{
+	Regex* re = regex::compile(mem, "\\bcaf\u00E9\\b")!!;
+	defer re.free();
+	assert(re.is_match("caf\u00E9!"));
+	assert(re.is_match("le caf\u00E9 noir"));
+	assert(!re.is_match("decaf\u00E9s"));
+}
+
+// ============================================================
+// Quantifiers
+// ============================================================
+
+fn void test_star() @test
+{
+	Regex* re = regex::compile(mem, "ab*c")!!;
+	defer re.free();
+	assert(re.is_match("ac"));
+	assert(re.is_match("abc"));
+	assert(re.is_match("abbbbc"));
+}
+
+fn void test_plus() @test
+{
+	Regex* re = regex::compile(mem, "ab+c")!!;
+	defer re.free();
+	assert( re.is_match("abc"));
+	assert( re.is_match("abbbbc"));
+	assert(!re.is_match("ac"));
+}
+
+fn void test_question() @test
+{
+	Regex* re = regex::compile(mem, "colou?r")!!;
+	defer re.free();
+	assert(re.is_match("color"));
+	assert(re.is_match("colour"));
+}
+
+fn void test_repeat_exact() @test
+{
+	Regex* re = regex::compile(mem, "a{3}")!!;
+	defer re.free();
+	assert( re.is_match("aaa"));
+	assert( re.is_match("xaaax"));
+	assert(!re.is_match("aa"));
+}
+
+fn void test_repeat_zero_exact() @test
+{
+	Regex* re = regex::compile(mem, "a{0}b")!!;
+	defer re.free();
+	assert(re.is_match("b"));
+	assert(!re.is_match(""));
+}
+
+fn void test_repeat_range() @test
+{
+	Regex* re = regex::compile(mem, "a{2,4}")!!;
+	defer re.free();
+	assert( re.is_match("aa"));
+	assert( re.is_match("aaa"));
+	assert( re.is_match("aaaa"));
+}
+
+fn void test_repeat_min() @test
+{
+	Regex* re = regex::compile(mem, "a{2,}")!!;
+	defer re.free();
+	assert( re.is_match("aa"));
+	assert( re.is_match("aaaaaa"));
+	assert(!re.is_match("a"));
+}
+
+fn void test_greedy_vs_lazy() @test
+{
+	Regex* greedy = regex::compile(mem, "<.+>")!!;
+	defer greedy.free();
+	Regex* lazy = regex::compile(mem, "<.+?>")!!;
+	defer lazy.free();
+
+	Match mg = greedy.find(mem, "<a><b>")!!;
+	defer mg.free();
+	Match ml = lazy.find(mem, "<a><b>")!!;
+	defer ml.free();
+
+	assert(mg.full() == "<a><b>");
+	assert(ml.full() == "<a>");
+}
+
+fn void test_alternation_prefers_longest_match_at_same_start() @test
+{
+	Regex* re = regex::compile(mem, "sam|same")!!;
+	defer re.free();
+	Match m = re.find(mem, "same")!!;
+	defer m.free();
+	assert(m.full() == "same");
+}
+
+// ============================================================
+// Alternation and groups
+// ============================================================
+
+fn void test_alternation() @test
+{
+	Regex* re = regex::compile(mem, "cat|dog")!!;
+	defer re.free();
+	assert( re.is_match("I have a cat"));
+	assert( re.is_match("I have a dog"));
+	assert(!re.is_match("I have a fish"));
+}
+
+fn void test_capturing_group() @test
+{
+	Regex* re = regex::compile(mem, "(\\w+)@(\\w+)")!!;
+	defer re.free();
+	Match m = re.find(mem, "user@example")!!;
+	defer m.free();
+	assert(m.group(1)!! == "user");
+	assert(m.group(2)!! == "example");
+}
+
+fn void test_noncapturing_group() @test
+{
+	Regex* re = regex::compile(mem, "(?:ab)+")!!;
+	defer re.free();
+	assert( re.is_match("ababab"));
+	assert(!re.is_match("aaa"));
+}
+
+fn void test_named_group() @test
+{
+	Regex* re = regex::compile(mem, "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})")!!;
+	defer re.free();
+	Match m = re.find(mem, "date: 2024-03-15")!!;
+	defer m.free();
+	assert(m.named_group("year")!!  == "2024");
+	assert(m.named_group("month")!! == "03");
+	assert(m.named_group("day")!!   == "15");
+}
+
+// ============================================================
+// Case-insensitive
+// ============================================================
+
+fn void test_ignorecase() @test
+{
+	Regex* re = regex::compile(mem, "hello", regex::FLAG_IGNORECASE)!!;
+	defer re.free();
+	assert(re.is_match("HELLO"));
+	assert(re.is_match("Hello"));
+	assert(re.is_match("hElLo"));
+}
+
+fn void test_inline_ignorecase_is_parse_only_compatibility_syntax() @test
+{
+	Regex* re = regex::compile(mem, "ab(?i)cd")!!;
+	defer re.free();
+	assert(re.is_match("abcd"));
+	assert(!re.is_match("abCD"));
+}
+
+fn void test_inline_multiline_is_parse_only_compatibility_syntax() @test
+{
+	Regex* re = regex::compile(mem, "(?m)^foo")!!;
+	defer re.free();
+	assert(!re.is_match("bar\nfoo"));
+	assert(re.is_match("foo"));
+}
+
+// ============================================================
+// Lookahead / Lookbehind
+// ============================================================
+
+fn void test_lookahead_pos() @test
+{
+	Regex* re = regex::compile(mem, "\\d+(?= dollars)")!!;
+	defer re.free();
+	Match m = re.find(mem, "100 dollars")!!;
+	defer m.free();
+	assert(m.full() == "100");
+	assert(!re.is_match("100 euros"));
+}
+
+fn void test_lookahead_with_word_boundary() @test
+{
+	Regex* re = regex::compile(mem, "(?=\\bfoo)foo")!!;
+	defer re.free();
+	assert(re.is_match("foo"));
+	assert(!re.is_match("xfoo"));
+}
+
+fn void test_lookahead_neg() @test
+{
+	Regex* re = regex::compile(mem, "\\d+(?! dollars)")!!;
+	defer re.free();
+	assert(re.is_match("100 euros"));
+}
+
+fn void test_lookbehind_pos() @test
+{
+	Regex* re = regex::compile(mem, "(?<=\\$)\\d+")!!;
+	defer re.free();
+	Match m = re.find(mem, "price: $42")!!;
+	defer m.free();
+	assert(m.full() == "42");
+}
+
+fn void test_lookbehind_pos_utf8_fixed_width() @test
+{
+	Regex* re = regex::compile(mem, "(?<=\u00E9)a")!!;
+	defer re.free();
+	assert(re.is_match("\u00E9a"));
+	assert(!re.is_match("ea"));
+}
+
+fn void test_lookbehind_neg() @test
+{
+	Regex* re = regex::compile(mem, "(?<!\\$)\\d+")!!;
+	defer re.free();
+	assert(re.is_match("42 items"));
+}
+
+// ============================================================
+// Unicode
+// ============================================================
+
+fn void test_unicode_literal() @test
+{
+	// é = U+00E9 (2-byte UTF-8: 0xC3 0xA9)
+	Regex* re = regex::compile(mem, "\u00E9")!!;
+	defer re.free();
+	assert(re.is_match("caf\u00E9"));
+	assert(!re.is_match("cafe"));
+}
+
+fn void test_unicode_escape_pattern() @test
+{
+	Regex* re = regex::compile(mem, "\\u00E9")!!;
+	defer re.free();
+	assert(re.is_match("caf\u00E9"));
+}
+
+// ============================================================
+// find_all
+// ============================================================
+
+fn void test_find_all() @test
+{
+	Regex* re = regex::compile(mem, "\\d+")!!;
+	defer re.free();
+	MatchIter it = re.find_all(mem, "abc 123 def 456 ghi 789");
+	String[3] expected = { "123", "456", "789" };
+	int count = 0;
+	while (try m = it.next())
+	{
+		assert(count < 3);
+		assert(m.full() == expected[count]);
+		m.free();
+		count++;
+	}
+	assert(count == 3);
+}
+
+fn void test_find_all_zero_length() @test
+{
+	// a* can match empty string; find_all must not loop infinitely
+	Regex* re = regex::compile(mem, "a*")!!;
+	defer re.free();
+	MatchIter it = re.find_all(mem, "bab");
+	int count = 0;
+	while (try m = it.next())
+	{
+		m.free();
+		count++;
+		if (count > 20) break; // guard
+	}
+	assert(count <= 10); // should finish
+}
+
+fn void test_find_all_zero_length_word_boundaries_no_duplicates() @test
+{
+	Regex* re = regex::compile(mem, "\\b")!!;
+	defer re.free();
+	MatchIter it = re.find_all(mem, "ab cd");
+
+	Match m1 = it.next()!!;
+	defer m1.free();
+	assert(m1.start() == 0);
+	assert(m1.full() == "");
+
+	Match m2 = it.next()!!;
+	defer m2.free();
+	assert(m2.start() == 2);
+	assert(m2.full() == "");
+
+	Match m3 = it.next()!!;
+	defer m3.free();
+	assert(m3.start() == 3);
+	assert(m3.full() == "");
+
+	Match m4 = it.next()!!;
+	defer m4.free();
+	assert(m4.start() == 5);
+	assert(m4.full() == "");
+
+	assert(@catch(it.next()) == regex::NO_MATCH);
+}
+
+// ============================================================
+// replace / replace_all
+// ============================================================
+
+fn void test_replace() @test
+{
+	Regex* re = regex::compile(mem, "world")!!;
+	defer re.free();
+	String result = re.replace(mem, "hello world", "C3")!!;
+	defer alloc::free(mem, result.ptr);
+	assert(result == "hello C3");
+}
+
+fn void test_replace_all() @test
+{
+	Regex* re = regex::compile(mem, "\\d+")!!;
+	defer re.free();
+	String result = re.replace_all(mem, "a1b2c3", "X")!!;
+	defer alloc::free(mem, result.ptr);
+	assert(result == "aXbXcX");
+}
+
+fn void test_replace_all_zero_length_boundaries() @test
+{
+	Regex* re = regex::compile(mem, "\\b")!!;
+	defer re.free();
+	String result = re.replace_all(mem, "ab cd", "|")!!;
+	defer alloc::free(mem, result.ptr);
+	assert(result == "|ab| |cd|");
+}
+
+fn void test_replace_group_ref() @test
+{
+	Regex* re = regex::compile(mem, "(\\w+)@(\\w+)")!!;
+	defer re.free();
+	String result = re.replace(mem, "user@example", "$2/$1")!!;
+	defer alloc::free(mem, result.ptr);
+	assert(result == "example/user");
+}
+
+fn void test_replace_named_group() @test
+{
+	Regex* re = regex::compile(mem, "(?<first>\\w+) (?<last>\\w+)")!!;
+	defer re.free();
+	String result = re.replace(mem, "John Doe", "${last}, ${first}")!!;
+	defer alloc::free(mem, result.ptr);
+	assert(result == "Doe, John");
+}
+
+fn void test_replace_literal_dollar_escape() @test
+{
+	Regex* re = regex::compile(mem, "world")!!;
+	defer re.free();
+	String result = re.replace(mem, "hello world", "$$$0 $$")!!;
+	defer alloc::free(mem, result.ptr);
+	assert(result == "hello $world $");
+}
+
+fn void test_replace_braced_numeric_group_refs() @test
+{
+	Regex* re = regex::compile(mem, "(\\w+)@(\\w+)")!!;
+	defer re.free();
+	String result = re.replace(mem, "user@example", "${2}/${1}/${0}")!!;
+	defer alloc::free(mem, result.ptr);
+	assert(result == "example/user/user@example");
+}
+
+fn void test_replace_all_literal_dollar_escape() @test
+{
+	Regex* re = regex::compile(mem, "\\d+")!!;
+	defer re.free();
+	String result = re.replace_all(mem, "a1b2", "$$$0")!!;
+	defer alloc::free(mem, result.ptr);
+	assert(result == "a$1b$2");
+}
+
+fn void test_replace_unknown_or_unmatched_groups_expand_empty() @test
+{
+	Regex* re = regex::compile(mem, "(a)?b")!!;
+	defer re.free();
+	String result = re.replace(mem, "b", "<$1><${9}><${missing}>")!!;
+	defer alloc::free(mem, result.ptr);
+	assert(result == "<><><>");
+}
+
+fn void test_match_group_faults_for_missing_or_unmatched_groups() @test
+{
+	Regex* re = regex::compile(mem, "(a)?b")!!;
+	defer re.free();
+	Match m = re.find(mem, "b")!!;
+	defer m.free();
+	assert(@catch(m.group(1)) == regex::GROUP_NOT_FOUND);
+	assert(@catch(m.group(99)) == regex::GROUP_NOT_FOUND);
+	assert(@catch(m.named_group("missing")) == regex::GROUP_NOT_FOUND);
+}
+
+// ============================================================
+// Error cases
+// ============================================================
+
+fn void test_invalid_unclosed_paren() @test
+{
+	assert(@catch(regex::compile(mem, "(abc")) == regex::INVALID_PATTERN);
+}
+
+fn void test_invalid_inverted_range() @test
+{
+	assert(@catch(regex::compile(mem, "[z-a]")) == regex::INVALID_PATTERN);
+}
+
+fn void test_invalid_repeat_too_large() @test
+{
+	assert(@catch(regex::compile(mem, "a{5000}")));
+}
+
+fn void test_invalid_quantified_anchor() @test
+{
+	assert(@catch(regex::compile(mem, "^*")) == regex::INVALID_PATTERN);
+}
+
+fn void test_invalid_quantified_lookaround() @test
+{
+	assert(@catch(regex::compile(mem, "(?=a)+")) == regex::INVALID_PATTERN);
+	assert(@catch(regex::compile(mem, "(?<!a){2}")) == regex::INVALID_PATTERN);
+}
+
+fn void test_invalid_unknown_unicode_property() @test
+{
+	assert(@catch(regex::compile(mem, "\\p{Letter}")) == regex::INVALID_PATTERN);
+	assert(@catch(regex::compile(mem, "[\\P{Letter}]")) == regex::INVALID_PATTERN);
+}
+
+fn void test_invalid_scoped_inline_flag_group() @test
+{
+	assert(@catch(regex::compile(mem, "(?i:foo)")) == regex::INVALID_PATTERN);
+	assert(@catch(regex::compile(mem, "(?x: a b c )")) == regex::INVALID_PATTERN);
+}
+
+// ============================================================
+// Tier 1: new features
+// ============================================================
+
+fn void test_comment_group() @test
+{
+	// (?#...) should be ignored entirely
+	Regex* re = regex::compile(mem, "hel(?#this is a comment)lo")!!;
+	defer re.free();
+	assert(re.is_match("hello"));
+	assert(!re.is_match("hel"));
+}
+
+fn void test_absolute_start_anchor() @test
+{
+	Regex* re = regex::compile(mem, "\\Ahello")!!;
+	defer re.free();
+	assert( re.is_match("hello world"));
+	assert(!re.is_match("say hello"));
+}
+
+fn void test_absolute_end_anchor() @test
+{
+	Regex* re = regex::compile(mem, "world\\z")!!;
+	defer re.free();
+	assert( re.is_match("hello world"));
+	assert(!re.is_match("world tour"));
+}
+
+fn void test_absolute_end_anchor_z_capital() @test
+{
+	// \Z matches at end of string or just before a final \n
+	Regex* re = regex::compile(mem, "world\\Z")!!;
+	defer re.free();
+	assert( re.is_match("hello world"));
+	assert( re.is_match("hello world\n"));  // before final \n
+	assert(!re.is_match("world\ntour"));
+}
+
+fn void test_absolute_anchor_not_multiline() @test
+{
+	// \A should NOT match after a newline, even with FLAG_MULTILINE
+	Regex* re = regex::compile(mem, "\\Afoo", regex::FLAG_MULTILINE)!!;
+	defer re.free();
+	assert( re.is_match("foo"));
+	assert(!re.is_match("bar\nfoo"));  // \A is not multiline-aware
+}
+
+fn void test_ungreedy_flag() @test
+{
+	// FLAG_UNGREEDY makes * lazy by default
+	Regex* greedy = regex::compile(mem, "<.+>")!!;
+	defer greedy.free();
+	Regex* lazy   = regex::compile(mem, "<.+>", regex::FLAG_UNGREEDY)!!;
+	defer lazy.free();
+
+	Match mg = greedy.find(mem, "<a><b>")!!;
+	defer mg.free();
+	Match ml = lazy.find(mem, "<a><b>")!!;
+	defer ml.free();
+
+	assert(mg.full() == "<a><b>");
+	assert(ml.full() == "<a>");
+}
+
+fn void test_ungreedy_suffix_restores_greedy() @test
+{
+	// With FLAG_UNGREEDY, adding ? suffix makes the quantifier greedy
+	Regex* re = regex::compile(mem, "<.+?>", regex::FLAG_UNGREEDY)!!;
+	defer re.free();
+	Match m = re.find(mem, "<a><b>")!!;
+	defer m.free();
+	assert(m.full() == "<a><b>");
+}
+
+fn void test_inline_ungreedy_flag() @test
+{
+	// (?U) sets ungreedy mode inline
+	Regex* re = regex::compile(mem, "(?U)<.+>")!!;
+	defer re.free();
+	Match m = re.find(mem, "<a><b>")!!;
+	defer m.free();
+	assert(m.full() == "<a>");
+}
+
+fn void test_freespacing_mode() @test
+{
+	// FLAG_EXTENDED: whitespace and # comments ignored
+	Regex* re = regex::compile(mem, "hel  lo  # match hello", regex::FLAG_EXTENDED)!!;
+	defer re.free();
+	assert( re.is_match("hello"));
+	assert(!re.is_match("hel  lo"));
+}
+
+fn void test_freespacing_inline() @test
+{
+	// (?x) inline
+	Regex* re = regex::compile(mem, "(?x) \\d+ # one or more digits")!!;
+	defer re.free();
+	assert( re.is_match("123"));
+	assert(!re.is_match("abc"));
+}
+
+fn void test_linebreak_R() @test
+{
+	// \R matches any Unicode line break
+	Regex* re = regex::compile(mem, "a\\Rb")!!;
+	defer re.free();
+	assert(re.is_match("a\nb"));
+	assert(re.is_match("a\rb"));
+	assert(re.is_match("a\r\nb"));  // CRLF counts as one \R
+	assert(re.is_match("a\vb"));
+	assert(re.is_match("a\fb"));
+	assert(!re.is_match("ab"));
+}
+
+// ============================================================
+// Tier 2: new features
+// ============================================================
+
+fn void test_hspace() @test
+{
+	Regex* re = regex::compile(mem, "\\h+")!!;
+	defer re.free();
+	assert( re.is_match(" \t "));
+	assert( re.is_match("a b"));   // contains space
+	assert(!re.is_match("abc"));
+	assert(!re.is_match("\n"));    // \n is NOT horizontal whitespace
+}
+
+fn void test_hspace_inv() @test
+{
+	Regex* re = regex::compile(mem, "\\H+")!!;
+	defer re.free();
+	assert( re.is_match("abc"));
+	assert(!re.is_match(" \t"));
+}
+
+fn void test_vspace_class() @test
+{
+	// \v as a CLASS (vertical whitespace), not literal VT
+	Regex* re = regex::compile(mem, "\\v")!!;
+	defer re.free();
+	assert(re.is_match("\n"));
+	assert(re.is_match("\r"));
+	assert(re.is_match("\v"));  // VT is still in the class
+	assert(re.is_match("\f"));
+	assert(!re.is_match("a"));
+}
+
+fn void test_vspace_inv() @test
+{
+	Regex* re = regex::compile(mem, "\\V+")!!;
+	defer re.free();
+	assert( re.is_match("abc"));
+	assert(!re.is_match("\n\r\v\f"));
+}
+
+fn void test_non_newline() @test
+{
+	// \N = non-newline, ignores FLAG_DOTALL
+	Regex* re_dot  = regex::compile(mem, "a.b",  regex::FLAG_DOTALL)!!;
+	defer re_dot.free();
+	Regex* re_N    = regex::compile(mem, "a\\Nb")!!;
+	defer re_N.free();
+
+	assert( re_dot.is_match("a\nb"));  // . with DOTALL matches \n
+	assert(!re_N.is_match("a\nb"));    // \N never matches \n
+	assert( re_N.is_match("axb"));
+}
+
+fn void test_keep() @test
+{
+	// \K resets the match start
+	Regex* re = regex::compile(mem, "foo\\Kbar")!!;
+	defer re.free();
+	Match m = re.find(mem, "foobar")!!;
+	defer m.free();
+	assert(m.full() == "bar");     // match text is only "bar"
+	assert(m.start() == 3);        // starts after "foo"
+}
+
+fn void test_keep_in_find_all() @test
+{
+	Regex* re = regex::compile(mem, "\\w+\\K\\s+")!!;
+	defer re.free();
+	// Match the whitespace after a word, but report only the whitespace
+	Match m = re.find(mem, "hello   world")!!;
+	defer m.free();
+	assert(m.full() == "   ");
+}
+
+fn void test_keep_preserves_captures() @test
+{
+	Regex* re = regex::compile(mem, "ab(c)\\Kde")!!;
+	defer re.free();
+	Match m = re.find(mem, "abcde")!!;
+	defer m.free();
+	assert(m.full() == "de");
+	assert(m.group(1)!! == "c");
+}
+
+fn void test_unicode_icase_literal() @test
+{
+	// Latin-1 Supplement case folding
+	Regex* re = regex::compile(mem, "caf\u00E9", regex::FLAG_IGNORECASE)!!;
+	defer re.free();
+	assert(re.is_match("caf\u00E9"));  // lowercase é
+	assert(re.is_match("CAF\u00C9"));  // uppercase É (U+00C9)
+	assert(re.is_match("Caf\u00E9"));  // mixed
+}
+
+fn void test_unicode_icase_literal_greek() @test
+{
+	Regex* re = regex::compile(mem, "\u03C3", regex::FLAG_IGNORECASE)!!;
+	defer re.free();
+	assert(re.is_match("\u03A3"));  // Σ
+	assert(re.is_match("\u03C3"));  // σ
+	assert(re.is_match("\u03C2"));  // ς
+}
+
+fn void test_unicode_icase_literal_cyrillic() @test
+{
+	Regex* re = regex::compile(mem, "\u0436", regex::FLAG_IGNORECASE)!!;
+	defer re.free();
+	assert(re.is_match("\u0416"));  // Ж
+	assert(re.is_match("\u0436"));  // ж
+	assert(!re.is_match("x"));
+}
+
+fn void test_unicode_icase_literal_latin_extended() @test
+{
+	Regex* re = regex::compile(mem, "\u00FF", regex::FLAG_IGNORECASE)!!;
+	defer re.free();
+	assert(re.is_match("\u0178"));  // Ÿ
+	assert(re.is_match("\u00FF"));  // ÿ
+}
+
+fn void test_unicode_icase_charclass() @test
+{
+	// [À-Ö] with IGNORECASE should match both upper and lower
+	Regex* re = regex::compile(mem, "[\u00C0-\u00D6]", regex::FLAG_IGNORECASE)!!;
+	defer re.free();
+	assert(re.is_match("\u00C0"));  // À (uppercase, in range)
+	assert(re.is_match("\u00E0"));  // à (lowercase, should match via icase)
+	assert(re.is_match("\u00D6"));  // Ö
+	assert(re.is_match("\u00F6"));  // ö
+}
+
+fn void test_unicode_icase_charclass_greek_cyrillic() @test
+{
+	Regex* greek = regex::compile(mem, "[\u03A3]", regex::FLAG_IGNORECASE)!!;
+	defer greek.free();
+	Regex* cyrillic = regex::compile(mem, "[\u0416]", regex::FLAG_IGNORECASE)!!;
+	defer cyrillic.free();
+	assert(greek.is_match("\u03C3"));
+	assert(greek.is_match("\u03C2"));
+	assert(cyrillic.is_match("\u0436"));
+}
+
+fn void test_variable_lookbehind() @test
+{
+	// Variable-width positive lookbehind
+	Regex* re = regex::compile(mem, "(?<=foo+)bar")!!;
+	defer re.free();
+	assert( re.is_match("foobar"));
+	assert( re.is_match("fooobar"));
+	assert(!re.is_match("bar"));
+	assert(!re.is_match("xbar"));
+}
+
+fn void test_variable_lookbehind_neg() @test
+{
+	// Variable-width negative lookbehind
+	Regex* re = regex::compile(mem, "(?<!foo+)bar")!!;
+	defer re.free();
+	assert( re.is_match("xbar"));
+	assert( re.is_match("bar"));
+	assert(!re.is_match("foobar"));
+	assert(!re.is_match("fooobar"));
+}
+
+fn void test_variable_lookbehind_scans_beyond_1000_bytes() @test
+{
+	Regex* re = regex::compile(mem, "(?<=\u00E9{500,}c)b")!!;
+	defer re.free();
+	DString input_builder = dstring::new_with_capacity(mem, 1002);
+	defer input_builder.free();
+	for (int i = 0; i < 500; i++) input_builder.append("\u00E9");
+	input_builder.append("cb");
+	String input = input_builder.str_view();
+	Match m = re.find(mem, input)!!;
+	defer m.free();
+	assert(m.start() == 1001);
+	assert(m.full() == "b");
+}
+
+fn void test_variable_lookbehind_neg_scans_beyond_1000_bytes() @test
+{
+	Regex* re = regex::compile(mem, "(?<!\u00E9{500,}c)b")!!;
+	defer re.free();
+	DString input_builder = dstring::new_with_capacity(mem, 1002);
+	defer input_builder.free();
+	for (int i = 0; i < 500; i++) input_builder.append("\u00E9");
+	input_builder.append("cb");
+	String input = input_builder.str_view();
+	assert(!re.is_match(input));
+}
+
+fn void test_variable_lookbehind_scans_beyond_1000_bytes_in_backtracking_engine() @test
+{
+	Regex* re = regex::compile(mem, "(?<=\u00E9{500,}c)(b)\\1")!!;
+	defer re.free();
+	DString input_builder = dstring::new_with_capacity(mem, 1003);
+	defer input_builder.free();
+	for (int i = 0; i < 500; i++) input_builder.append("\u00E9");
+	input_builder.append("cbb");
+	String input = input_builder.str_view();
+	Match m = re.find(mem, input)!!;
+	defer m.free();
+	assert(m.start() == 1001);
+	assert(m.full() == "bb");
+	assert(m.group(1)!! == "b");
+}
+
+fn void test_variable_lookbehind_neg_scans_beyond_1000_bytes_in_backtracking_engine() @test
+{
+	Regex* re = regex::compile(mem, "(?<!\u00E9{500,}c)(b)\\1")!!;
+	defer re.free();
+	DString input_builder = dstring::new_with_capacity(mem, 1003);
+	defer input_builder.free();
+	for (int i = 0; i < 500; i++) input_builder.append("\u00E9");
+	input_builder.append("cbb");
+	String input = input_builder.str_view();
+	assert(!re.is_match(input));
+}
+
+// ============================================================
+// Performance: no catastrophic backtracking
+// ============================================================
+
+fn void test_no_catastrophic_backtracking() @test
+{
+	// (a+)+b against 30 a's — exponential for backtracking engines,
+	// linear for Thompson NFA
+	Regex* re = regex::compile(mem, "(a+)+b")!!;
+	defer re.free();
+	assert(!re.is_match("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+}
+
+// ============================================================
+// Compile-test: all supported syntax compiles without error
+// ============================================================
+
+fn void test_syntax_coverage() @test
+{
+	String[] patterns = {
+		"abc",
+		"a|b|c",
+		"(ab)+",
+		"(?:ab){3}",
+		"(?<name>\\d+)",
+		"[a-zA-Z0-9_]",
+		"[[:alpha:]]+",
+		"[[:alnum:]_]+",
+		"\\d\\w\\s\\D\\W\\S",
+		"\\h\\H\\v\\V\\N",
+		"\\p{ASCII}+",
+		"\\p{Word}+",
+		"\\P{White_Space}+",
+		"[\\p{Horiz_Space}\\P{Vert_Space}]",
+		"foo\\Kbar",
+		"(?<=\\w+)\\d+",   // variable-width lookbehind
+		"^start",
+		"end$",
+		"\\bword\\b",
+		"a*b+c?",
+		"a{2,5}",
+		"a{3,}",
+		".+",
+		"(?i)hello",
+		"(?m)^foo",
+		"(?s)a.b",
+		"(?U)<.+>",
+		"(?x) hel lo # match hello",
+		"(?#comment)hello",
+		"\\Astart",
+		"end\\z",
+		"end\\Z",
+		"a\\Rb",
+		"(?=\\d)",
+		"(?!\\d)",
+		"(?<=\\s)",
+		"(?<!\\s)",
+		"\\u0041",   // \uXXXX
+		"(?>a|ab)",  // atomic group
+		"(\\w+) \\1", // backreference
+		"(?<x>\\w+) \\k<x>", // named backreference
+		"a*+b",      // possessive star
+		"a++b",      // possessive plus
+		"a?+b",      // possessive quest
+		"\\e",      // ESC char
+		"\\cA",     // control char
+		"\\x{41}",  // braced hex
+		"\\Q.*\\E", // literal quoting
+		"(?|(a)|(b))", // branch reset
+		"\\G\\w+", // \G anchor
+	};
+	foreach (pat : patterns)
+	{
+		Regex*? re = regex::compile(mem, pat);
+		if (!@ok(re))
+		{
+			io::printfn("Pattern failed to compile: %s", pat);
+		}
+		test::@check(@ok(re), "Pattern %s failed to compile", pat);
+		if (try re) re.free();
+	}
+}
+// ============================================================
+// Tier 3: Backreferences, atomic groups, possessive quantifiers
+// ============================================================
+
+fn void test_backref_simple() @test
+{
+	// \1 matches same text as group 1
+	Regex* re = regex::tcompile("(\\w+) \\1");
+	test::@check(re.is_match("hello hello"));
+	test::@check(!re.is_match("hello world"));
+}
+
+fn void test_backref_case_insensitive() @test
+{
+	Regex* re = regex::compile(mem, "(\\w+) \\1", regex::FLAG_IGNORECASE)!!;
+	defer re.free();
+	test::@check(re.is_match("Hello hello"));
+	test::@check(re.is_match("TEST test"));
+	test::@check(!re.is_match("foo bar"));
+}
+
+fn void test_backref_named() @test
+{
+	// \k<name> matches the same text as the named group
+	Regex* re = regex::tcompile("(?<word>\\w+) \\k<word>");
+	test::@check(re.is_match("cat cat"));
+	test::@check(!re.is_match("cat dog"));
+}
+
+fn void test_backref_capture() @test
+{
+	@pool()
+	{
+		Regex* re = regex::tcompile("([a-z]+)\\1");
+		Match? m = re.find(tmem, "abcabc");
+		test::@check(@ok(m));
+		if (try m) {
+			test::@check(m.full() == "abcabc");
+			m.free();
+		}
+	};
+}
+
+fn void test_atomic_group_basic() @test
+{
+	// (?>a|ab) atomically matches 'a' — will not backtrack to try 'ab'
+	Regex* re = regex::tcompile("(?>a|ab)c");
+	// 'a' consumed atomically, then 'c' fails because next char is 'b'
+	test::@check(!re.is_match("abc"));
+	// But straight 'ac' works
+	test::@check(re.is_match("ac"));
+}
+
+fn void test_atomic_group_greedy_commit() @test
+{
+	// (?>.*) consumes all — continuation always fails
+	Regex* re = regex::tcompile("(?>.*)x");
+	test::@check(!re.is_match("abcx"));
+}
+
+fn void test_atomic_vs_non_atomic_alternation() @test
+{
+	Regex* non_atomic = regex::compile(mem, "(a|ab)c")!!;
+	defer non_atomic.free();
+	Regex* atomic = regex::compile(mem, "(?>a|ab)c")!!;
+	defer atomic.free();
+	assert(non_atomic.is_match("abc"));
+	assert(!atomic.is_match("abc"));
+}
+
+fn void test_possessive_star() @test
+{
+	// a*+b: possessive star, no backtrack
+	Regex* re = regex::tcompile("a*+b");
+	test::@check(re.is_match("aaab"));
+	// Without possessive: "aaa" consumed, 'b' matches; with possessive same result here
+	test::@check(!re.is_match("aaac"));
+	// The possessive prevents backtracking: a*+ eats all 'a's, then 'b' must follow directly
+	test::@check(!re.is_match("aaaa"));  // no 'b' at end
+}
+
+fn void test_possessive_plus() @test
+{
+	// \\w++ consumes entire word, can't backtrack
+	Regex* re = regex::tcompile("\\w++\\d");
+	// \w++ eats "abc3", then needs a \d after — but all consumed
+	test::@check(!re.is_match("abc3"));
+}
+
+fn void test_possessive_quest() @test
+{
+	// a?+b — possessive optional
+	Regex* re = regex::tcompile("a?+b");
+	test::@check(re.is_match("ab"));
+	test::@check(re.is_match("b"));
+	// a?+ consumed 'a' possessively; next must be 'b'
+	test::@check(!re.is_match("a"));
+}
+
+fn void test_possessive_prevents_suffix_backtracking() @test
+{
+	Regex* greedy = regex::compile(mem, "a*ab")!!;
+	defer greedy.free();
+	Regex* possessive = regex::compile(mem, "a*+ab")!!;
+	defer possessive.free();
+	assert(greedy.is_match("aaab"));
+	assert(!possessive.is_match("aaab"));
+}
+
+fn void test_backref_in_find() @test
+{
+	@pool()
+	{
+		Regex* re = regex::tcompile("(\\d+)-\\1");
+		Match? m = re.find(tmem, "price: 42-42 end");
+		test::@check(@ok(m));
+		if (try m) {
+			test::@check(m.full() == "42-42");
+			m.free();
+		}
+	};
+}
+
+fn void test_backtracking_engine_handles_long_linear_chain() @test
+{
+	DString pattern_builder = dstring::new_with_capacity(mem, 1028);
+	defer pattern_builder.free();
+	pattern_builder.append("\\G");
+	for (int i = 0; i < 1024; i++) pattern_builder.append("a");
+	pattern_builder.append("\\z");
+
+	DString input_builder = dstring::new_with_capacity(mem, 1024);
+	defer input_builder.free();
+	input_builder.append_repeat('a', 1024);
+
+	Regex* re = regex::compile(mem, pattern_builder.str_view())!!;
+	defer re.free();
+	assert(re.is_match(input_builder.str_view()));
+}
+
+fn void test_backtracking_engine_handles_many_choice_points() @test
+{
+	const int OPTIONAL_COUNT = 24;
+	const int SUFFIX_COUNT = 12;
+
+	DString pattern_builder = dstring::new_with_capacity(mem, 80);
+	defer pattern_builder.free();
+	pattern_builder.append("\\G");
+	for (int i = 0; i < OPTIONAL_COUNT; i++) pattern_builder.append("a?");
+	for (int i = 0; i < SUFFIX_COUNT; i++) pattern_builder.append("a");
+	pattern_builder.append("b\\z");
+
+	DString input_builder = dstring::new_with_capacity(mem, OPTIONAL_COUNT + 1);
+	defer input_builder.free();
+	input_builder.append_repeat('a', OPTIONAL_COUNT);
+	input_builder.append("b");
+
+	Regex* re = regex::compile(mem, pattern_builder.str_view())!!;
+	defer re.free();
+	assert(re.is_match(input_builder.str_view()));
+}
+
+fn void test_backtracking_engine_handles_long_atomic_chain() @test
+{
+	DString pattern_builder = dstring::new_with_capacity(mem, 3076);
+	defer pattern_builder.free();
+	pattern_builder.append("\\G");
+	for (int i = 0; i < 512; i++) pattern_builder.append("(?>a)");
+	pattern_builder.append("\\z");
+
+	DString input_builder = dstring::new_with_capacity(mem, 512);
+	defer input_builder.free();
+	input_builder.append_repeat('a', 512);
+
+	Regex* re = regex::compile(mem, pattern_builder.str_view())!!;
+	defer re.free();
+	assert(re.is_match(input_builder.str_view()));
+}
+
+fn void test_backtracking_engine_handles_long_conditional_chain() @test
+{
+	DString pattern_builder = dstring::new_with_capacity(mem, 2052);
+	defer pattern_builder.free();
+	pattern_builder.append("\\G");
+	for (int i = 0; i < 128; i++) pattern_builder.append("(a)?(?(1)a|b)");
+	pattern_builder.append("\\z");
+
+	DString input_builder = dstring::new_with_capacity(mem, 256);
+	defer input_builder.free();
+	for (int i = 0; i < 128; i++) input_builder.append("aa");
+
+	Regex* re = regex::compile(mem, pattern_builder.str_view())!!;
+	defer re.free();
+	assert(re.is_match(input_builder.str_view()));
+}
+
+// ============================================================
+// Tier 4: Escape sequences, literal quoting, branch reset, conditionals, \G
+// ============================================================
+
+fn void test_escape_esc() @test
+{
+	// \e = ESC (0x1B)
+	Regex* re = regex::tcompile("\\e");
+	test::@check(re.is_match("\x1b"));
+	test::@check(!re.is_match("e"));
+}
+
+fn void test_escape_control_char() @test
+{
+	// \cA = chr(1), \cG = BEL (chr(7))
+	Regex* re = regex::tcompile("\\cA");
+	test::@check(re.is_match("\x01"));
+	test::@check(!re.is_match("A"));
+}
+
+fn void test_escape_hex_braced() @test
+{
+	// \x{41} = 'A', \x{263A} = smiley U+263A
+	Regex* re = regex::tcompile("\\x{41}");
+	test::@check(re.is_match("A"));
+	test::@check(!re.is_match("B"));
+}
+
+fn void test_escape_hex_two_digit() @test
+{
+	// \x41 = 'A' (2-digit hex)
+	Regex* re = regex::tcompile("\\x41");
+	test::@check(re.is_match("A"));
+	test::@check(!re.is_match("B"));
+}
+
+fn void test_literal_quoting_basic() @test
+{
+	// \Q...\E treats ., *, + etc as literals
+	Regex* re = regex::tcompile("\\Q.*+?\\E");
+	test::@check(re.is_match(".*+?"));
+	test::@check(!re.is_match("abcd"));
+}
+
+fn void test_literal_quoting_in_pattern() @test
+{
+	// Pattern before and after \Q...\E should still work as regex
+	Regex* re = regex::tcompile("\\d+\\Q.\\E\\d+");
+	test::@check(re.is_match("123.456"));
+	test::@check(!re.is_match("123x456"));
+}
+
+fn void test_literal_quoting_empty() @test
+{
+	// \Q\E is empty — should match adjacent context
+	Regex* re = regex::tcompile("ab\\Q\\Ecd");
+	test::@check(re.is_match("abcd"));
+}
+
+fn void test_branch_reset_basic() @test
+{
+	// (?|(\d+)|(\w+)) — both branches use group 1
+	@pool()
+	{
+		Regex* re = regex::tcompile("(?|(\\d+)|(\\w+))");
+		Match? m1 = re.find(tmem, "123");
+		test::@check(@ok(m1));
+		if (try m1) {
+			// Group 1 should capture the digits
+			String? g = m1.group(1);
+			test::@check(@ok(g));
+			if (try g) test::@check(g == "123");
+			m1.free();
+		}
+		Match? m2 = re.find(tmem, "abc");
+		test::@check(@ok(m2));
+		if (try m2) {
+			String? g = m2.group(1);
+			test::@check(@ok(g));
+			if (try g) test::@check(g == "abc");
+			m2.free();
+		}
+	};
+}
+
+fn void test_branch_reset_backref_reuses_group_number() @test
+{
+	Regex* re = regex::compile(mem, "(?|(a)|(b))\\1")!!;
+	defer re.free();
+	assert(re.is_match("aa"));
+	assert(re.is_match("bb"));
+	assert(!re.is_match("ab"));
+}
+
+fn void test_branch_reset_following_group_numbering() @test
+{
+	Regex* re = regex::compile(mem, "(?|(a)|(b))(c)")!!;
+	defer re.free();
+
+	Match m1 = re.find(mem, "ac")!!;
+	defer m1.free();
+	assert(m1.group(1)!! == "a");
+	assert(m1.group(2)!! == "c");
+
+	Match m2 = re.find(mem, "bc")!!;
+	defer m2.free();
+	assert(m2.group(1)!! == "b");
+	assert(m2.group(2)!! == "c");
+}
+
+fn void test_conditional_numeric() @test
+{
+	// (?(1)yes|no) — anchored so no sliding past the conditional
+	Regex* re = regex::tcompile("^(\\d)?x(?(1)digit|other)$");
+	test::@check(re.is_match("3xdigit"));
+	test::@check(re.is_match("xother"));
+	test::@check(!re.is_match("3xother"));
+	test::@check(!re.is_match("xdigit"));
+}
+
+fn void test_conditional_named() @test
+{
+	// (?(name)yes|no) — named group condition
+	Regex* re = regex::tcompile("(?<n>\\d)?x(?(n)digit|other)");
+	test::@check(re.is_match("3xdigit"));
+	test::@check(re.is_match("xother"));
+}
+
+fn void test_conditional_no_else() @test
+{
+	// (?(1)yes) — no else branch: condition failure → match empty
+	// Anchored to prevent finding match at a later position
+	Regex* re = regex::tcompile("^(a)?(?(1)b)c$");
+	test::@check(re.is_match("abc"));
+	test::@check(re.is_match("c"));   // no 'a', no 'b', condition fails → empty → matches 'c'
+	test::@check(!re.is_match("ac")); // 'a' captured but no 'b'
+}
+
+fn void test_conditional_preserves_following_captures() @test
+{
+	Regex* re = regex::compile(mem, "^(a)?(?(1)b|c)(d)$")!!;
+	defer re.free();
+
+	Match m1 = re.find(mem, "abd")!!;
+	defer m1.free();
+	assert(m1.group(1)!! == "a");
+	assert(m1.group(2)!! == "d");
+
+	Match m2 = re.find(mem, "cd")!!;
+	defer m2.free();
+	assert(@catch(m2.group(1)) == regex::GROUP_NOT_FOUND);
+	assert(m2.group(2)!! == "d");
+
+	assert(!re.is_match("acd"));
+	assert(!re.is_match("bd"));
+}
+
+fn void test_gpos_anchor() @test
+{
+	// \G anchors to the position where find_at starts
+	@pool()
+	{
+		Regex* re = regex::tcompile("\\G\\d+");
+		// find_at(0): \G matches at pos 0, digits start there
+		Match? m1 = re.find_at(tmem, "123abc", 0);
+		test::@check(@ok(m1));
+		if (try m1) { test::@check(m1.full() == "123"); m1.free(); }
+		// find_at(3): pos 3 is 'a', \G matches but \d+ fails
+		Match? m2 = re.find_at(tmem, "123abc", 3);
+		test::@check(!@ok(m2));
+	};
+}
+
+fn void test_gpos_find_all() @test
+{
+	// \G\w+ tokenizes input by always matching at the previous end
+	@pool()
+	{
+		Regex* re = regex::tcompile("\\G\\w+");
+		MatchIter it = re.find_all(tmem, "hello world");
+		Match? m1 = it.next();
+		test::@check(@ok(m1));
+		if (try m1) { test::@check(m1.full() == "hello"); m1.free(); }
+		// After "hello", pos=5; input[5]=' '; \G at pos=5, \w+ fails → no more matches
+		Match? m2 = it.next();
+		test::@check(!@ok(m2));
+	};
+}
+
+fn void test_gpos_find_all_progresses_from_previous_end() @test
+{
+	Regex* re = regex::compile(mem, "\\G\\d{2}")!!;
+	defer re.free();
+	MatchIter it = re.find_all(mem, "123456x");
+
+	Match m1 = it.next()!!;
+	defer m1.free();
+	assert(m1.full() == "12");
+
+	Match m2 = it.next()!!;
+	defer m2.free();
+	assert(m2.full() == "34");
+
+	Match m3 = it.next()!!;
+	defer m3.free();
+	assert(m3.full() == "56");
+
+	assert(@catch(it.next()) == regex::NO_MATCH);
+}


### PR DESCRIPTION
## Summary

Adds a stdlib regex engine with a hybrid execution model.

This implementation combines Thompson-style NFA matching for the regular subset with a backtracking path for advanced constructs that require it. The result is a practical, PCRE-like regex engine in the stdlib with a broad supported feature set and explicit documented compatibility boundaries.

Included in this PR:
- public regex API under `std::regex`
- support for captures, named groups, non-capturing groups, alternation, quantifiers, lazy and possessive quantifiers
- anchors and zero-width constructs including `^`, `$`, `\A`, `\z`, `\Z`, `\b`, `\B`, `\G`, lookahead, lookbehind, and `\K`
- advanced grouping and control flow including backreferences, atomic groups, branch reset groups, and conditionals
- escapes and character-class support including `\d`, `\w`, `\s`, `\h`, `\v`, `\R`, POSIX classes, Unicode whitespace properties, and selected Unicode-aware matching behavior
- replacement support including `$&`, `$0`..`$9`, `${N}`, `${name}`, and `$$`
- regex benchmarks
- systematic unit tests, matrix-style API coverage, and deterministic fuzz coverage
- public module documentation and C3 doc-contract annotations for the exported API

## Design Notes

The implementation uses a hybrid matcher:
- regular constructs are handled through Thompson-style NFA execution
- advanced constructs such as backreferences, atomic groups, conditionals, and `\G` route through a dedicated backtracking path

The code is split by responsibility:
- `lib/std/regex/parser.c3`
- `lib/std/regex/nfa.c3`
- `lib/std/regex/engine.c3`
- `lib/std/regex/regex.c3`

This PR is intentionally focused on delivering a practical stdlib regex engine with explicit documented semantics, rather than full PCRE compatibility.

## Compatibility Notes

This engine is intended to be practical and PCRE-like, but it is not a bug-for-bug compatibility target for PCRE2, Oniguruma, .NET, Java, Python, or ECMAScript.

A few important boundaries:
- Unicode support is partial and explicitly documented in `lib/std/regex/regex.c3`
- bare inline `(?i)`, `(?m)`, and `(?s)` are accepted for compatibility syntax, but compile flags are the supported way to control runtime ignore-case, multiline, and dotall behavior
- supported and unsupported syntax is documented in the public module header

## Structure

Main files:
- `lib/std/regex/regex.c3`
- `lib/std/regex/parser.c3`
- `lib/std/regex/nfa.c3`
- `lib/std/regex/engine.c3`

Tests and benchmarks:
- `test/unit/stdlib/regex/regex.c3`
- `test/unit/stdlib/regex/matrix.c3`
- `test/unit/stdlib/regex/fuzz.c3`
- `benchmarks/stdlib/regex/regex.c3`

## Verification

Focused regex suite:
```bash
./build/c3c compile-test -O0 test/unit/stdlib/regex/regex.c3 test/unit/stdlib/regex/matrix.c3 test/unit/stdlib/regex/fuzz.c3
