### PR TITLE
Better align `.clang-tidy` to the c3c codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,11 +1,17 @@
+Language: C
+
 IndentWidth: 4
-UseCRLF: false
-IndentCaseLabels: true
-UseTab: ForIndentation
 TabWidth: 4
+UseTab: ForIndentation
+IndentCaseLabels: true
+ColumnLimit: 0
 BreakBeforeBraces: Allman
 AllowShortBlocksOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortFunctionsOnASingleLine: InlineOnly
+PointerAlignment: Right
+DerivePointerAlignment: false
+UseCRLF: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeParens: ControlStatementsExceptControlMacros
@@ -13,3 +19,22 @@ SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
+SpacesInContainerLiterals: true
+SortIncludes: Never
+
+ForEachMacros:
+  - SCOPE_START
+  - SCOPE_START_WITH_FLAGS
+  - SCOPE_START_WITH_LABEL
+  - SCOPE_OUTER_START
+
+StatementMacros:
+  - ASSIGN_DECL_OR_RET
+  - ASSIGN_DECL_OR_NULL
+  - ASSIGN_DECL_OR_STOP
+
+TypenameMacros:
+  - ASSIGN_EXPR_OR_RET
+  - ASSIGN_DECL_OR_RET
+  - ASSIGN_DECL_OR_NULL
+  - ASSIGN_DECL_OR_STOP

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,44 +1,36 @@
 ---
-# Configure clang-tidy for this project.
+# clang-tidy configuration for c3c (C11 codebase)
 
-
-
-# Disabled:
-#  -google-readability-namespace-comments the *_CLIENT_NS is a macro, and
-#   clang-tidy fails to match it against the initial value.
 Checks: >
   -*,
   bugprone-*,
-  google-*,
   misc-*,
-  modernize-*,
   performance-*,
   portability-*,
   readability-*,
-  -google-readability-namespace-comments,
-  -google-runtime-int,
-  -google-runtime-references,
-  -misc-non-private-member-variables-in-classes,
-  -readability-named-parameter,
-  -readability-magic-numbers,
-  -readability-braces-around-statements,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-macro-parentheses,
+  -bugprone-multi-level-implicit-pointer-conversion,
+  -bugprone-reserved-identifier,
+  -misc-include-cleaner,
   -misc-no-recursion,
+  -misc-use-internal-linkage,
+  -portability-avoid-pragma-once,
+  -readability-braces-around-statements,
+  -readability-duplicate-include,
+  -readability-enum-initial-value,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-identifier-naming,
+  -readability-implicit-bool-conversion,
+  -readability-isolate-declaration,
+  -readability-magic-numbers,
+  -readability-math-missing-parentheses,
+  -readability-named-parameter,
+  -readability-redundant-casting,
+  -readability-redundant-declaration,
+  -readability-redundant-parentheses,
+  -readability-uppercase-literal-suffix,
 
-# Turn all the warnings from the checks above into errors.
+# Turn remaining warnings into errors.
 WarningsAsErrors: "*"
-CheckOptions:
-  - { key: readability-function-cognitive-complexity.Threshold,        value: 100 }
-  - { key: readability-identifier-naming.StructCase,                   value: CamelCase  }
-  - { key: readability-identifier-naming.FunctionCase,                 value: lower_case  }
-  - { key: readability-identifier-naming.VariableCase,                 value: lower_case }
-  - { key: readability-identifier-naming.MacroDefinitionCase,          value: UPPER_CASE }
-  - { key: readability-identifier-naming.EnumConstantCase,             value: UPPER_CASE }
-  - { key: readability-identifier-naming.ConstexprVariableCase,        value: CamelCase }
-  - { key: readability-identifier-naming.ConstexprVariablePrefix,      value: k         }
-  - { key: readability-identifier-naming.GlobalConstantCase,           value: CamelCase }
-  - { key: readability-identifier-naming.GlobalConstantPrefix,         value: k         }
-  - { key: readability-identifier-naming.StaticConstantCase,           value: CamelCase }
-  - { key: readability-identifier-naming.StaticConstantPrefix,         value: k         }
-  - { key: readability-identifier-naming.MinimumParameterNameLength,   value: 0 }
-
-MinimumParameterNameLength: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -629,6 +629,7 @@ jobs:
       contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_NAME: ""
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8

