### PR TITLE
build: remove git binary dependency for hash extraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,14 +512,14 @@ add_executable(c3c
         ${CMAKE_BINARY_DIR}/git_hash.h
 )
 
-if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
     # We are inside of a git repository so rebuilding the hash every time something changes.
     add_custom_command(
             OUTPUT ${CMAKE_BINARY_DIR}/git_hash.h
             COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_LIST_DIR}/git_hash.cmake"
-            DEPENDS "${CMAKE_CURRENT_LIST_DIR}/.git")
+            DEPENDS "${CMAKE_CURRENT_LIST_DIR}/.git/HEAD")
 else()
-    # We are NOT inside of a git repository. Building the has only once.
+    # We are NOT inside of a git repository. Building the hash only once.
     add_custom_command(
             OUTPUT ${CMAKE_BINARY_DIR}/git_hash.h
             COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_LIST_DIR}/git_hash.cmake")

--- a/git_hash.cmake
+++ b/git_hash.cmake
@@ -1,15 +1,40 @@
-find_package(Git QUIET)
-
 set(GIT_HASH "unknown")
 
-if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git")
-    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-                    OUTPUT_VARIABLE GIT_HASH
-                    OUTPUT_STRIP_TRAILING_WHITESPACE
-                    COMMAND_ERROR_IS_FATAL ANY)
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git/HEAD")
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/.git/HEAD" HASH)
+    string(STRIP "${HASH}" HASH)
+
+    if(HASH MATCHES "^ref: (.*)")
+        set(HEAD "${CMAKE_MATCH_1}")
+        if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git/${HEAD}")
+            file(READ "${CMAKE_CURRENT_LIST_DIR}/.git/${HEAD}" HASH)
+            string(STRIP "${HASH}" HASH)
+        else()
+            set(HASH "")
+            if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/.git/packed-refs")
+                file(READ "${CMAKE_CURRENT_LIST_DIR}/.git/packed-refs" PACKED_REFS)
+                if("\n${PACKED_REFS}" MATCHES "\n([0-9a-f]+) ${HEAD}(\n|$)")
+                    set(HASH "${CMAKE_MATCH_1}")
+                endif()
+            endif()
+        endif()
+    endif()
+
+    if(NOT "${HASH}" STREQUAL "")
+        set(GIT_HASH "${HASH}")
+    endif()
 endif()
 
 message("Git Hash: ${GIT_HASH}")
 
-file(WRITE ${CMAKE_BINARY_DIR}/git_hash.h "#pragma once\n#define GIT_HASH \"${GIT_HASH}\"\n")
+set(NEW_CONTENTS "#pragma once\n#define GIT_HASH \"${GIT_HASH}\"\n")
+set(OUTPUT_FILE "${CMAKE_BINARY_DIR}/git_hash.h")
+
+if(EXISTS "${OUTPUT_FILE}")
+    file(READ "${OUTPUT_FILE}" OLD_CONTENTS)
+    if(NOT "${NEW_CONTENTS}" STREQUAL "${OLD_CONTENTS}")
+        file(WRITE "${OUTPUT_FILE}" "${NEW_CONTENTS}")
+    endif()
+else()
+    file(WRITE "${OUTPUT_FILE}" "${NEW_CONTENTS}")
+endif()


### PR DESCRIPTION
Parse `.git/HEAD` and `packed-refs` directly via cmake instead of invoking `git rev-parse`. This drops `git` as a strict build dependency.

I was doing a bash script but that defeated the purpose of removing a dependency. This is better (got the idea from mold: https://github.com/rui314/mold/blob/main/lib/update-git-hash.cmake)