### PR TITLE
feat(vendor-fetch): allow decompress downloaded .c3l

### DIFF
--- a/c3c.1
+++ b/c3c.1
@@ -127,7 +127,7 @@ Analyze files and generate C headers for public methods.
 .RE
 .PP
 .B c3c vendor-fetch
-[\fB-e\fR|\fB--extract\fR] [\fB-f\fR|\fB--force\fR] \fIlibrary\fR ...
+[\fB-e\fR|\fB--extract\fR] [\fB-f\fR|\fB--force\fR] [\fB-t\fR|\fB--target\fR] \fIlib\fR ...
 .RS
 Fetch one or more libraries from the vendor collection.
 .RE
@@ -173,6 +173,11 @@ Add this library to the compilation.
 \fIdir\fR
 .RS
 Use this as the base directory for the current command.
+.RE
+.PP
+.B -t, --target
+.RS
+For \fBvendor-fetch\fR, allow to specify \fBtarget\fR for fetching dependencies.
 .RE
 .PP
 .B -e, --extract

--- a/c3c.1
+++ b/c3c.1
@@ -127,7 +127,7 @@ Analyze files and generate C headers for public methods.
 .RE
 .PP
 .B c3c vendor-fetch
-\fIlibrary\fR ...
+[\fB-e\fR|\fB--extract\fR] [\fB-f\fR|\fB--force\fR] \fIlibrary\fR ...
 .RS
 Fetch one or more libraries from the vendor collection.
 .RE
@@ -173,6 +173,18 @@ Add this library to the compilation.
 \fIdir\fR
 .RS
 Use this as the base directory for the current command.
+.RE
+.PP
+.B -e, --extract
+.RS
+For \fBvendor-fetch\fR, extract downloaded \fB.c3l\fR archives into a directory named
+\fB<library>.c3l\fR.
+.RE
+.PP
+.B -f, --force
+.RS
+For \fBvendor-fetch\fR, force to download \fB.c3l\fR archives into a directory named
+\fB<library>.c3l\fR when extract option is passed.
 .RE
 .PP
 .B --template

