### PR TITLE
Migrating towards AVR as a enabled by default target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ set(C3_OPTIONS
         C3_LLD_DIR
         C3_ENABLE_CLANGD_LSP
         LLVM_CRT_LIBRARY_DIR
-        C3_AVR_ENABLE
+        C3_AVR_DISABLE
 )
 
 set(C3_USE_MIMALLOC OFF)
@@ -525,9 +525,10 @@ add_executable(c3c
         ${CMAKE_BINARY_DIR}/docs_template.h
 )
 
-# Building C3 with AVR Support
-if(C3_AVR_ENABLE)
-	target_compile_definitions(c3c PRIVATE AVR_ENABLE)
+# Building C3 with llvm toolchains that don't have AVR Support
+if(C3_AVR_DISABLE)
+    message(STATUS "AVR support is disabled")
+	target_compile_definitions(c3c PRIVATE AVR_DISABLE)
 endif()
 
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")

--- a/src/compiler/target.c
+++ b/src/compiler/target.c
@@ -1957,7 +1957,7 @@ void *llvm_target_machine_create(void)
 #ifdef XTENSA_ENABLE
 		INITIALIZE_TARGET(Xtensa);
 #endif
-#ifdef AVR_ENABLE
+#ifndef AVR_DISABLE
 		INITIALIZE_TARGET(AVR);
 #endif
 #ifndef ARM_DISABLE
@@ -2190,12 +2190,6 @@ void target_setup(BuildTarget *build_target)
 	if (build_target->arch_os_target == ELF_XTENSA)
 	{
 		error_exit("Xtensa support is not available with this LLVM version.");
-	}
-#endif
-#ifndef AVR_ENABLE 
-	if (build_target->arch_os_target == ELF_XTENSA)
-	{
-		error_exit("For AVR support please use a compiler compiled with -DAVR_ENABLE");
 	}
 #endif
 


### PR DESCRIPTION
As the title says. It inverts the current logic around the AVR_ENABLE flag to make AVR a by default supported backend for c3.

I tested it with and without the `-DC3_AVR_DISABLE=ON` flag and the output was as expected.


> For anyone that hasn't read the chat in the discord:
> But why do this? AVR microcontrollers are probably the most widespread kind of microcontrollers there are on planet earth for beginner use, most notably the Arduino family of microcontrollers. This would add official support in the downloadable binary version of the compiler for those kinds of things. Which would in turn allow new users of the language to dive into an easy path to building things on the embedded platform they are already really comfortable with.