### PR TITLE
fix typo in insertionsort.c3

### DIFF
--- a/lib/std/sort/insertionsort.c3
+++ b/lib/std/sort/insertionsort.c3
@@ -1,7 +1,7 @@
 module std::sort;
 
 <*
- Sort list using the quick sort algorithm.
+ Sort list using the insertion sort algorithm.
 
  @require @list_is_by_ref(list) : "Expected a list passed by reference, or slice passed by value"
  @require @is_sortable(list) : "The list must be indexable and support .len or .len()"


### PR DESCRIPTION
the insertion sort macro says it's quick sort. the comment was probably copied originally, or something.