--- a/scripts/tools/ci_tests.sh
+++ b/scripts/tools/ci_tests.sh
@@ -116,8 +116,12 @@ run_cli_tests() {
     else
         echo "Testing vendor-fetch..."
         cd "$ROOT_DIR/resources"
-        if ! "$C3C_BIN" vendor-fetch raylib; then
+        if ! "$C3C_BIN" vendor-fetch -e raylib; then
             echo "::warning::vendor-fetch failed. Skipping dependent tests."
+            return
+        fi
+        if [ ! -d "raylib.c3l" ]; then
+            echo "::warning::vendor-fetch -e did not create extracted directory."
             return
         fi
 

--- a/src/build/build.h
+++ b/src/build/build.h
@@ -202,6 +202,8 @@ typedef struct BuildOptions_
 	const char *target_select;
 	const char *path;
 	const char *vendor_download_path;
+	bool vendor_extract;
+	bool vendor_force;
 	const char *template;
 	const char **unchecked_directories;
 	LinkerType linker_type;

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -69,7 +69,7 @@ static void usage(bool full)
 	print_cmd("compile-test <file1> [<file2> ...]", "Compile files into a benchmark-executable and run unit tests.");
 	print_cmd("static-lib <file1> [<file2> ...]", "Compile files without a project into a static library.");
 	print_cmd("dynamic-lib <file1> [<file2> ...]", "Compile files without a project into a dynamic library.");
-	print_cmd("vendor-fetch <library> ...", "Fetches one or more libraries from the vendor collection.");
+	print_cmd("vendor-fetch [-e|--extract] [-f|--force] <library>...","Fetch one or more libraries from the vendor collection.");
 	print_cmd("project <subcommand> ...", "Manipulate or view project files.");
 	print_cmd("fetch-sdk <windows|macos|android> ...", "Fetches the SDK required for cross-compiling.");
 	PRINTF("");
@@ -497,6 +497,19 @@ static void parse_command(BuildOptions *options)
 	if (arg_match("vendor-fetch"))
 	{
 		options->command = COMMAND_VENDOR_FETCH;
+		while (!at_end() && next_is_opt()) {
+			next_arg();
+			if (!options->vendor_extract && (match_shortopt("e") || match_longopt("extract"))) {
+				options->vendor_extract = true;
+				continue;
+			}
+		 	if (!options->vendor_force && (match_shortopt("f") || match_longopt("force"))) {
+				options->vendor_force = true;
+				continue;
+			}
+			error_exit("Invalid options after vendor-fetch");
+			return;
+		}
 		while (!at_end() && !next_is_opt())
 		{
 			const char *lib = next_arg();

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -69,7 +69,7 @@ static void usage(bool full)
 	print_cmd("compile-test <file1> [<file2> ...]", "Compile files into a benchmark-executable and run unit tests.");
 	print_cmd("static-lib <file1> [<file2> ...]", "Compile files without a project into a static library.");
 	print_cmd("dynamic-lib <file1> [<file2> ...]", "Compile files without a project into a dynamic library.");
-	print_cmd("vendor-fetch [-e|--extract] [-f|--force] <lib>...","Fetch one or more libraries from the vendor collection.");
+	print_cmd("vendor-fetch [-e|--extract] [-f|--force] [-t|--target] <lib>...","Fetch one or more libraries from the vendor collection.");
 	print_cmd("project <subcommand> ...", "Manipulate or view project files.");
 	print_cmd("fetch-sdk <windows|macos|android> ...", "Fetches the SDK required for cross-compiling.");
 	PRINTF("");
@@ -316,7 +316,7 @@ static void project_usage()
 	PRINTF("Project Subcommands:");
 	print_cmd("view", "view the current projects structure.");
 	print_cmd("add-target <name>  <target_type>  [sources...]", "add a new target to the project.");
-	print_cmd("fetch [-e|--extract] [-f|--force]", "fetch missing project libraries.");
+	print_cmd("fetch [-e|--extract] [-f|--force] [-t|--target]", "fetch missing project libraries.");
 }
 
 static void project_view_usage()
@@ -432,6 +432,13 @@ static void parse_project_subcommand(BuildOptions *options)
 				options->vendor_force = true;
 				continue;
 			}
+			if (!options->project_options.target_name && (match_shortopt("t") || match_longopt("target"))) {
+				if (at_end() || next_is_opt()) error_exit("Expected a target name");
+				
+				options->project_options.target_name = next_arg();
+				
+				continue;
+			}
 			error_exit("Invalid options after fetch");
 			return;
 		}
@@ -518,6 +525,13 @@ static void parse_command(BuildOptions *options)
 			}
 		 	if (!options->vendor_force && (match_shortopt("f") || match_longopt("force"))) {
 				options->vendor_force = true;
+				continue;
+			}
+			if (!options->project_options.target_name && (match_shortopt("t") || match_longopt("target"))) {
+				if (at_end() || next_is_opt()) error_exit("Expected a target name");
+				
+				options->project_options.target_name = next_arg();
+				
 				continue;
 			}
 			error_exit("Invalid options after vendor-fetch");

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -69,7 +69,7 @@ static void usage(bool full)
 	print_cmd("compile-test <file1> [<file2> ...]", "Compile files into a benchmark-executable and run unit tests.");
 	print_cmd("static-lib <file1> [<file2> ...]", "Compile files without a project into a static library.");
 	print_cmd("dynamic-lib <file1> [<file2> ...]", "Compile files without a project into a dynamic library.");
-	print_cmd("vendor-fetch [-e|--extract] [-f|--force] <library>...","Fetch one or more libraries from the vendor collection.");
+	print_cmd("vendor-fetch [-e|--extract] [-f|--force] <lib>...","Fetch one or more libraries from the vendor collection.");
 	print_cmd("project <subcommand> ...", "Manipulate or view project files.");
 	print_cmd("fetch-sdk <windows|macos|android> ...", "Fetches the SDK required for cross-compiling.");
 	PRINTF("");
@@ -316,7 +316,7 @@ static void project_usage()
 	PRINTF("Project Subcommands:");
 	print_cmd("view", "view the current projects structure.");
 	print_cmd("add-target <name>  <target_type>  [sources...]", "add a new target to the project.");
-	print_cmd("fetch", "fetch missing project libraries.");
+	print_cmd("fetch [-e|--extract] [-f|--force]", "fetch missing project libraries.");
 }
 
 static void project_view_usage()