--- a/src/compiler/llvm_codegen_expr.c
+++ b/src/compiler/llvm_codegen_expr.c
@@ -3803,7 +3803,7 @@ void llvm_emit_lhs_is_subtype(GenContext *c, BEValue *result, BEValue *lhs, BEVa
 	LLVMValueRef phi = LLVMBuildPhi(c->builder, c->typeid_type, "");
 	BEValue cond;
 	llvm_emit_int_comp_raw(c, &cond, canonical_typeid, canonical_typeid, switch_val, phi, BINARYOP_EQ);
-	llvm_emit_cond_br(c, &cond, result_block, parent_type_block);
+	llvm_emit_cond_br(c, &cond, result_block, parent_type_block); // NOLINT(readability-suspicious-call-argument)
 	llvm_emit_block(c, parent_type_block);
 	LLVMValueRef introspect_ptr = LLVMBuildIntToPtr(c->builder, phi, c->ptr_type, "");
 	AlignSize alignment;
@@ -4192,7 +4192,7 @@ void llvm_emit_binary(GenContext *c, BEValue *be_value, Expr *expr, BEValue *lhs
 			{
 				Type *element_type = lhs_type->array.base->pointer;
 				unsigned len = LLVMGetVectorSize(LLVMTypeOf(lhs_value));
-				LLVMTypeRef int_vec_type = llvm_get_type(c, type_get_vector_from_vector(type_sz, lhs_type));
+				LLVMTypeRef int_vec_type = llvm_get_type(c, type_get_vector_from_vector(type_sz, lhs_type)); // NOLINT(readability-suspicious-call-argument)
 				if (lhs_type == rhs_type)
 				{
 					val = LLVMBuildSub(c->builder, LLVMBuildPtrToInt(c->builder, lhs_value, int_vec_type, ""),
@@ -6462,13 +6462,13 @@ static inline void llvm_emit_vector_initializer_list(GenContext *c, BEValue *val
 			{
 				case DESIGNATOR_ARRAY:
 				{
-					vec_value = llvm_update_vector(c, vec_value, value_ref, element->index);
+					vec_value = llvm_update_vector(c, vec_value, value_ref, element->index); // NOLINT(readability-suspicious-call-argument)
 					break;
 				}
 				case DESIGNATOR_RANGE:
 					for (ArrayIndex idx = element->index; idx <= element->index_end; idx++)
 					{
-						vec_value = llvm_update_vector(c, vec_value, value_ref, idx);
+						vec_value = llvm_update_vector(c, vec_value, value_ref, idx); // NOLINT(readability-suspicious-call-argument)
 					}
 					break;
 				case DESIGNATOR_FIELD:

--- a/src/compiler/llvm_codegen_storeload.c
+++ b/src/compiler/llvm_codegen_storeload.c
@@ -20,7 +20,7 @@ LLVMValueRef llvm_store_to_ptr_raw_aligned(GenContext *c, LLVMValueRef pointer, 
 		if (!is_power_of_two(len))
 		{
 			ByteSize size = llvm_store_size(c, type);
-			if (size < aligned_offset(alignment, size))
+			if (size < aligned_offset(size, alignment))
 			{
 				unsigned npot = next_highest_power_of_2(len);
 				static LLVMValueRef vec[MAX_VECTOR_WIDTH];

--- a/src/compiler/sema_casts.c
+++ b/src/compiler/sema_casts.c
@@ -760,14 +760,14 @@ static bool report_cast_error(CastContext *cc, bool may_cast_explicit)
 		{
 			RETURN_CAST_ERROR(expr,
 					   "Implicitly casting %s to %s is not permitted. It's possible to do an explicit cast by placing '(%s)' before the expression. However, explicit casts between distinct types are usually not intended and are not safe.",
-					   type_quoted_error_string_maybe_with_path(from, typeto),
+					   type_quoted_error_string_maybe_with_path(from, typeto), // NOLINT(readability-suspicious-call-argument)
 					   type_quoted_error_string_maybe_with_path(to, from),
 					   type_error_string_maybe_with_path(typeto, from));
 
 		}
 		RETURN_CAST_ERROR(expr,
 		           "Implicitly casting %s to %s is not permitted, but you may do an explicit cast by placing '(%s)' before the expression.",
-		           type_quoted_error_string_maybe_with_path(from, typeto),
+		           type_quoted_error_string_maybe_with_path(from, typeto), // NOLINT(readability-suspicious-call-argument)
 				   type_quoted_error_string_maybe_with_path(to, from),
 				   type_error_string_maybe_with_path(typeto, from));
 	}
@@ -1179,7 +1179,7 @@ static bool rule_slice_to_vecarr(CastContext *cc, bool is_explicit, bool is_sile
 	{
 		if (expr_is_const_string(expr) || expr_is_const_bytes(expr))
 		{
-			if (cc->to->array.len > size) size = cc->to->array.len;
+			if ((ArrayIndex)cc->to->array.len > size) size = (ArrayIndex)cc->to->array.len;
 		}
 		cast_context_set_from(cc, type_get_array(base, size));
 	}

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -1076,7 +1076,9 @@ static inline bool sema_expr_analyse_ternary(SemaContext *context, Type *infer_t
 		if (!is_const || is_left)
 		{
 			SCOPE_START(left->loc);
+			{
 				success = sema_analyse_maybe_dead_expr(context, left, !is_left, infer_type);
+			}
 			SCOPE_END;
 			if (!success) return expr_poison(expr);
 		}
@@ -1125,7 +1127,9 @@ static inline bool sema_expr_analyse_ternary(SemaContext *context, Type *infer_t
 	if (!is_const || is_right)
 	{
 		SCOPE_START(right->loc);
+		{
 		success = sema_analyse_maybe_dead_expr(context, right, !is_right, infer_type);
+		}
 		SCOPE_END;
 		if (!success) return expr_poison(expr);
 	}
@@ -1767,9 +1771,11 @@ INLINE bool sema_set_default_argument(SemaContext *context, CalledDecl *callee, 
 		}
 		bool success;
 		SCOPE_START(arg->loc)
+		{
 			new_context->original_module = context->original_module;
 			success = sema_analyse_parameter(new_context, arg, param, callee->definition, optional, no_match_ref,
 											 callee->macro, false);
+		}
 		SCOPE_END;
 		context_switch_stat_pop(new_context, switch_state);
 		sema_context_destroy(&default_context);
@@ -3454,6 +3460,7 @@ static bool sema_call_analyse_body_expansion(SemaContext *macro_context, Expr *c
 	call->body_expansion_expr.declarations = macro_context->yield_params;
 	AstId last_defer = context->active_scope.defer_last;
 	SCOPE_START(call->loc);
+	{
 		unsigned ct_context = sema_context_push_ct_stack(context);
 		if (macro_defer)
 		{
@@ -3492,6 +3499,7 @@ static bool sema_call_analyse_body_expansion(SemaContext *macro_context, Expr *c
 			context->active_scope.defer_last = last_defer;
 		}
 		sema_context_pop_ct_stack(context, ct_context);
+	}
 	SCOPE_END;
 
 	return true;
@@ -8723,7 +8731,9 @@ static inline bool sema_rewrite_expr_as_macro_block(SemaContext *context, Expr *
 	Ast *compound_stmt = ast_new(AST_COMPOUND_STMT, expr->loc);
 	compound_stmt->compound_stmt.first_stmt = start;
 	SCOPE_START_WITH_FLAGS(SCOPE_MACRO, compound_stmt->loc)
+	{
 		success = sema_analyse_stmt_chain(context, compound_stmt);
+	}
 	SCOPE_END;
 	context->expected_block_type = old_expected_block;
 	context->block_exit_ref = old_exit_ref;

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -2837,7 +2837,7 @@ static inline Type *context_unify_returns(SemaContext *context)
 		if (common_type == rtype || (type_is_void(common_type) && rtype == type_wildcard)) continue;
 
 		// 4. Find the max of the old and new.
-		Type *max = type_find_max_type(common_type, rtype, NULL, NULL);
+		Type *max = type_find_max_type(common_type, rtype, NULL, NULL); // NOLINT(readability-suspicious-call-argument)
 
 		// 5. No match -> error.
 		if (!max)
@@ -7805,7 +7805,7 @@ static bool sema_binary_arithmetic_promotion(SemaContext *context, Expr *left, E
 		if (type_is_pointer_like(right_type))
 		{
 			*operator_overload_ref = OVERLOAD_NONE; // NOLINT
-			return sema_expr_analyse_ptr_add(context, parent, right, left, right_type, left_type, cast_to_iptr, failed_ref);
+			return sema_expr_analyse_ptr_add(context, parent, right, left, right_type, left_type, cast_to_iptr, failed_ref); // NOLINT(readability-suspicious-call-argument)
 		}
 	}
 
@@ -9695,10 +9695,12 @@ static inline bool sema_expr_analyse_incdec(SemaContext *context, Expr *expr)
 	Type *type = type_flatten(inner->type);
 
 	if (type->type_kind)
-	// 5. We can only inc/dec numbers or pointers.
-	if (type->type_kind != TYPE_ENUM && !type_underlying_may_add_sub(type) && !type_kind_is_real_vector(type->type_kind))
 	{
-		RETURN_SEMA_ERROR(inner, "The expression must be a vector, enum, number or a pointer.");
+		// 5. We can only inc/dec numbers or pointers.
+		if (type->type_kind != TYPE_ENUM && !type_underlying_may_add_sub(type) && !type_kind_is_real_vector(type->type_kind))
+		{
+			RETURN_SEMA_ERROR(inner, "The expression must be a vector, enum, number or a pointer.");
+		}
 	}
 
 	if (inner->expr_kind == EXPR_SUBSCRIPT_ASSIGN)

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -5,7 +5,7 @@
 #include "sema_internal.h"
 #include <math.h>
 
-#include "compiler_tests/benchmark.h"
+
 
 #define RETURN_SEMA_FUNC_ERROR(_decl, _node, ...) do { sema_error_at(context, (_node)->loc, __VA_ARGS__); SEMA_NOTE(_decl, "The definition was here."); return false; } while (0)
 #define RETURN_NOTE_FUNC_DEFINITION do { SEMA_NOTE(callee->definition, "The definition was here."); return false; } while (0)
@@ -2213,7 +2213,7 @@ SPLAT_NORMAL:;
 				return false;
 			}
 			if (last_index == -1) last_index = i - 1;
-			for (int j = last_index + 1; j < index; j++)
+			for (int j = (int)last_index + 1; j < index; j++)
 			{
 				if (j == vaarg_index) continue;
 				if (!sema_set_default_argument(context, callee, call,
@@ -2408,7 +2408,7 @@ SPLAT_NORMAL:;
 									   callee->name, needed);
 			}
 			if (!last) last = args[0];
-			int more_needed = (ArrayIndex)func_param_count - i;
+			int more_needed = (int)((ArrayIndex)func_param_count - i);
 			if (missing != more_needed)
 			{
 				RETURN_SEMA_FUNC_ERROR(callee->definition, last,
@@ -7085,7 +7085,7 @@ SLICE_COPY:;
 	}
 	else
 	{
-		right_len = sema_len_from_const(right);
+		right_len = (IndexDiff)sema_len_from_const(right);
 	}
 	if (left_len >= 0 && right_len >= 0 && left_len != right_len)
 	{
@@ -8776,7 +8776,7 @@ static bool sema_rewrite_slice_comparison(SemaContext *context, Expr *expr, Expr
 		Ast *ast_if = ast_new(AST_IF_STMT, default_loc);
 		Expr *expr_comparison = expr_new_binary(default_loc, expr_variable(len_var_left), len_right, BINARYOP_NE);
 		Ast *ast_then = ast_new(AST_RETURN_STMT, default_loc);
-		ast_then->return_stmt.expr = expr_new_const_bool(default_loc, type_bool, false);
+		ast_then->return_stmt.expr = expr_new_const_bool((int)default_loc, type_bool, false);
 		ast_if->if_stmt = (AstIfStmt) {
 			.cond = exprid(expr_new_cond(expr_comparison)),
 			.then_body = astid(ast_then),
@@ -8813,7 +8813,7 @@ static bool sema_rewrite_slice_comparison(SemaContext *context, Expr *expr, Expr
 
 	Expr *expr_comparison = expr_new_binary(default_loc, left_check, right_check, BINARYOP_NE);
 	Ast *ast_then = ast_new(AST_RETURN_STMT, default_loc);
-	ast_then->return_stmt.expr = expr_new_const_bool(default_loc, type_bool, false);
+	ast_then->return_stmt.expr = expr_new_const_bool((int)default_loc, type_bool, false);
 	Ast *ast_if = ast_new(AST_IF_STMT, default_loc);
 	ast_if->if_stmt = (AstIfStmt) {
 		.cond = exprid(expr_new_cond(expr_comparison)),
@@ -8824,7 +8824,7 @@ static bool sema_rewrite_slice_comparison(SemaContext *context, Expr *expr, Expr
 	current->next = astid(ast);
 	current = ast;
 	Ast *ast_after = ast_new(AST_RETURN_STMT, default_loc);
-	ast_after->return_stmt.expr = expr_new_const_bool(default_loc, type_bool, true);
+	ast_after->return_stmt.expr = expr_new_const_bool((int)default_loc, type_bool, true);
 	current->next = astid(ast_after);
 
 	return sema_rewrite_expr_as_macro_block(context, expr, dummy.next);
@@ -9499,11 +9499,11 @@ INLINE void sema_expr_inc_dec_const_enum(bool dec, Expr *value)
 			int next_val;
 			if (dec)
 			{
-				next_val = (i + count - 1) % count;
+				next_val = (int)((i + count - 1) % count);
 			}
 			else
 			{
-				next_val = (i + 1) % count;
+				next_val = (int)((i + 1) % count);
 			}
 			value->const_expr.enum_val = values[next_val];
 			return;

--- a/src/compiler/sema_internal.h
+++ b/src/compiler/sema_internal.h
@@ -252,11 +252,11 @@ static inline IndexDiff range_const_len(Range *range)
 		case RANGE_SINGLE_ELEMENT:
 			UNREACHABLE;
 		case RANGE_CONST_LEN:
-			return range->const_end;
+			return (IndexDiff)range->const_end;
 		case RANGE_CONST_END:
 			return -1;
 		case RANGE_CONST_RANGE:
-			return range->len_index;
+			return (IndexDiff)range->len_index;
 		case RANGE_DYNAMIC:
 			break;
 	}

--- a/src/compiler/sema_stmts.c
+++ b/src/compiler/sema_stmts.c
@@ -251,8 +251,10 @@ static inline bool sema_analyse_compound_stmt(SemaContext *context, Ast *stateme
 	bool success;
 	EndJump ends_with_jump;
 	SCOPE_START(statement->loc)
+	{
 		success = sema_analyse_compound_statement_no_scope(context, statement);
 		ends_with_jump = context->active_scope.end_jump;
+	}
 	SCOPE_END;
 	// If this ends with a jump, then we know we don't need to certain analysis.
 	context->active_scope.end_jump = ends_with_jump;
@@ -537,6 +539,7 @@ static bool sema_analyse_macro_constant_ensures(SemaContext *context, Expr *ret_
 	context->return_expr = ret_expr;
 	bool success = true;
 	SCOPE_START_WITH_FLAGS(SCOPE_ENSURE_MACRO, ret_expr->loc);
+	{
 		FOREACH(Expr *, directive, ensures)
 		{
 			Expr *checks = copy_expr_single(directive->contract_expr.decl_exprs);
@@ -567,6 +570,7 @@ static bool sema_analyse_macro_constant_ensures(SemaContext *context, Expr *ret_
 			}
 		}
 END:
+	}
 	SCOPE_END;
 	context->return_expr = return_expr_old;
 	return success;
@@ -761,7 +765,9 @@ static inline bool sema_analyse_return_stmt(SemaContext *context, Ast *statement
 		{
 			bool success;
 			SCOPE_START_WITH_FLAGS(SCOPE_ENSURE, statement->loc);
+			{
 				success = assert_create_from_contract(context, ensure, &append_id, statement->loc);
+			}
 			SCOPE_END;
 			if (!success) return false;
 		}
@@ -1317,6 +1323,7 @@ bool sema_analyse_defer_stmt_body(SemaContext *context, Ast *statement)
 	body->compound_stmt.parent_defer = astid(statement);
 	bool success = true;
 	SCOPE_START(statement->loc)
+	{
 
 	context->active_scope.defer_last = 0;
 	context->active_scope.defer_start = 0;
@@ -1335,6 +1342,7 @@ bool sema_analyse_defer_stmt_body(SemaContext *context, Ast *statement)
 
 	// We should never need to replace any defers here.
 
+	}
 	SCOPE_END;
 
 	return success;
@@ -1404,6 +1412,7 @@ static inline bool sema_analyse_for_stmt(SemaContext *context, Ast *statement)
 	}
 	// Enter for scope
 	SCOPE_OUTER_START(statement->loc)
+	{
 
 		if (statement->for_stmt.init)
 		{
@@ -1412,6 +1421,7 @@ static inline bool sema_analyse_for_stmt(SemaContext *context, Ast *statement)
 
 		// Conditional scope start
 		SCOPE_START_WITH_LABEL(statement->for_stmt.flow.label, statement->loc)
+		{
 
 			if (!do_loop)
 			{
@@ -1424,23 +1434,26 @@ static inline bool sema_analyse_for_stmt(SemaContext *context, Ast *statement)
 
 
 			PUSH_BREAKCONT(statement);
-				success = sema_analyse_statement(context, body);
-				statement->for_stmt.flow.no_exit = context->active_scope.end_jump.active;
+			success = sema_analyse_statement(context, body);
+			statement->for_stmt.flow.no_exit = context->active_scope.end_jump.active;
 			POP_BREAKCONT();
 
 			// End for body scope
 			context_pop_defers_and_replace_ast(context, body);
 
+		}
 		SCOPE_END;
 
 		if (statement->for_stmt.flow.skip_first)
 		{
 			SCOPE_START(statement->loc)
+			{
 				if (!sema_analyse_for_cond(context, &statement->for_stmt.cond, &is_infinite) || !success)
 				{
 					SCOPE_ERROR_END_OUTER();
 					return false;
 				}
+			}
 			SCOPE_END;
 			// Rewrite do { } while(true) to while(true) { }
 			if (is_infinite)
@@ -1454,8 +1467,10 @@ static inline bool sema_analyse_for_stmt(SemaContext *context, Ast *statement)
 		{
 			// Incr scope start
 			SCOPE_START(statement->loc)
+			{
 				success = sema_analyse_expr_rvalue(context, exprptr(statement->for_stmt.incr));
 				// Incr scope end
+			}
 			SCOPE_END;
 		}
 
@@ -1463,6 +1478,7 @@ static inline bool sema_analyse_for_stmt(SemaContext *context, Ast *statement)
 		// End for body scope
 		context_pop_defers_and_replace_ast(context, statement);
 
+	}
 	SCOPE_OUTER_END;
 
 	if (is_infinite && !statement->for_stmt.flow.has_break)
@@ -1507,6 +1523,7 @@ static inline bool sema_analyse_foreach_stmt(SemaContext *context, Ast *statemen
 	}
 	// Conditional scope start
 	SCOPE_START(statement->loc)
+	{
 
 		// In the case of foreach (int x : { 1, 2, 3 }) we will infer the int[] type, so pick out the number of elements.
 		Type *inferred_type = variable_type_info ? type_get_inferred_array(type_no_optional(variable_type_info->type)) : NULL;
@@ -1520,6 +1537,7 @@ static inline bool sema_analyse_foreach_stmt(SemaContext *context, Ast *statemen
 			if (!sema_analyse_expr_rvalue(context, enumerator)) return SCOPE_POP_ERROR();
 		}
 		// And pop the cond scope.
+	}
 	SCOPE_END;
 
 	// Trying to iterate over an optional is meaningless, it should always be handled
@@ -1965,6 +1983,7 @@ static inline bool sema_analyse_if_stmt(SemaContext *context, Ast *statement)
 	bool is_invalid = false;
 	bool reverse = false;
 	SCOPE_OUTER_START(statement->loc)
+	{
 
 		success = sema_analyse_cond(context, cond, COND_TYPE_UNWRAP_BOOL, &result);
 		if (success && cond->expr_kind == EXPR_COND)
@@ -2001,9 +2020,11 @@ static inline bool sema_analyse_if_stmt(SemaContext *context, Ast *statement)
 			goto END;
 		}
 		SCOPE_START_WITH_LABEL(statement->if_stmt.flow.label, then->loc);
+		{
 			if (result == COND_FALSE) context->active_scope.is_dead = true;
 			success = success && sema_analyse_statement(context, then);
 			then_jump = context->active_scope.end_jump.active && !(statement->if_stmt.flow.label && statement->if_stmt.flow.has_break);
+		}
 		SCOPE_END;
 
 		if (!success) goto END;
@@ -2013,11 +2034,13 @@ static inline bool sema_analyse_if_stmt(SemaContext *context, Ast *statement)
 			bool store_break = statement->if_stmt.flow.has_break;
 			statement->if_stmt.flow.has_break = false;
 			SCOPE_START_WITH_LABEL(statement->if_stmt.flow.label, statement->loc);
+			{
 				if (result == COND_TRUE) context->active_scope.is_dead = true;
 				sema_remove_unwraps_from_try(context, cond);
 				sema_unwrappable_from_catch_in_else(context, cond);
 				success = sema_analyse_statement(context, else_body);
 				else_jump = context->active_scope.end_jump.active && !(statement->if_stmt.flow.label && statement->if_stmt.flow.has_break);
+			}
 			SCOPE_END;
 			statement->if_stmt.flow.has_break |= store_break;
 		}
@@ -2026,6 +2049,7 @@ END:
 		context_pop_defers_and_replace_ast(context, statement);
 
 		is_invalid = context->active_scope.is_poisoned;
+	}
 	SCOPE_OUTER_END;
 	if (is_invalid) context->active_scope.is_poisoned = true;
 	if (!success)
@@ -2605,6 +2629,7 @@ static bool sema_analyse_switch_body(SemaContext *context, Ast *statement, Sourc
 	{
 		Ast *stmt = cases[i];
 		SCOPE_START(statement->loc)
+		{
 			PUSH_BREAK(statement);
 			Ast *next = (i < case_count - 1) ? cases[i + 1] : NULL;
 			PUSH_NEXT(next, statement);
@@ -2614,6 +2639,7 @@ static bool sema_analyse_switch_body(SemaContext *context, Ast *statement, Sourc
 			POP_NEXT();
 			if (!body && i < case_count - 1) continue;
 			all_jump_end &= context->active_scope.end_jump.active;
+		}
 		SCOPE_END;
 	}
 	if (is_enum_switch && !exhaustive && success && !if_chain)
@@ -2960,6 +2986,7 @@ static inline bool sema_analyse_switch_stmt(SemaContext *context, Ast *statement
 	statement->switch_stmt.scope_defer = context->active_scope.in_defer;
 
 	SCOPE_START_WITH_LABEL(statement->switch_stmt.flow.label, statement->loc);
+	{
 
 		Expr *cond = exprptrzero(statement->switch_stmt.cond);
 		Type *switch_type;
@@ -2984,6 +3011,7 @@ static inline bool sema_analyse_switch_stmt(SemaContext *context, Ast *statement
 			return SCOPE_POP_ERROR();
 		}
 		context_pop_defers_and_replace_ast(context, statement);
+	}
 	SCOPE_END;
 
 	if (statement->flow.no_exit && !statement->flow.has_break)
@@ -3385,6 +3413,7 @@ bool sema_analyse_function_body(SemaContext *context, Decl *func)
 	Ast *body = astptr(func->func_decl.body);
 	Decl **lambda_params = NULL;
 	SCOPE_START(func->loc)
+	{
 		ASSERT(context->active_scope.depth == 1);
 		FOREACH(Decl *, param, signature->params)
 		{
@@ -3442,6 +3471,7 @@ NEXT:
 			}
 		}
 
+	}
 	SCOPE_END;
 	if (lambda_params)
 	{

--- a/src/compiler/sema_stmts.c
+++ b/src/compiler/sema_stmts.c
@@ -569,7 +569,7 @@ static bool sema_analyse_macro_constant_ensures(SemaContext *context, Expr *ret_
 				goto END;
 			}
 		}
-END:
+END:;
 	}
 	SCOPE_END;
 	context->return_expr = return_expr_old;

--- a/src/utils/malloc.c
+++ b/src/utils/malloc.c
@@ -95,7 +95,7 @@ void *cmalloc(size_t size)
 
 void *ccalloc(size_t size, size_t elements)
 {
-	void *ptr = calloc(size, elements);
+	void *ptr = calloc(size, elements); // NOLINT(readability-suspicious-call-argument)
 	if (!ptr) error_exit("Failed to calloc %zu bytes.", size * elements);
 	return ptr;
 }

--- a/src/utils/msi.c
+++ b/src/utils/msi.c
@@ -436,7 +436,7 @@ static bool cab_extract_buffer(uint8_t *data, size_t size, const char *out_root,
 					char *norm_path = str_dup(real_path);
 					for (char *p = norm_path; *p; p++)
 						if (*p == '\\') *p = '/';
-					char *full_dst = (char *)file_append_path(out_root, norm_path);
+					char *full_dst = (char *)file_append_path(out_root, norm_path); // NOLINT(readability-suspicious-call-argument)
 					file_create_folders(full_dst);
 					if (files[j].uoffset + files[j].usize <= total_usize)
 					{


### PR DESCRIPTION
Changes the `.clang-tidy` and `.clang-format` to better align to the c3c codebase and by default catch more with less static analysis.

- I caught at least [one bug](https://github.com/c3lang/c3c/pull/3135)
- Added some `// NOLINT` but very specific ones to not clog the other analysis.
- Also enforced scope braces on some macros for better static analysis and overall format niceness. It reads better but the static analysis is a plus.

Nothing mayor, just tidying up stuff for better static analysis in general and less noise (better defaults).