### PR TITLE
Add Object.to_value. Fix Object.get_enum and Object.get_enum_at

### DIFF
--- a/lib/std/collections/object.c3
+++ b/lib/std/collections/object.c3
@@ -91,9 +91,10 @@ fn Object* new_int(Allocator allocator, int128 i)
 	return @alloc_obj(allocator, { .i = i, .allocator = allocator, .type = int128::typeid });
 }
 
+<* @require @kindof(e) == ENUM *>
 macro Object* new_enum(Allocator allocator, e)
 {
-	return @alloc_obj(allocator, { .i = e, .allocator = allocator, .type = @typeid(e) });
+	return @alloc_obj(allocator, { .i = (int128) e.ordinal, .allocator = allocator, .type = @typeid(e) });
 }
 
 fn Object* new_float(Allocator allocator, double f)
@@ -152,8 +153,70 @@ fn bool Object.is_bool(&self) @inline => self.type == bool::typeid;
 fn bool Object.is_string(&self) @inline => self.type == String::typeid;
 fn bool Object.is_float(&self) @inline => self.type == double::typeid;
 fn bool Object.is_int(&self) @inline => self.type == int128::typeid;
+fn bool Object.is_enum(&self) @inline => @kindof(self.type) == ENUM;
 fn bool Object.is_keyable(&self) => self.is_empty() || self.is_map();
 fn bool Object.is_indexable(&self) => self.is_empty() || self.is_array();
+
+macro Object.to_value(&self, $Type, strict = true)
+{
+	$switch:
+		$case types::is_int($Type):
+			if (!strict)
+			{
+				if (self.is_string())
+				{
+					$if $Type::kind == TypeKind.SIGNED_INT:
+						return ($Type)self.s.to_int128();
+					$else
+						return ($Type)self.s.to_uint128();
+					$endif
+				}
+				if (self.is_float())
+				{
+					return ($Type)self.f;
+				}
+			}
+			if (!self.is_int()) return TYPE_MISMATCH~;
+			return ($Type)self.i;
+		$case types::is_float($Type):
+			if (!strict)
+			{
+				if (self.is_int())
+				{
+					return ($Type)self.i;
+				}
+				if (self.is_string())
+				{
+					return ($Type)self.s.to_double();
+				}
+			}
+			if (!self.is_float()) return TYPE_MISMATCH~;
+			return ($Type)self.f;
+		$case $Type == String:
+			if (self.is_string()) return self.s;
+			if (strict) return TYPE_MISMATCH~;
+			return string::format(self.allocator, "%d", self);
+		$case $Type == bool:
+			if (self.is_bool()) return self.b;
+			return TYPE_MISMATCH~;
+		$case $Type == Object*:
+			return self;
+		$case $Type == void*:
+			return self.other;
+		$case $Type::kind == ENUM:
+			if (!strict)
+			{
+				if (self.is_int())
+				{
+					return $Type::from_ordinal(self.i);
+				}
+			}
+			if ($Type::typeid != self.type) return TYPE_MISMATCH~;
+			return $Type::from_ordinal(self.i);
+		$default:
+			$error "Unsupported object type '" +++ $Type::name +++ "'";
+	$endswitch
+}
 
 <*
  @require self.is_keyable()
@@ -212,10 +275,11 @@ macro Object* Object.object_from_value(&self, value) @private
 			return &NULL_OBJECT;
 		$case $defined(String x = value):
 			return new_string(self.allocator, value);
+		$case $Type::kind == ENUM:
+			return new_enum(self.allocator, value);
 		$default:
-			$error "Unsupported object type.";
+			$error "Unsupported object type '" +++ $Type::name +++ "'";
 	$endswitch
-
 }
 
 macro Object* Object.set(&self, String key, value)
@@ -396,22 +460,24 @@ fn String? Object.get_string_at(&self, sz index)
 
 <*
  @require self.is_keyable()
+ @require $EnumType::kind == ENUM
 *>
-macro String? Object.get_enum(&self, $EnumType, String key)
+macro Object.get_enum(&self, $EnumType, String key)
 {
-	Object value = self.get(key)!;
+	Object* value = self.get(key)!;
 	if ($EnumType::typeid != value.type) return TYPE_MISMATCH~;
-	return ($EnumType)value.i;
+	return $EnumType::from_ordinal(value.i);
 }
 
 <*
  @require self.is_indexable()
+ @require $EnumType::kind == ENUM
 *>