@@ -422,6 +422,19 @@ static void parse_project_subcommand(BuildOptions *options)
 	if (arg_match("fetch"))
 	{
 		options->project_options.command = SUBCOMMAND_FETCH;
+		while (!at_end() && next_is_opt()) {
+			next_arg();
+			if (!options->vendor_extract && (match_shortopt("e") || match_longopt("extract"))) {
+				options->vendor_extract = true;
+				continue;
+			}
+		 	if (!options->vendor_force && (match_shortopt("f") || match_longopt("force"))) {
+				options->vendor_force = true;
+				continue;
+			}
+			error_exit("Invalid options after fetch");
+			return;
+		}
 		return;
 	}
 

--- a/src/build/project.h
+++ b/src/build/project.h
@@ -9,5 +9,6 @@ const char** get_project_dependencies(JSONObject *json);
 
 static void print_vec(const char *header, const char **vec, bool opt, const char *delim);
 void add_libraries_to_project_file(const char** libs, const char* target_name, JSONObject *project_json, const char* filename);
+JSONObject* get_target_in_project_json(JSONObject *project_json, const char* target_name);
 const char* vendor_fetch_single(const char* lib, const char* path, bool progress);
 void vendor_fetch(BuildOptions *options);

--- a/src/build/project.h
+++ b/src/build/project.h
@@ -1,9 +1,13 @@
 #pragma once
 #include "../utils/json.h"
+#include "../build/build.h"
 
-const char** get_project_dependency_directories();
-const char** get_project_dependencies();
+JSONObject *project_json_load(const char **filename_ref);
+
+const char** get_project_dependency_directories(JSONObject *json, const char *filename);
+const char** get_project_dependencies(JSONObject *json);
 
 static void print_vec(const char *header, const char **vec, bool opt, const char *delim);
-void add_libraries_to_project_file(const char** libs, const char* target_name);
+void add_libraries_to_project_file(const char** libs, const char* target_name, JSONObject *project_json, const char* filename);
 const char* vendor_fetch_single(const char* lib, const char* path, bool progress);
+void vendor_fetch(BuildOptions *options);

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -299,6 +299,11 @@ void fetch_project(BuildOptions* options)
 			{
 				error_exit("Invalid data in target '%s'", key);
 			}
+			
+			if(options->project_options.target_name && strcmp(options->project_options.target_name, key) != 0)
+			{
+				continue;
+			}
 
 			const char **target_deps = get_optional_string_array((BuildParseContext) { filename, key }, target, "dependencies");
 
@@ -314,23 +319,62 @@ void fetch_project(BuildOptions* options)
 }
 
 
