### PR TITLE
src/utils/json.c: fix linking warning in mold

### DIFF
--- a/src/utils/json.c
+++ b/src/utils/json.c
@@ -3,12 +3,12 @@
 
 #define PRINTF(file, string, ...) fprintf(file, string, ##__VA_ARGS__) /* NOLINT */
 
-JSONObject error = { .type = J_ERROR };
+JSONObject error_val = { .type = J_ERROR };
 JSONObject true_val = { .type = J_BOOL, .b = true };
 JSONObject false_val = { .type = J_BOOL, .b = false };
 JSONObject zero_val = { .type = J_NUMBER, .f = 0.0 };
 
-#define CONSUME(token_) do { if (!consume(parser, token_)) { json_error(parser, "Unexpected character encountered."); return &error; } } while(0)
+#define CONSUME(token_) do { if (!consume(parser, token_)) { json_error(parser, "Unexpected character encountered."); return &error_val; } } while(0)
 
 static inline void json_skip_whitespace(JsonParser *parser)
 {
@@ -281,7 +281,7 @@ JSONObject *json_parse_array(JsonParser *parser)
 	while (1)
 	{
 		JSONObject *parsed = json_parse(parser);
-		if (parser->error_message) return &error;
+		if (parser->error_message) return &error_val;
 		vec_add(array->elements, parsed);
 
 		if (consume(parser, T_RBRACKET)) break;
@@ -354,7 +354,7 @@ JSONObject *json_map_get(JSONObject *obj, const char *key)
 
 JSONObject *json_parse(JsonParser *parser)
 {
-	if (parser->error_message) return &error;
+	if (parser->error_message) return &error_val;
 	switch (parser->current_token_type)
 	{
 		case T_EOF:
@@ -414,7 +414,7 @@ void json_init_string(JsonParser *parser, const char *str)
 
 bool is_freable(JSONObject *obj)
 {
-	if (obj == &error) return false;
+	if (obj == &error_val) return false;
 	if (obj == &true_val) return false;
 	if (obj == &false_val) return false;
 	if (obj == &zero_val) return false;


### PR DESCRIPTION
mold is a little stricter, so this prevents:
```
[99/99] Linking CXX executable c3c
mold: warning: symbol type mismatch: error
>>> defined in CMakeFiles/c3c.dir/src/utils/json.c.o as STT_OBJECT
>>> defined in /usr/lib/libc.so.6 as STT_FUNC
```