### PR TITLE
don't override the sigaltstack when address sanitizing: fixes #3115

### DIFF
--- a/lib/std/core/builtin.c3
+++ b/lib/std/core/builtin.c3
@@ -1125,7 +1125,7 @@ char[64 * 1024] sig_stack @local @if(env::BACKTRACE && env::LINUX);
 // Clean this up
 fn void install_signal_handlers() @init(101) @local @if(env::BACKTRACE)
 {
-	$if env::LINUX:
+	$if env::LINUX && !env::ADDRESS_SANITIZER:
 		Stack_t ss = {
 			.ss_sp = &sig_stack,
 			.ss_size = sig_stack.len

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -60,6 +60,7 @@
 - `\r` was not filtered when piping a source file from stdin.
 - SHA-3 and Keccak contexts are now explicitly `@mustinit` structures. #3110
 - `UnbufferedChannel` would deadlock on multiple producers.
+- Don't override `sigaltstack` when running with `--sanitize=address`. #3115
 
 ## 0.7.11 Change list
 


### PR DESCRIPTION
fixes https://github.com/c3lang/c3c/issues/3115