+JSONObject* get_target_in_project_json(JSONObject *project_json, const char* target_name) {
+	if(!project_json || !target_name) return NULL;	
+	
+	JSONObject *targets_json = json_map_get(project_json, "targets");
+	
+	if (!targets_json) error_exit("No targets found in project.");
+	if (targets_json->type != J_OBJECT) error_exit("'targets' did not contain map of targets.");
+	
+	JSONObject *target_json = json_map_get(targets_json, target_name);
+	
+	if (!target_json) error_exit("Target '%s' no found in project.", target_name);	
+	if (target_json->type != J_OBJECT) error_exit("Invalid data in target '%s'", target_name);
+	
+	JSONObject *libraries_json = json_map_get(target_json, "dependencies");
+
+	if (libraries_json && libraries_json->type != J_ARRAY)
+	{
+		error_exit("Target '%s' field 'dependencies' must be an array.", target_name);
+	}
+	
+	return target_json;
+}
 
 void add_libraries_to_project_file(const char** libs, const char* target_name, JSONObject *project_json, const char *filename) {
-
 	if (!libs || vec_size(libs) == 0) return;
-	//TODO! Target name option not implemented
-
-	// TODO! check if target is specified and exists (NULL at the moment)
-	JSONObject *libraries_json = json_map_get(project_json, "dependencies");
+	
+	JSONObject *libraries_json = NULL;
+	JSONObject *target_json = NULL;	
+	
+	if(target_name)
+	{		
+		target_json = get_target_in_project_json(project_json, target_name);
+		libraries_json = json_map_get(target_json, "dependencies");
+	}
+	else
+	{
+		libraries_json = json_map_get(project_json, "dependencies");
+	}
+	
 	if (!libraries_json)
 	{
 		libraries_json = json_new_object(J_ARRAY);
-		json_map_set(project_json, "dependencies", libraries_json);
+		
+		json_map_set(!target_json ? project_json: target_json, "dependencies", libraries_json);
 	}
 	
 	if (libraries_json->type != J_ARRAY)
 	{
-		error_exit("Project field 'dependencies' must be an array in '%s'.", filename);
+		if(!target_json)
+		{
+			error_exit("Project field 'dependencies' must be an array in '%s'.", filename);
+		}
+		else
+		{
+			error_exit("Target '%s' field 'dependencies' must be an array in '%s'.", target_name, filename);
+		}
 	}
 
 	const char** dependencies = NULL;

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -8,11 +8,8 @@
 
 bool use_ansi(void);
 
-const char** get_project_dependency_directories()
-{
-	const char *filename;
-	JSONObject *json = project_json_load(&filename);
-
+const char** get_project_dependency_directories(JSONObject *json, const char *filename)
+{	
 	const char *target = NULL;
 	const char **deps_dirs = NULL;
 	BuildParseContext context = { filename, target };
@@ -38,14 +35,14 @@ static void print_vec(const char *header, const char **vec, bool opt, const char
 	PRINTFN("");
 }
 
-const char** get_project_dependencies()
+const char** get_project_dependencies(JSONObject *project_json)
 {
-	const char *filename;
 	const char** dependencies = NULL;
 
-	JSONObject *project_json = project_json_load(&filename);
 	JSONObject *dependencies_json = json_map_get(project_json, "dependencies");
-
+	
+	if (!dependencies_json) return dependencies;
+	
 	FOREACH(JSONObject *, element, dependencies_json->elements)
 	{
 		vec_add(dependencies, element->str);
@@ -268,9 +265,6 @@ static void view_target(BuildParseContext context, JSONObject *target, bool verb
 	TARGET_VIEW_BOOL("Merge functions", "merge-functions");
 }
 
-
-
-
 void fetch_project(BuildOptions* options)
 {
 	if (!download_available())
@@ -278,25 +272,21 @@ void fetch_project(BuildOptions* options)
 		error_exit("The 'project fetch' command requires libcurl to download dependencies.\n"
 				   "Please ensure libcurl is installed on your system.");
 	}
-	if (!file_exists(PROJECT_JSON5) && !file_exists(PROJECT_JSON))
-	{
-		error_exit("Failed: no project file found.");
-	}
+	
+	const char *filename;
+	JSONObject *project_json = project_json_load(&filename);	
+
+	const char **libdirs = get_project_dependency_directories(project_json, filename);
+	const char **deps = get_project_dependencies(project_json);
 
 	if (str_eq(options->path, DEFAULT_PATH))
 	{
 		{
-			const char** deps_dirs =  get_project_dependency_directories();
-			int num_lib = vec_size(deps_dirs);
-			if (num_lib > 0) options->vendor_download_path = deps_dirs[0];
+			int num_lib = vec_size(libdirs);
+			if (num_lib > 0) options->vendor_download_path = libdirs[0];
 		}
-	}
-
-	const char **libdirs = get_project_dependency_directories();
-	const char **deps = get_project_dependencies();
-	const char *filename;
-	JSONObject *project_json = project_json_load(&filename);
-
+	}	
+	
 	JSONObject *targets_json = json_map_get(project_json, "targets");
 
 	if (targets_json && targets_json->type == J_OBJECT)
@@ -318,47 +308,30 @@ void fetch_project(BuildOptions* options)
 			}
 		}
 	}
-
-	// dependency check tree
-	while (vec_size(deps) > 0)
-	{
-		FOREACH(const char*, dir, libdirs)
-		{
-			const char *dep = VECLAST(deps);
-			if (file_exists(file_append_path(dir, str_printf("%s.c3l", dep))))
-			{
-				vec_pop(deps);
-				break;
-			}
-
-			printf("Fetching missing library '%s'...\n", dep);
-			fflush(stdout);
-
-			const char *error = vendor_fetch_single(dep, options->vendor_download_path, use_ansi());
-
-			if (error)
-			{
-				printf("Failed: '%s'\n", error);
-			}
-
-			vec_pop(deps);
-			break;
-		}
-	}
+	
+	options->libraries_to_fetch = deps;
+	vendor_fetch(options);
 }
 
 
 
