### PR TITLE
fix(compiler): handle inferred typeid in $switch cases & add regression tests coverage

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -107,6 +107,7 @@
 - Macro `$Type = ...` would not work correctly with `$defined`
 - Fix enum value handling in `Object` (`std::collections::object`) to conform with changes in enums.
 - Compiler assert in certain cases with ?? and void returns. #3168
+- Fix parsing and typeid handling for grouped and inferred type case labels in `$switch`/`$case`, including `(char*)::typeid`, `(char[*]*)::typeid` and `char[*]::typeid`.
 
 ## 0.7.11 Change list
 

--- a/src/compiler/parse_expr.c
+++ b/src/compiler/parse_expr.c
@@ -875,6 +875,10 @@ static Expr *parse_grouping_expr(ParseContext *c, Expr *left, SourceLoc *lhs_spa
 				*sourcelocptr(expr->loc) = extend_loc_with_token(&span, sourcelocptr(expr->loc));
 				return expr;
 			}
+			if (tok_is(c, TOKEN_SCOPE))
+			{
+				return parse_type_property_expr(c, expr);
+			}
 			// Create a cast expr
 			if (rules[c->tok].prefix)
 			{

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -10350,14 +10350,11 @@ static inline bool sema_expr_analyse_force_unwrap(SemaContext *context, Expr *ex
 
 static inline bool sema_expr_analyse_typeid(SemaContext *context, Expr *expr)
 {
-	if (!sema_resolve_type_info(context, expr->typeid_expr, RESOLVE_TYPE_DEFAULT)) return expr_poison(expr);
+	if (!sema_resolve_type_info(context, expr->typeid_expr, RESOLVE_TYPE_ALLOW_INFER)) return expr_poison(expr);
 	Type *type = expr->type_expr->type;
-	switch (type->type_kind)
+	if (type_is_ct_only(type) && !type_is_infer_type(type))
 	{
-		case CT_TYPES:
-			RETURN_SEMA_ERROR(expr->typeid_expr, "Cannot get typeid of %s: this type exists only at compile time. Only runtime types have a typeid.", type_quoted_error_string(type));
-		default:
-			break;
+		RETURN_SEMA_ERROR(expr->typeid_expr, "Cannot get typeid of %s: this type exists only at compile time. Only runtime types have a typeid.", type_quoted_error_string(type));
 	}
 	expr->expr_kind = EXPR_CONST;
 	expr->resolve_status = RESOLVE_DONE;

--- a/src/compiler/sema_types.c
+++ b/src/compiler/sema_types.c
@@ -11,7 +11,7 @@ static inline bool sema_resolve_type(SemaContext *context, TypeInfo *type_info, 
 static bool sema_resolve_type_identifier(SemaContext *context, TypeInfo *type_info, ResolveTypeKind resolve_type_kind);
 INLINE bool sema_resolve_typefrom(SemaContext *context, TypeInfo *type_info, ResolveTypeKind resolve_kind);
 INLINE bool sema_resolve_typeof(SemaContext *context, TypeInfo *type_info);
-static inline bool sema_check_ptr_type(SemaContext *context, TypeInfo *type_info, Type *inner);
+static inline bool sema_check_ptr_type(SemaContext *context, TypeInfo *type_info, Type *inner, ResolveTypeKind resolve_kind);
 static int compare_function(Signature *sig, FunctionPrototype *proto);
 
 static inline bool sema_resolve_ptr_type(SemaContext *context, TypeInfo *type_info, ResolveTypeKind resolve_kind)
@@ -21,7 +21,7 @@ static inline bool sema_resolve_ptr_type(SemaContext *context, TypeInfo *type_in
 	{
 		return type_info_poison(type_info);
 	}
-	if (!sema_check_ptr_type(context, type_info, type_info->pointer->type)) return type_info_poison(type_info);
+	if (!sema_check_ptr_type(context, type_info, type_info->pointer->type, resolve_kind)) return type_info_poison(type_info);
 
 	// Construct the type after resolving the underlying type.
 	type_info->type = type_get_ptr(type_info->pointer->type);
@@ -458,7 +458,7 @@ INLINE bool sema_resolve_generic_type(SemaContext *context, TypeInfo *type_info)
 	return true;
 }
 
-static inline bool sema_check_ptr_type(SemaContext *context, TypeInfo *type_info, Type *inner)
+static inline bool sema_check_ptr_type(SemaContext *context, TypeInfo *type_info, Type *inner, ResolveTypeKind resolve_kind)
 {
 	CanonicalType *type = inner->canonical;
 	switch (type->type_kind)
@@ -466,6 +466,7 @@ static inline bool sema_check_ptr_type(SemaContext *context, TypeInfo *type_info
 		case CT_TYPES:
 			if (type_is_infer_type(type))
 			{
+				if (resolve_kind & RESOLVE_TYPE_ALLOW_INFER) return true;
 				RETURN_SEMA_ERROR(type_info, "A pointer to a type of inferred length is not supported.");
 			}
 			RETURN_SEMA_ERROR(type_info, "Pointers to %s are not supported.", type_quoted_error_string(inner));
@@ -557,7 +558,7 @@ APPEND_QUALIFIERS:;
 		case TYPE_COMPRESSED_NONE:
 			break;
 		case TYPE_COMPRESSED_PTR:
-			if (!sema_check_ptr_type(context, type_info, type)) return type_info_poison(type_info);
+			if (!sema_check_ptr_type(context, type_info, type, resolve_kind)) return type_info_poison(type_info);
 			type = type_get_ptr(type);
 			break;
 		case TYPE_COMPRESSED_SUB:
@@ -568,11 +569,11 @@ APPEND_QUALIFIERS:;
 			type = type_get_ptr(type);
 			break;
 		case TYPE_COMPRESSED_PTRPTR:
-			if (!sema_check_ptr_type(context, type_info, type)) return type_info_poison(type_info);
+			if (!sema_check_ptr_type(context, type_info, type, resolve_kind)) return type_info_poison(type_info);
 			type = type_get_ptr(type_get_ptr(type));
 			break;
 		case TYPE_COMPRESSED_PTRSUB:
-			if (!sema_check_ptr_type(context, type_info, type)) return type_info_poison(type_info);
+			if (!sema_check_ptr_type(context, type_info, type, resolve_kind)) return type_info_poison(type_info);
 			type = type_get_slice(type_get_ptr(type));
 			break;
 		case TYPE_COMPRESSED_SUBSUB:
@@ -811,4 +812,3 @@ Type *sema_resolve_type_get_func(Signature *signature, CallABI abi)
 		index = (index + 1) & mask;
 	}
 }
-

--- a/src/compiler/types.c
+++ b/src/compiler/types.c
@@ -698,7 +698,19 @@ void type_mangle_introspect_name_to_buffer(Type *type)
 {
 	switch (type->type_kind)
 	{
-		case CT_TYPES:
+		case TYPE_INFERRED_ARRAY:
+			scratch_buffer_append("ia$");
+			type_mangle_introspect_name_to_buffer(type->array.base);
+			return;
+		case TYPE_INFERRED_VECTOR:
+			scratch_buffer_append("iv$");
+			type_mangle_introspect_name_to_buffer(type->array.base);
+			return;
+		case TYPE_TYPEINFO:
+		case TYPE_POISONED:
+		case TYPE_MEMBER:
+		case TYPE_WILDCARD:
+		case TYPE_REFLECTION:
 			UNREACHABLE_VOID
 		case TYPE_UNTYPEDLIST:
 			scratch_buffer_append("ul$");

--- a/test/unit/regression/subtype.c3
+++ b/test/unit/regression/subtype.c3
@@ -89,3 +89,50 @@ fn void is_subtype()
 	assert(!bar.is_subtype_of(double::typeid));
 	assert(!baz.is_subtype_of(bar));
 }
+
+alias CharPtr = char*;
+
+fn void grouped_typeid_cases()
+{
+	switch (CharPtr::typeid)
+	{
+		case String::typeid:
+			assert(false);
+		case ZString::typeid:
+			assert(false);
+		case (char*)::typeid:
+			assert(true);
+		default:
+			assert(false);
+	}
+
+	$switch (char[*]*)::typeid:
+	$case String::typeid:
+		assert(false);
+	$case ZString::typeid:
+		assert(false);
+	$case char[*]::typeid:
+		assert(false);
+	$case (char*)::typeid:
+		assert(false);
+	$case (char[*]*)::typeid:
+		assert(true);
+	$default:
+		assert(false);
+	$endswitch
+
+	$switch char[*]::typeid:
+	$case String::typeid:
+		assert(false);
+	$case ZString::typeid:
+		assert(false);
+	$case (char[*]*)::typeid:
+		assert(false);
+	$case (char*)::typeid:
+		assert(false);
+	$case char[*]::typeid:
+		assert(true);
+	$default:
+		assert(false);
+	$endswitch
+}


### PR DESCRIPTION
- Fix compiler parsing so grouped type properties are valid in case labels, e.g. (char*)::typeid.
- Allow inferred typeid forms in switch case analysis, covering (char[*]*)::typeid and char[*]::typeid.
- Add explicit regression coverage for grouped/inferred typeid case labels.