### PR TITLE
Added std::collections::result to the standard lib

### DIFF
--- a/lib/std/collections/result.c3
+++ b/lib/std/collections/result.c3
@@ -1,4 +1,5 @@
 module std::collections::result <OkType, ErrType>;
+import std::io;
 
 faultdef RESULT_ERROR, RESULT_OK;
 

--- a/lib/std/collections/result.c3
+++ b/lib/std/collections/result.c3
@@ -133,10 +133,10 @@ fn bool Result.equals(self, Result other) @operator(==)
 *>
 macro OkType Result.@or_else(&self; @body(Result res))
 {
-	if (!self.is_ok) @body(*self);
-
-	if (@unlikely(!self.is_ok)) {
-		abort("@or_else must diverge on error.");
+	if (!self.is_ok) 
+	{
+		@body(*self);
+		unreachable("@or_else must diverge on error.");
 	}
-	return self.value;
+	return self.value;;
 }

--- a/lib/std/collections/result.c3
+++ b/lib/std/collections/result.c3
@@ -101,7 +101,7 @@ macro OkType Result.@or_else(&self; @body(Result res))
 {
 	if (!self.is_ok) @body(*self);
 
-  if (@unlickly(!self.is_ok)) {
+  if (@unlikely(!self.is_ok)) {
     abort("@or_else must diverge on error.");
   }
 	return self.value;

--- a/lib/std/collections/result.c3
+++ b/lib/std/collections/result.c3
@@ -4,37 +4,37 @@ faultdef RESULT_ERROR, RESULT_OK;
 
 <*
  Result{OkType, ErrType} holds either a success value or an error value with a payload.
- 
+
  **Prefer C3 optionals for normal error handling.**
  C3's built-in optional/fault system handles most error cases with less overhead.
  See: https://c3-lang.org/language-common/optionals-essential/
- 
+
  Use Result only when the error path must carry structured data that a bare fault cannot express.
- 
+
  Good Example:
  ```c3
  struct ParseError { int line; String msg; }
- 
+
  fn Result{int, ParseError} parse_number(String s)
  {
-   int! v = s.to_int();
-   if (catch v) return result::err({ .line = 1, .msg = string::tformat("not a number: %s", s) });
-   return result::ok(v);
+	 int! v = s.to_int();
+	 if (catch v) return result::err({ .line = 1, .msg = string::tformat("not a number: %s", s) });
+	 return result::ok(v);
  }
- 
+
  fn void main()
  {
-   Result{int, ParseError} r = parse_number("42");
-   if (try int v = r.ok()) 
-   {
-     io::printfn("got %d", v);
-   }
-   
-   Result{int, ParseError} bad = parse_number("abc");
-   if (try ParseError e = bad.err()) 
-   {
-     io::printfn("error on line %d: %s", e.line, e.msg);
-   }
+	 Result{int, ParseError} r = parse_number("42");
+	 if (try int v = r.ok()) 
+	 {
+		 io::printfn("got %d", v);
+	 }
+
+	 Result{int, ParseError} bad = parse_number("abc");
+	 if (try ParseError e = bad.err()) 
+	 {
+		 io::printfn("error on line %d: %s", e.line, e.msg);
+	 }
  }
  ```
 
@@ -42,19 +42,19 @@ faultdef RESULT_ERROR, RESULT_OK;
  ```c3
  fn Result{int, String} div(int a, int b) 
  {
-   if (b == 0) return result::err("division by zero");
-   return result::ok(a / b);
+	 if (b == 0) return result::err("division by zero");
+	 return result::ok(a / b);
  }
- 
+
  fn void print_int(int x) 
  {
-   io::printfn("Integer %d", x);
+	 io::printfn("Integer %d", x);
  }
- 
+
  fn void main() 
  {
-   print_int(div(4, 1).ok())!!;
-   print_int(div(4, 0).ok())!!;
+	 print_int(div(4, 1).ok())!!;
+	 print_int(div(4, 0).ok())!!;
  }
  ```
  *>
@@ -110,23 +110,23 @@ fn bool Result.equals(self, Result other) @operator(==)
 }
 
 <*
-  This macro allows the result to diverge on error (return/break/continue)
-	
+	This macro allows the result to diverge on error (return/break/continue)
+
 	**Aborts the program if the body doesn't diverge**
 
 	Examples:
 	```c3
 	fn Result{int, String} foo()
 	{
-    Result{int, String} res = result::err("Error");
-    int value = res.@or_else(;it) { return it; }; // early function return
+		Result{int, String} res = result::err("Error");
+		int value = res.@or_else(;it) { return it; }; // early function return
 		// ...
 	}
 
 	fn Result{int, String} bar()
 	{
-    Result{int, String} res = result::ok(22);
-    int value = res.@or_else(;it) { return it; };
+		Result{int, String} res = result::ok(22);
+		int value = res.@or_else(;it) { return it; };
 		// value is 22
 	}
 	```

--- a/lib/std/collections/result.c3
+++ b/lib/std/collections/result.c3
@@ -139,5 +139,5 @@ macro OkType Result.@or_else(&self; @body(Result res))
 		@body(*self);
 		unreachable("@or_else must diverge on error.");
 	}
-	return self.value;;
+	return self.value;
 }

--- a/lib/std/collections/result.c3
+++ b/lib/std/collections/result.c3
@@ -71,17 +71,29 @@ struct Result (Printable)
 fn Result ok(OkType val) => {.is_ok = true, .value = val};
 fn Result err(ErrType err) => {.is_ok = false, .error = err};
 
