### PR TITLE
Limits the size of the sortedmap skip list per-node forward slice to the actual level of the node

### DIFF
--- a/lib/std/collections/sortedmap.c3
+++ b/lib/std/collections/sortedmap.c3
@@ -34,7 +34,7 @@ struct SkipNode
 	Key key;
 	Value value;
 	int level;
-	SkipNode*[MAX_LEVEL] forward;
+	SkipNode*[] forward;
 }
 
 // CmpFn is a comparator: returns true if a should come before b in the list.
@@ -77,13 +77,6 @@ struct SortedMapRangeIterator
 	sz count;
 }
 
-fn int sortedmap_random_level(SimpleRandom* rng) @private
-{
-	int level = 1;
-	while (level < MAX_LEVEL && (rng.next_int() & 1) == 0) level++;
-	return level;
-}
-
 // Returns true if 'a' should come before 'b' in the list.
 macro bool sortedmap_cmp(custom_cmp, a, b) @private
 {
@@ -97,7 +90,9 @@ macro bool sortedmap_cmp(custom_cmp, a, b) @private
 fn SortedMap* SortedMap.init(&self, Allocator allocator)
 {
 	*self = { .allocator = allocator };
-	self.head = alloc::new(allocator, SkipNode);
+	// Single allocation for head + forward slice, calloc for zeroing of slice pointers
+	self.head = alloc::calloc(allocator, SkipNode.sizeof + MAX_LEVEL * SkipNode*.sizeof);
+	self.head.forward = ((SkipNode**)(self.head + 1))[:MAX_LEVEL];	
 	random::seed_entropy(&self.rng);
 	return self;
 }
@@ -133,6 +128,14 @@ fn SortedMap* SortedMap.tinit_with_cmp(&self, CmpFn cmp_fn)
 fn bool SortedMap.is_initialized(&self)
 {
 	return self.allocator && self.allocator.ptr != &dummy;
+}
+
+fn int SortedMap.random_level(&self) 
+{
+	int level = 1;
+	int limit_level = min(MAX_LEVEL, self.current_level + 2);
+	while (level < limit_level && (self.rng.next_int() & 1) == 0) level++;
+	return level;
 }
 
 <*
@@ -172,15 +175,16 @@ fn bool SortedMap.set(&self, Key key, Value value) @operator([]=)
 	}
 
 	// Insert new node
-	int new_level = sortedmap_random_level(&self.rng);
+	int new_level = self.random_level();
 	if (new_level > self.current_level)
 	{
 		for (int i = self.current_level; i < new_level; i++) update[i] = self.head;
 		self.current_level = new_level;
 	}
 
-	SkipNode* node = alloc::alloc(self.allocator, SkipNode);
-	*node = { .key = key, .value = value, .level = new_level };
+	// Single allocation for node + forward slice
+	SkipNode* node = alloc::malloc(self.allocator, SkipNode.sizeof + new_level * SkipNode*.sizeof);
+	*node = { .key = key, .value = value, .level = new_level, .forward = ((SkipNode**)(node + 1))[:new_level]};
 
 	for (int i = 0; i < new_level; i++)
 	{
@@ -440,7 +444,7 @@ fn void SortedMap.clear(&self)
 		alloc::free(self.allocator, node);
 		node = next;
 	}
-	*self.head = {};
+	self.head.forward[..self.current_level] = null;
 	self.count = 0;
 	self.current_level = 0;
 }

--- a/lib/std/collections/sortedmap.c3
+++ b/lib/std/collections/sortedmap.c3
@@ -23,6 +23,8 @@
 
 module std::collections::sortedmap <Key, Value>;
 import std::io, std::math::random;
+import std::core::mem::alloc;
+
 
 const int MAX_LEVEL = 32;
 
@@ -34,7 +36,7 @@ struct SkipNode
 	Key key;
 	Value value;
 	int level;
-	SkipNode*[] forward;
+	SkipNode*[*] forward;
 }
 
 // CmpFn is a comparator: returns true if a should come before b in the list.
@@ -91,8 +93,7 @@ fn SortedMap* SortedMap.init(&self, Allocator allocator)
 {
 	*self = { .allocator = allocator };
 	// Single allocation for head + forward slice, calloc for zeroing of slice pointers
-	self.head = alloc::calloc(allocator, SkipNode.sizeof + MAX_LEVEL * SkipNode*.sizeof);
-	self.head.forward = ((SkipNode**)(self.head + 1))[:MAX_LEVEL];	
+	self.head = alloc::new_with_padding(allocator, SkipNode, SkipNode*[MAX_LEVEL]::size)!!;
 	random::seed_entropy(&self.rng);
 	return self;
 }
@@ -132,8 +133,8 @@ fn bool SortedMap.is_initialized(&self)
 
 fn int SortedMap.random_level(&self) 
 {
-	int level = 1;
 	int limit_level = min(MAX_LEVEL, self.current_level + 2);
+	int level = 1;
 	while (level < limit_level && (self.rng.next_int() & 1) == 0) level++;
 	return level;
 }
@@ -178,13 +179,13 @@ fn bool SortedMap.set(&self, Key key, Value value) @operator([]=)
 	int new_level = self.random_level();
 	if (new_level > self.current_level)
 	{
-		for (int i = self.current_level; i < new_level; i++) update[i] = self.head;
+		update[self.current_level..new_level - 1] = self.head;
 		self.current_level = new_level;
 	}
 
 	// Single allocation for node + forward slice
-	SkipNode* node = alloc::malloc(self.allocator, SkipNode.sizeof + new_level * SkipNode*.sizeof);
-	*node = { .key = key, .value = value, .level = new_level, .forward = ((SkipNode**)(node + 1))[:new_level]};
+	SkipNode* node = alloc::alloc_with_padding(self.allocator, SkipNode, new_level * SkipNode*::size)!!;
+	*node = { .key = key, .value = value, .level = new_level };
 
 	for (int i = 0; i < new_level; i++)
 	{
@@ -404,8 +405,7 @@ fn Key? SortedMap.lower_key(&self, Key key)
 			current = current.forward[i];
 		}
 	}
-	if (current != self.head) return current.key;
-	return NOT_FOUND~;
+	return current == self.head ? NOT_FOUND~ : current.key;
 }
 
 <*
@@ -426,19 +426,18 @@ fn Key? SortedMap.higher_key(&self, Key key)
 	if (!next) return NOT_FOUND~;
 	// If next equals key, advance one more
 	if (!sortedmap_cmp(self.custom_cmp, next.key, key) && !sortedmap_cmp(self.custom_cmp, key, next.key)) next = next.forward[0];
-	if (!next) return NOT_FOUND~;
-	return next.key;
+	return next ? next.key : NOT_FOUND~;
 }
 
 fn sz SortedMap.len(&self) @inline => self.count;
 
-fn bool SortedMap.is_empty(&self) @inline => self.count == 0;
+fn bool SortedMap.is_empty(&self) @inline => !self.count;
 
 fn void SortedMap.clear(&self)
 {
 	if (!self.allocator) return;
 	SkipNode* node = self.head.forward[0];
-	while (node != null)
+	while (node)
 	{
 		SkipNode* next = node.forward[0];
 		alloc::free(self.allocator, node);


### PR DESCRIPTION
Reduces the allocated forward slice in sortedmap skip list nodes from the fixed max level (32 * 8 = 256 bytes on 64-bit platforms) to the actual rolled level. Half the nodes (asymptotically) live on the bottom level and only require a single forward item and in practical use no node hits the max level.

Also caps level growth on insertion to no more than current level + 1, which avoids (otherwise harmless) looping through empty levels caused by potential outlier rolls in small maps.