-macro String? Object.get_enum_at(&self, $EnumType, sz index)
+macro Object.get_enum_at(&self, $EnumType, sz index)
 {
-	Object value = self.get_at(index);
+	Object* value = self.get_at(index);
 	if ($EnumType::typeid != value.type) return TYPE_MISMATCH~;
-	return ($EnumType)value.i;
+	return $EnumType::from_ordinal(value.i);
 }
 
 <*

--- a/lib/std/collections/object.c3
+++ b/lib/std/collections/object.c3
@@ -153,7 +153,7 @@ fn bool Object.is_bool(&self) @inline => self.type == bool::typeid;
 fn bool Object.is_string(&self) @inline => self.type == String::typeid;
 fn bool Object.is_float(&self) @inline => self.type == double::typeid;
 fn bool Object.is_int(&self) @inline => self.type == int128::typeid;
-fn bool Object.is_enum(&self) @inline => @kindof(self.type) == ENUM;
+fn bool Object.is_enum(&self) @inline => self.type.kind == ENUM;
 fn bool Object.is_keyable(&self) => self.is_empty() || self.is_map();
 fn bool Object.is_indexable(&self) => self.is_empty() || self.is_array();
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -79,6 +79,7 @@
 - `std::time` name changes: `diff_hour` => `diff_hours`. `DateTime.set_date` => `DateTime.set`, `datetime::from_date_*` => `datetime::at_*`
 - `std::hash` method name convention changes: `updatec` / `update_char` => `update_byte`.
 - `std::string` name changes: `strip` => `strip_prefix`, `strip_end` => `strip_suffix`.
+- `std::collections::object` added `Object.to_value` to convert from an object to a value.
 
 ### Fixes
 - Slice comparison lowering would not work correctly in macros in some cases. #3095
@@ -99,6 +100,7 @@
 - Bugs in check for name suggestions on name mismatch.
 - Fix bug where only one ensure would not be inlined correctly. #3162
 - Incorrect error message when casting to non-existent enum.
+- Fix enum value handling in `Object` (`std::collections::object`) to conform with changes in enums.
 
 ## 0.7.11 Change list
 

--- a/test/unit/stdlib/collections/object.c3
+++ b/test/unit/stdlib/collections/object.c3
@@ -77,6 +77,7 @@ fn void test_to_value()
 	{
 		Object* enum_obj = object::new_enum(tmem, MyEnum.THIRD);
 		defer enum_obj.free();
+		assert(enum_obj.is_enum());
 
 		MyEnum o = enum_obj.to_value(MyEnum)!!;
 		assert(o == THIRD);

--- a/test/unit/stdlib/collections/object.c3
+++ b/test/unit/stdlib/collections/object.c3
@@ -41,3 +41,72 @@ fn void test_to_format_int()
 		assert(s == "-16");
 	}
 }
+
+fn void test_to_value()
+{
+	{
+		Object* int_obj = object::new_int(tmem, 99);
+		defer int_obj.free();
+
+		char c = int_obj.to_value(char)!!;
+		assert(c == 99);
+	}
+	{
+		Object* float_obj = object::new_float(tmem, 99.17);
+		defer float_obj.free();
+
+		float f = float_obj.to_value(float)!!;
+		assert(f == 99.17f);
+	}
+	{
+		Object* str_obj = object::new_string(tmem, "222");
+		defer str_obj.free();
+
+		int i = str_obj.to_value(int, strict: false)!!;
+		assert(i == 222);
+
+		if (catch e = str_obj.to_value(int)) 
+		{
+			assert(e == TYPE_MISMATCH);
+		} 
+		else 
+		{
+			assert(false, "Should be an error when strict is true.");
+		}
+	}
+	{
+		Object* enum_obj = object::new_enum(tmem, MyEnum.THIRD);
+		defer enum_obj.free();
+
+		MyEnum o = enum_obj.to_value(MyEnum)!!;
+		assert(o == THIRD);
+	}
+}
+
+enum MyEnum : (String value)
+{
+    FIRST {"first"},
+    SECOND {"second"},
+    THIRD {"third"}
+}
+import std::io;
+
+fn void test_enum()
+{
+	{
+		Object* enum_obj = object::new_enum(tmem, MyEnum.FIRST);
+		defer enum_obj.free();
+
+		assert(enum_obj.to_value(MyEnum)!! == MyEnum.FIRST);
+	}
+	{
+		Object* obj = object::new_obj(tmem);
+		defer obj.free();
+
+		obj.set("Hello", MyEnum.THIRD);
+
+		MyEnum o = obj.get_enum(MyEnum, "Hello")!!;
+
+		assert(o == THIRD);
+	}
+}


### PR DESCRIPTION
Fixed the `Object.get_enum` and `Object.get_enum_at`

Added a `Object.to_value` to retrieve a value from an object directly.

See issue #3163 