-fn isz? Result.to_format(&self, Formatter* f) @dynamic
+fn sz? Result.to_format(&self, Formatter* f) @dynamic
 {
-	if (self.is_ok) return f.printf("ok[%s]", self.value);
-	return f.printf("err[%s]", self.error);
+	if (self.is_ok) return f.printf("OK[%s]", self.value);
+	return f.printf("ERR[%s]", self.error);
 }
 
+<*
+	Returns the ok value or a fault
+
+	@return "The ok value of the result"
+	@return? RESULT_ERROR
+*>
 fn OkType? Result.ok(&self)
 {
 	return self.is_ok ? self.value : RESULT_ERROR~;
 }
 
+<*
+	Returns the error value or a fault
+
+	@return "The error of the result"
+	@return? RESULT_OK
+*>
 fn ErrType? Result.err(&self)
 {
 	return self.is_ok ? RESULT_OK~ : self.error;
@@ -97,12 +109,34 @@ fn bool Result.equals(self, Result other) @operator(==)
 	return !other.is_ok && equals(self.error, other.error);
 }
 
+<*
+  This macro allows the result to diverge on error (return/break/continue)
+	
+	**Aborts the program if the body doesn't diverge**
+
+	Examples:
+	```c3
+	fn Result{int, String} foo()
+	{
+    Result{int, String} res = result::err("Error");
+    int value = res.@or_else(;it) { return it; }; // early function return
+		// ...
+	}
+
+	fn Result{int, String} bar()
+	{
+    Result{int, String} res = result::ok(22);
+    int value = res.@or_else(;it) { return it; };
+		// value is 22
+	}
+	```
+*>
 macro OkType Result.@or_else(&self; @body(Result res))
 {
 	if (!self.is_ok) @body(*self);
 
-  if (@unlikely(!self.is_ok)) {
-    abort("@or_else must diverge on error.");
-  }
+	if (@unlikely(!self.is_ok)) {
+		abort("@or_else must diverge on error.");
+	}
 	return self.value;
 }

--- a/lib/std/collections/result.c3
+++ b/lib/std/collections/result.c3
@@ -1,0 +1,108 @@
+module std::collections::result <OkType, ErrType>;
+
+faultdef RESULT_ERROR, RESULT_OK;
+
+<*
+ Result{OkType, ErrType} holds either a success value or an error value with a payload.
+ 
+ **Prefer C3 optionals for normal error handling.**
+ C3's built-in optional/fault system handles most error cases with less overhead.
+ See: https://c3-lang.org/language-common/optionals-essential/
+ 
+ Use Result only when the error path must carry structured data that a bare fault cannot express.
+ 
+ Good Example:
+ ```c3
+ struct ParseError { int line; String msg; }
+ 
+ fn Result{int, ParseError} parse_number(String s)
+ {
+   int! v = s.to_int();
+   if (catch v) return result::err({ .line = 1, .msg = string::tformat("not a number: %s", s) });
+   return result::ok(v);
+ }
+ 
+ fn void main()
+ {
+   Result{int, ParseError} r = parse_number("42");
+   if (try int v = r.ok()) 
+   {
+     io::printfn("got %d", v);
+   }
+   
+   Result{int, ParseError} bad = parse_number("abc");
+   if (try ParseError e = bad.err()) 
+   {
+     io::printfn("error on line %d: %s", e.line, e.msg);
+   }
+ }
+ ```
+
+ Bad Example (should be a fault):
+ ```c3
+ fn Result{int, String} div(int a, int b) 
+ {
+   if (b == 0) return result::err("division by zero");
+   return result::ok(a / b);
+ }
+ 
+ fn void print_int(int x) 
+ {
+   io::printfn("Integer %d", x);
+ }
+ 
+ fn void main() 
+ {
+   print_int(div(4, 1).ok())!!;
+   print_int(div(4, 0).ok())!!;
+ }
+ ```
+ *>
+struct Result (Printable)
+{
+	union
+	{
+		OkType value;
+		ErrType error;
+	}
+	bool is_ok;
+}
+
+fn Result ok(OkType val) => {.is_ok = true, .value = val};
+fn Result err(ErrType err) => {.is_ok = false, .error = err};
+
+fn isz? Result.to_format(&self, Formatter* f) @dynamic
+{
+	if (self.is_ok) return f.printf("ok[%s]", self.value);
+	return f.printf("err[%s]", self.error);
+}
+
+fn OkType? Result.ok(&self)
+{
+	return self.is_ok ? self.value : RESULT_ERROR~;
+}
+
+fn ErrType? Result.err(&self)
+{
+	return self.is_ok ? RESULT_OK~ : self.error;
+}
+
+fn bool Result.equals(self, Result other) @operator(==) 
+@if(types::is_equatable_type(OkType) &&& types::is_equatable_type(ErrType))
+{
+	if (self.is_ok)
+	{
+		return other.is_ok && equals(self.value, other.value);
+	}
+	return !other.is_ok && equals(self.error, other.error);
+}
+
+macro OkType Result.@or_else(&self; @body(Result res))
+{
+	if (!self.is_ok) @body(*self);
+
+  if (@unlickly(!self.is_ok)) {
+    abort("@or_else must diverge on error.");
+  }
+	return self.value;
+}


### PR DESCRIPTION
As discussed on discord, the `Result` struct will allow errors to carry a payload.

`Result`s should only be used when simple faults are not enough and should not be used as the default. The documentation included with the `Result` struct is clear about this.

The api only includes 2 constructors, 2 accessors, printing, `==` operation (if both OkType and ErrType support it) and the `result.@or_else` macro that allows the result to diverge on error.