### PR TITLE
Fix x64 ABI crash when returning structs with small first members

### DIFF
--- a/src/compiler/abi/c_abi_x64.c
+++ b/src/compiler/abi/c_abi_x64.c
@@ -585,7 +585,7 @@ AbiType x64_get_int_type_at_offset(Type *type, unsigned offset, Type *source_typ
 											  source_offset + type_size(type),
 											  source_offset + 8))
 			{
-				return abi_type_get(type);
+				if (type_size(source_type) - source_offset <= 8) return abi_type_get(type);
 			}
 			break;
 		case TYPE_STRUCT:

--- a/test/test_suite/abi/darwinx64_2.c3t
+++ b/test/test_suite/abi/darwinx64_2.c3t
@@ -155,15 +155,15 @@ fn V2i32 f36(V2i32 arg) { return arg; }
 
 /* #expect: test.ll
 
-define i32 @test.f12_0()
-define void @test.f12_1(i32 %0)
+define i64 @test.f12_0()
+define void @test.f12_1(i64 %0)
 define void @test.f13(ptr noalias sret(%St13_0) align 8 %0, i32 %1, i32 %2, i32 %3, i32 %4, ptr byval(%St13_1) align 8 %5, i32 %6) #0 {
 define void @test.f14(i32 %0, i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i8 signext %6) #0 {
 define void @test.f15(i32 %0, i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, ptr %6)
 define void @test.f16(float %0, float %1, float %2, float %3, float %4, float %5, float %6, float %7, float %8)
 define void @test.fl18(i32 %0, i32 %1)
 define void @test.f20(ptr byval(%St20) align 32 %0)
-define ptr @test.f21(i32 %0, ptr %1)
+define ptr @test.f21(i64 %0, ptr %1)
 define void @test.f22(i64 %0, i64 %1, i64 %2, i64 %3)
 entry:
   %x = alloca %St22s, align 16

--- a/test/test_suite/debug_symbols/defer_macro.c3t
+++ b/test/test_suite/debug_symbols/defer_macro.c3t
@@ -184,12 +184,12 @@ entry:
   store i64 %1, ptr %ptradd, align 8
     #dbg_declare(ptr %args, !49, !DIExpression(), !50)
     #dbg_declare(ptr %asdf, !51, !DIExpression(), !56)
-  %2 = call { i32, ptr } @attach.to_scope() #5, !dbg !57
-  store { i32, ptr } %2, ptr %result, align 8
-  %lo = load i32, ptr %result, align 8, !dbg !58
+  %2 = call { i64, ptr } @attach.to_scope() #5, !dbg !57
+  store { i64, ptr } %2, ptr %result, align 8
+  %lo = load i64, ptr %result, align 8, !dbg !58
   %ptradd1 = getelementptr inbounds i8, ptr %result, i64 8, !dbg !58
   %hi = load ptr, ptr %ptradd1, align 8, !dbg !58
-  %3 = call ptr @test.create_foo(i32 %lo, ptr %hi, i64 1, ptr null, i64 0), !dbg !60
+  %3 = call ptr @test.create_foo(i64 %lo, ptr %hi, i64 1, ptr null, i64 0), !dbg !60
   store ptr %3, ptr %asdf, align 8, !dbg !60
   %ptradd2 = getelementptr inbounds i8, ptr %args, i64 8, !dbg !61
   %4 = load i64, ptr %ptradd2, align 8, !dbg !61
@@ -201,12 +201,12 @@ entry:
 }
 
 
-define ptr @test.create_foo(i32 %0, ptr %1, i64 %2, ptr %3, i64 %4) #0 !dbg !66 {
+define ptr @test.create_foo(i64 %0, ptr %1, i64 %2, ptr %3, i64 %4) #0 !dbg !66 {
 entry:
   %attach = alloca %Attach_Arg, align 8
   %flags = alloca i64, align 8
   %name = alloca %"char[]", align 8
-  store i32 %0, ptr %attach, align 8
+  store i64 %0, ptr %attach, align 8
   %ptradd = getelementptr inbounds i8, ptr %attach, i64 8
   store ptr %1, ptr %ptradd, align 8
     #dbg_declare(ptr %attach, !70, !DIExpression(), !71)
@@ -562,7 +562,7 @@ expr_block.exit30:                                ; preds = %loop.exit28
   ret i32 %55, !dbg !210
 }
 
-declare { i32, ptr } @attach.to_scope() #0
+declare { i64, ptr } @attach.to_scope() #0
 
 declare extern_weak ptr @std.core.mem.calloc(i64) #0
 

--- a/test/test_suite/functions/struct_splat.c3t
+++ b/test/test_suite/functions/struct_splat.c3t
@@ -81,41 +81,41 @@ entry:
   store i32 0, ptr %literal, align 8
   %ptradd1 = getelementptr inbounds i8, ptr %literal, i64 8
   store double 0.000000e+00, ptr %ptradd1, align 8
-  %lo = load i32, ptr %literal, align 8
+  %lo = load i64, ptr %literal, align 8
   %ptradd2 = getelementptr inbounds i8, ptr %literal, i64 8
   %hi = load double, ptr %ptradd2, align 8
-  call void @test.test2(i32 0, i32 %lo, double %hi)
+  call void @test.test2(i32 0, i64 %lo, double %hi)
   store i32 0, ptr %literal3, align 8
   %ptradd4 = getelementptr inbounds i8, ptr %literal3, i64 8
   store double 0.000000e+00, ptr %ptradd4, align 8
-  %lo5 = load i32, ptr %literal3, align 8
+  %lo5 = load i64, ptr %literal3, align 8
   %ptradd6 = getelementptr inbounds i8, ptr %literal3, i64 8
   %hi7 = load double, ptr %ptradd6, align 8
-  call void @test.test2(i32 42, i32 %lo5, double %hi7)
+  call void @test.test2(i32 42, i64 %lo5, double %hi7)
   store i32 0, ptr %literal8, align 8
   %ptradd9 = getelementptr inbounds i8, ptr %literal8, i64 8
   store double 4.500000e+00, ptr %ptradd9, align 8
-  %lo10 = load i32, ptr %literal8, align 8
+  %lo10 = load i64, ptr %literal8, align 8
   %ptradd11 = getelementptr inbounds i8, ptr %literal8, i64 8
   %hi12 = load double, ptr %ptradd11, align 8
-  call void @test.test2(i32 42, i32 %lo10, double %hi12)
+  call void @test.test2(i32 42, i64 %lo10, double %hi12)
   store i32 0, ptr %literal13, align 8
   %ptradd14 = getelementptr inbounds i8, ptr %literal13, i64 8
   store double 4.500000e+00, ptr %ptradd14, align 8
-  %lo15 = load i32, ptr %literal13, align 8
+  %lo15 = load i64, ptr %literal13, align 8
   %ptradd16 = getelementptr inbounds i8, ptr %literal13, i64 8
   %hi17 = load double, ptr %ptradd16, align 8
-  call void @test.test2(i32 0, i32 %lo15, double %hi17)
+  call void @test.test2(i32 0, i64 %lo15, double %hi17)
   store i32 100, ptr %z, align 8
   %ptradd18 = getelementptr inbounds i8, ptr %z, i64 8
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %ptradd18, ptr align 8 %f, i32 16, i1 false)
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %.anon19, ptr align 8 %z, i32 24, i1 false)
   %ptradd20 = getelementptr inbounds i8, ptr %.anon19, i64 8
   %2 = load i32, ptr %.anon19, align 8
-  %lo21 = load i32, ptr %ptradd20, align 8
+  %lo21 = load i64, ptr %ptradd20, align 8
   %ptradd22 = getelementptr inbounds i8, ptr %ptradd20, i64 8
   %hi23 = load double, ptr %ptradd22, align 8
-  call void @test.test2(i32 %2, i32 %lo21, double %hi23)
+  call void @test.test2(i32 %2, i64 %lo21, double %hi23)
   store i32 100, ptr %z2, align 8
   %ptradd24 = getelementptr inbounds i8, ptr %z2, i64 8
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %.anon25, ptr align 8 %f, i32 16, i1 false)

--- a/test/test_suite/stdlib/map_linux.c3t
+++ b/test/test_suite/stdlib/map_linux.c3t
@@ -140,20 +140,20 @@ entry:
   store %any %3, ptr %varargslots, align 16
   %4 = call i64 @std.io.printfn(ptr %retparam, ptr @.str, i64 12, ptr %varargslots, i64 1)
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const, i32 16, i1 false)
-  %lo2 = load i32, ptr %literal, align 8
+  %lo2 = load i64, ptr %literal, align 8
   %ptradd3 = getelementptr inbounds i8, ptr %literal, i64 8
   %hi4 = load ptr, ptr %ptradd3, align 8
-  %5 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 1, i32 %lo2, ptr %hi4)
+  %5 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 1, i64 %lo2, ptr %hi4)
   %ptradd6 = getelementptr inbounds i8, ptr %map, i64 32
   %6 = insertvalue %any undef, ptr %ptradd6, 0
   %7 = insertvalue %any %6, i64 ptrtoint (ptr @"$ct.int" to i64), 1
   store %any %7, ptr %varargslots5, align 16
   %8 = call i64 @std.io.printfn(ptr %retparam7, ptr @.str.1, i64 12, ptr %varargslots5, i64 1)
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal8, ptr align 8 @.__const.2, i32 16, i1 false)
-  %lo9 = load i32, ptr %literal8, align 8
+  %lo9 = load i64, ptr %literal8, align 8
   %ptradd10 = getelementptr inbounds i8, ptr %literal8, i64 8
   %hi11 = load ptr, ptr %ptradd10, align 8
-  %9 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 1, i32 %lo9, ptr %hi11)
+  %9 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 1, i64 %lo9, ptr %hi11)
   %ptradd13 = getelementptr inbounds i8, ptr %map, i64 32
   %10 = insertvalue %any undef, ptr %ptradd13, 0
   %11 = insertvalue %any %10, i64 ptrtoint (ptr @"$ct.int" to i64), 1
@@ -187,10 +187,10 @@ after_check19:                                    ; preds = %entry, %after_check
   store %any %25, ptr %varargslots24, align 16
   %26 = call i64 @std.io.printfn(ptr %retparam26, ptr @.str.6, i64 9, ptr %varargslots24, i64 1)
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal29, ptr align 8 @.__const.7, i32 16, i1 false)
-  %lo30 = load i32, ptr %literal29, align 8
+  %lo30 = load i64, ptr %literal29, align 8
   %ptradd31 = getelementptr inbounds i8, ptr %literal29, i64 8
   %hi32 = load ptr, ptr %ptradd31, align 8
-  %27 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 7, i32 %lo30, ptr %hi32)
+  %27 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 7, i64 %lo30, ptr %hi32)
   %28 = call ptr @llvm.threadlocal.address.p0(ptr @std.core.mem.allocators.thread_allocator)
   %lo34 = load i64, ptr %28, align 8
   %ptradd35 = getelementptr inbounds i8, ptr %28, i64 8

--- a/test/test_suite/stdlib/map_macos.c3t
+++ b/test/test_suite/stdlib/map_macos.c3t
@@ -140,20 +140,20 @@ entry:
   store %any %3, ptr %varargslots, align 16
   %4 = call i64 @std.io.printfn(ptr %retparam, ptr @.str, i64 12, ptr %varargslots, i64 1)
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const, i32 16, i1 false)
-  %lo2 = load i32, ptr %literal, align 8
+  %lo2 = load i64, ptr %literal, align 8
   %ptradd3 = getelementptr inbounds i8, ptr %literal, i64 8
   %hi4 = load ptr, ptr %ptradd3, align 8
-  %5 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 1, i32 %lo2, ptr %hi4)
+  %5 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 1, i64 %lo2, ptr %hi4)
   %ptradd6 = getelementptr inbounds i8, ptr %map, i64 32
   %6 = insertvalue %any undef, ptr %ptradd6, 0
   %7 = insertvalue %any %6, i64 ptrtoint (ptr @"$ct.int" to i64), 1
   store %any %7, ptr %varargslots5, align 16
   %8 = call i64 @std.io.printfn(ptr %retparam7, ptr @.str.1, i64 12, ptr %varargslots5, i64 1)
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal8, ptr align 8 @.__const.2, i32 16, i1 false)
-  %lo9 = load i32, ptr %literal8, align 8
+  %lo9 = load i64, ptr %literal8, align 8
   %ptradd10 = getelementptr inbounds i8, ptr %literal8, i64 8
   %hi11 = load ptr, ptr %ptradd10, align 8
-  %9 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 1, i32 %lo9, ptr %hi11)
+  %9 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 1, i64 %lo9, ptr %hi11)
   %ptradd13 = getelementptr inbounds i8, ptr %map, i64 32
   %10 = insertvalue %any undef, ptr %ptradd13, 0
   %11 = insertvalue %any %10, i64 ptrtoint (ptr @"$ct.int" to i64), 1
@@ -187,10 +187,10 @@ after_check19:                                    ; preds = %entry, %after_check
   store %any %25, ptr %varargslots24, align 16
   %26 = call i64 @std.io.printfn(ptr %retparam26, ptr @.str.6, i64 9, ptr %varargslots24, i64 1)
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal29, ptr align 8 @.__const.7, i32 16, i1 false)
-  %lo30 = load i32, ptr %literal29, align 8
+  %lo30 = load i64, ptr %literal29, align 8
   %ptradd31 = getelementptr inbounds i8, ptr %literal29, i64 8
   %hi32 = load ptr, ptr %ptradd31, align 8
-  %27 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 7, i32 %lo30, ptr %hi32)
+  %27 = call i8 @"std.collections.map.HashMap$int$test.Foo$.set"(ptr %map, i32 7, i64 %lo30, ptr %hi32)
   %28 = call ptr @llvm.threadlocal.address.p0(ptr @std.core.mem.allocators.thread_allocator)
   %lo34 = load i64, ptr %28, align 8
   %ptradd35 = getelementptr inbounds i8, ptr %28, i64 8


### PR DESCRIPTION
Forces the first 8-byte register chunk to `i64` for structs spanning >8 bytes, so pointers in the second chunk are correctly aligned at the 8-byte boundary in LLVM IR.

fixes https://github.com/c3lang/c3c/issues/3136