-void add_libraries_to_project_file(const char** libs, const char* target_name) {
+void add_libraries_to_project_file(const char** libs, const char* target_name, JSONObject *project_json, const char *filename) {
 
-	if (!file_exists(PROJECT_JSON5) && !file_exists(PROJECT_JSON)) return;
+	if (!libs || vec_size(libs) == 0) return;
 	//TODO! Target name option not implemented
-
-	const char *filename;
-	JSONObject *project_json = project_json_load(&filename);
 
 	// TODO! check if target is specified and exists (NULL at the moment)
 	JSONObject *libraries_json = json_map_get(project_json, "dependencies");
+	if (!libraries_json)
+	{
+		libraries_json = json_new_object(J_ARRAY);
+		json_map_set(project_json, "dependencies", libraries_json);
+	}
+	
+	if (libraries_json->type != J_ARRAY)
+	{
+		error_exit("Project field 'dependencies' must be an array in '%s'.", filename);
+	}
 
 	const char** dependencies = NULL;
 	FOREACH(JSONObject *, element, libraries_json->elements)
@@ -387,6 +360,8 @@ void add_libraries_to_project_file(const char** libs, const char* target_name) {
 	if (!file) error_exit("Failed to open file '%s'", filename);
 	print_json_to_file(project_json, file);
 	fclose(file);
+	
+	printf("Project file '%s' updated...\n", filename);
 }
 
 void add_target_project(BuildOptions *build_options)

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -990,6 +990,51 @@ const char * vendor_fetch_single(const char* lib, const char* path, bool progres
 	return error;	
 }
 
+static const char *vendor_extract_archive(const char *archive, const char *extract_dir)
+{
+	FILE *zip = fopen(archive, "rb");
+	if (!zip)
+	{
+		return str_printf("Failed to open downloaded archive '%s': %s", archive, strerror(errno));
+	}
+
+	char *extract_dir_copy = strdup(extract_dir);
+	if (!dir_make_recursive(extract_dir_copy))
+	{
+		fclose(zip);
+		return str_printf("Failed to create extraction directory '%s'.", extract_dir);
+	}
+
+	ZipDirIterator iterator;
+	ZipFile file;
+	const char *error = zip_dir_iterator(zip, &iterator);
+	if (error)
+	{
+		fclose(zip);
+		return error;
+	}
+
+	while (iterator.current_file < iterator.files)
+	{
+		error = zip_dir_iterator_next(&iterator, &file);
+		if (error)
+		{
+			fclose(zip);
+			return error;
+		}
+		if (file.uncompressed_size == 0 || file.name[0] == '.') continue;
+		error = zip_file_write(zip, &file, extract_dir, true);
+		if (error)
+		{
+			fclose(zip);
+			return error;
+		}
+	}
+
+	fclose(zip);
+	return NULL;
+}
+
 
 void vendor_fetch(BuildOptions *options)
 {
@@ -1062,9 +1107,35 @@ void vendor_fetch(BuildOptions *options)
 	for(int i = 0; i < total_libraries; i++)
 	{
 		const char *lib = options->libraries_to_fetch[i];
+		const char *archive_path = file_append_path(options->vendor_download_path, str_printf("%s.c3l", lib));
+		if (file_is_dir(archive_path)) {
+			if (options->vendor_force) file_delete_dir(archive_path);
+			else {
+				printf("Please delete library directory '%s'...\n", archive_path);
+				continue;
+			}
+		}
 		printf("Fetching library '%s'...\n", lib);
 		(void)fflush(stdout);
 		const char *error = vendor_fetch_single(lib, options->vendor_download_path, ansi);
+
+		if (!error && options->vendor_extract)
+		{
+			const char *extract_tmp_dir = str_printf("%s.temp.c3l", archive_path);
+			error = vendor_extract_archive(archive_path, extract_tmp_dir);
+			if (!error)
+			{
+				if (!file_delete_file(archive_path))
+				{
+					error = str_printf("Failed to remove downloaded archive '%s'.", archive_path);
+				}
+				else if (rename(extract_tmp_dir, archive_path) != 0)
+				{
+					error = str_printf("Failed to finalize extracted library '%s': %s", lib, strerror(errno));
+				}
+			}
+			if (error) file_delete_dir(extract_tmp_dir);
+		}
 
 		if (!error)
 		{

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -981,7 +981,6 @@ bool use_ansi(void)
 #endif
 }
 
-
 const char * vendor_fetch_single(const char* lib, const char* path, bool progress) 
 {
 	const char *resource = str_printf("/c3lang/vendor/releases/download/latest/%s.c3l", lib);
@@ -1044,20 +1043,21 @@ void vendor_fetch(BuildOptions *options)
 				   "Please ensure libcurl is installed on your system.");
 	}
 	bool ansi = use_ansi();
-
+	
+	const char *filename;
+	JSONObject *project_json = project_json_load(&filename);	
+	
 	if (str_eq(options->path, DEFAULT_PATH))
 	{
 		// check if there is a project JSON file
 		if (file_exists(PROJECT_JSON5) || file_exists(PROJECT_JSON))
 		{
-			const char** deps_dirs =  get_project_dependency_directories();
+			const char** deps_dirs =  get_project_dependency_directories(project_json, filename);
 			int num_lib = (int)vec_size(deps_dirs);
 			if (num_lib > 0) options->vendor_download_path = deps_dirs[0];
 		}
 	}
-
-	unsigned count = 0;
-	const char** fetched_libraries = NULL;
+	
 	int total_libraries = (int)vec_size(options->libraries_to_fetch);
 	
 	if (total_libraries == 0)
@@ -1103,17 +1103,38 @@ void vendor_fetch(BuildOptions *options)
 		file_delete_dir(tmp_dir);
 		return;
 	}
+	
+	unsigned count = 0;
+	const char** fetched_libraries = NULL;
+	const char** failed_libraries = NULL;
 
+	//  c3c project fetch cmd only pull missing dependencies
+	const bool is_project_fetch_cmd = options->project_options.command == SUBCOMMAND_FETCH;
+	
 	for(int i = 0; i < total_libraries; i++)
 	{
 		const char *lib = options->libraries_to_fetch[i];
 		const char *archive_path = file_append_path(options->vendor_download_path, str_printf("%s.c3l", lib));
-		if (file_is_dir(archive_path)) {
-			if (options->vendor_force) file_delete_dir(archive_path);
-			else {
-				printf("Please delete library directory '%s'...\n", archive_path);
-				continue;
+		if (file_exists(archive_path)) {
+			if (options->vendor_force) {
+				if (file_is_dir(archive_path)) file_delete_dir(archive_path);
+				else if (!file_delete_file(archive_path))
+				{
+					error_exit("Failed to remove archive: '%s'.", archive_path);
+				}
 			}
+			else {
+				if (!is_project_fetch_cmd) {
+					printf(
+					    "Cannot install '%s': '%s' already exists.\n"
+					    "\tRemove it first or use -f/--force to overwrite it.\n",
+					    lib,
+					    archive_path
+					);
+					vec_add(failed_libraries, lib);
+				}
+				continue;
+			} 
 		}
 		printf("Fetching library '%s'...\n", lib);
 		(void)fflush(stdout);
@@ -1140,31 +1161,43 @@ void vendor_fetch(BuildOptions *options)
 		if (!error)
 		{
 			vec_add(fetched_libraries, lib);
+			
+			if (ansi) printf("\033[32mFetch complete.\033[0m\t\t\n");
+			else printf("Fetch complete.\n");
+			
 			count++;
 		}
 		else
 		{
+			vec_add(failed_libraries, lib);
 			if (ansi)
 			{
 				printf("\033[2K\033[31mFailed to fetch library '%s': %s\033[0m\n", lib, error);
 			}
 			else
 			{
-				printf("Failed: '%s'\n", error);
+				printf("Failed to fetch library '%s': %s\n",  lib, error);
 			}
 			(void)fflush(stdout);
 		}
 	}
 
 	if (ansi && total_libraries > 1) printf("\033[2K");
-
+	
 	// add fetched library to the dependency list
-	add_libraries_to_project_file(fetched_libraries, options->project_options.target_name);
+	if (!is_project_fetch_cmd && count > 0) add_libraries_to_project_file(fetched_libraries, options->project_options.target_name, project_json, filename);
 
-	if (count == 0)	error_exit("Error: Failed to download any libraries.");
-	if (count < vec_size(options->libraries_to_fetch)) error_exit("Error: Only some libraries were downloaded.");
-
-	if (ansi) printf("\033[32mFetching complete.\033[0m\t\t\n");
+	if (vec_size(failed_libraries) > 0)
+	{	
+		scratch_buffer_clear();
+		FOREACH_IDX(i, const char *, lib, failed_libraries)
+		{
+				if (i > 0) scratch_buffer_append(", ");
+				scratch_buffer_append(lib);
+		}
+		const char *error = str_printf("Failed to download libraries: %s", scratch_buffer_to_string());
+		error_exit(ansi ? "\033[2K\033[31m%s\033[0m\n" : "%s", error);
+	}
 }
 
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1049,13 +1049,20 @@ void vendor_fetch(BuildOptions *options)
 	
 	if (str_eq(options->path, DEFAULT_PATH))
 	{
-		// check if there is a project JSON file
-		if (file_exists(PROJECT_JSON5) || file_exists(PROJECT_JSON))
-		{
-			const char** deps_dirs =  get_project_dependency_directories(project_json, filename);
-			int num_lib = (int)vec_size(deps_dirs);
-			if (num_lib > 0) options->vendor_download_path = deps_dirs[0];
-		}
+		const char** deps_dirs =  get_project_dependency_directories(project_json, filename);
+		int num_lib = (int)vec_size(deps_dirs);
+		if (num_lib > 0) options->vendor_download_path = deps_dirs[0];
+	}
+	
+	JSONObject *libraries_json = json_map_get(project_json, "dependencies");
+	if (libraries_json && libraries_json->type != J_ARRAY)
+	{
+		error_exit("Project field 'dependencies' must be an array.");
+	}
+	
+	if (options->project_options.target_name)
+	{
+		(void)get_target_in_project_json(project_json, options->project_options.target_name);
 	}
 	
 	int total_libraries = (int)vec_size(options->libraries_to_fetch);

--- a/src/utils/http.c
+++ b/src/utils/http.c
@@ -216,11 +216,15 @@ static size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream)
 typedef long long curl_off_t;
 #endif
 
-static void internal_print_progress(const char *label, int percent)
+typedef struct DownloadProgressState
 {
-	static int last_percent = -1;
-	if (percent == last_percent) return;
-	last_percent = percent;
+	int last_percent;
+} DownloadProgressState;
+
+static void internal_print_progress(const char *label, int percent, DownloadProgressState *state)
+{
+	if (percent == state->last_percent) return;
+	state->last_percent = percent;
 
 	if (percent > 100) percent = 100;
 	int width = 40;
@@ -264,11 +268,12 @@ static void internal_print_progress(const char *label, int percent)
 static int curl_xfer_cb(void *clientp, curl_off_t dltotal, curl_off_t dlnow,
                          curl_off_t ultotal, curl_off_t ulnow)
 {
-	(void)ultotal; (void)ulnow; (void)clientp;
+	(void)ultotal; (void)ulnow;
+	DownloadProgressState *state = (DownloadProgressState *)clientp;
 	if (dltotal > 0)
 	{
 		int percent = (int)((dlnow * 100) / dltotal);
-		internal_print_progress("Downloading", percent);
+		internal_print_progress("Downloading", percent, state);
 	}
 	return 0;
 }
@@ -299,11 +304,13 @@ const char *download_file(const char *url, const char *resource, const char *fil
 	ptr_curl_easy_setopt(curl_handle, CURLOPT_FAILONERROR, 1L);
 	ptr_curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_data);
 	ptr_curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, file);
+	DownloadProgressState state = { .last_percent = -1 };
 
 	if (show_progress)
 	{
 		ptr_curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 0L);
 		ptr_curl_easy_setopt(curl_handle, CURLOPT_XFERINFOFUNCTION, curl_xfer_cb);
+		ptr_curl_easy_setopt(curl_handle, CURLOPT_XFERINFODATA, &state);
 	}
 	else
 	{


### PR DESCRIPTION
this adds extraction flag support for downloaded `.c3l` in `project fetch -e | vendor-fetch -e`, existing library paths are not replaced without `-f/--force` flag