### PR TITLE
Further adressing #3188 by improving support for enum/constdef in the docgen

### DIFF
--- a/resources/docs.html
+++ b/resources/docs.html
@@ -2165,11 +2165,63 @@
 
 		function buildMembersHtml(vd, baseDocs) {
 			const isFunction = vd.kind === 'function' || vd.kind === 'macro' || (vd.kind === 'type_alias' && vd.return_type);
-			let title = isFunction ? 'Arguments' : 'Fields';
-			if (vd.kind === 'enum' || vd.kind === 'constdef') title = 'Values';
+			const isEnum = vd.kind === 'enum' || vd.kind === 'constdef';
 
 			if (!vd.members || vd.members.length === 0) return '';
 
+			if (isEnum) {
+				const enumValues = vd.members.filter(m => m.kind === 'enum_value');
+				const schemaParams = vd.members.filter(m => m.kind !== 'enum_value');
+
+				let html = '';
+
+				if (enumValues.length > 0) {
+					html += `<h3>Values</h3>`;
+					html += `<table class="contract-table">
+						<thead><tr>
+							<th class="col-name">Name</th>
+							<th class="col-type">Value</th>
+							<th>Description</th>
+						</tr></thead><tbody>`;
+
+					enumValues.forEach(m => {
+						const desc = (m.docs && m.docs.text) ? formatDocText(m.docs.text) : '';
+						const val = m.value !== undefined && m.value !== null
+							? `<span class="c3-number">${escapeHtml(String(m.value))}</span>`
+							: '<span class="secondary-text">auto</span>';
+						html += `<tr>
+							<td class="col-name monospace bold c3-constdef">${escapeHtml(m.name)}</td>
+							<td class="col-type monospace">${val}</td>
+							<td class="doc-text">${desc}</td>
+						</tr>`;
+					});
+					html += `</tbody></table>`;
+				}
+
+				if (schemaParams.length > 0) {
+					html += `<h3>Associated Values</h3>`;
+					html += `<table class="contract-table">
+						<thead><tr>
+							<th class="col-type">Type</th>
+							<th class="col-name">Name</th>
+							<th>Description</th>
+						</tr></thead><tbody>`;
+					schemaParams.forEach(m => {
+						const docParam = (baseDocs && baseDocs.params) ? baseDocs.params.find(p => p.name === m.name) : null;
+						const desc = (docParam && docParam.description) ? docParam.description : '';
+						html += `<tr>
+							<td class="col-type monospace">${renderTypeName(m.type)}</td>
+							<td class="col-name monospace bold c3-variable">${escapeHtml(m.name)}</td>
+							<td class="doc-text">${desc}</td>
+						</tr>`;
+					});
+					html += `</tbody></table>`;
+				}
+
+				return html;
+			}
+
+			let title = isFunction ? 'Arguments' : 'Fields';
 			let html = `<h3>${title}</h3>`;
 			html += `<table class="contract-table">
 				<thead>

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -22,6 +22,7 @@ static void write_decl_uid(FILE *file, Module *module, Decl *decl);
 static void emit_type_name_to_scratch(TypeInfo *type);
 static void print_doc_type(FILE *file, Module *module, TypeInfo *type);
 static void emit_params_json(FILE *file, Module *module, Decl **params);
+static void emit_doc_comments(FILE *file, Decl *decl);
 static void write_expr_source_json(FILE *file, Expr *expr)
 {
 	if (!expr)
@@ -492,24 +493,20 @@ static void emit_doc_members(FILE *file, Module *module, Decl *decl)
 			first = false;
 			fputs("{\"name\":\"", file);
 			fputs(p->name ? p->name : "", file);
-			fputs("\"", file);
-			fputs(",\"type\":", file);
-			fputs("{\"name\":\"", file);
-			fputs(decl->name ? decl->name : "", file);
-			fputs("\"", file);
-			emit_decl_uid_json(file, decl);
-			fputs("}", file);
-			if (p->enum_constant.value)
+			fputs("\",\"kind\":\"enum_value\"", file);
+			if (decl->decl_kind == DECL_CONSTDEF && p->enum_constant.value)
 			{
 				fputs(",\"value\":", file);
 				write_const_value_json(file, p->enum_constant.value);
 			}
-			else if (decl->decl_kind == DECL_ENUM)
+			else
 			{
 				fputs(",\"value\":\"", file);
 				fprintf(file, "%u", p->enum_constant.inner_ordinal);
 				fputs("\"", file);
 			}
+			fputs(",", file);
+			emit_doc_comments(file, p);
 			fputs("}", file);
 		}
 	}


### PR DESCRIPTION
This pull request aims to further implement and hopefully completly resolve #3188.

I hope I got what was planned and if not or if there are notable things that should be improved just hit me up I'd be glad to this time fully resolving the issue :)

> Each example is one image of the rendered docs and the code snippet that made it happen.

<details>
<summary>
Example 1:
</summary>

```c3
<* An enum with explicit ordinal values. *>
enum HttpStatus : ushort
{
	OK,
	NOT_FOUND,
	SERVER_ERROR,
}
```

<img width="735" height="508" alt="Image" src="https://github.com/user-attachments/assets/77505972-12af-4f0f-b164-eb59e804c079" />

</details>

<details>
<summary>
Example 2:
</summary>

```c3
<* A plain enum with auto-assigned ordinals and per-value docs. *>
enum Color : int
{
	<* Represents the color red *>
	RED,
	<* Represents the color green *>
	GREEN,
	<* Represents the color blue *>
	BLUE,
}
```
<img width="734" height="608" alt="Image" src="https://github.com/user-attachments/assets/c4d8fde9-b129-4c5c-97c2-34a8aca0cab6" />

</details>

<details>
<summary>
Example 3:
</summary>

```c3
<* An enum with associated values for each constant. *>
enum Status : int (int code, String msg)
{
	OK { 0, "ok" },
	WARN { 1, "warn" },
	ERROR { 2, "error" },
}
```
<img width="736" height="646" alt="Image" src="https://github.com/user-attachments/assets/d0b5dab5-1fe1-4331-a019-d72a9733216a" />

</details>

<details>
<summary>
Example 4:
</summary>

```c3
<* A constdef with explicit values. *>
constdef Priority : int
{
	LOW = 1,
	MEDIUM = 5,
	HIGH = 10,
}
```
<img width="736" height="512" alt="Image" src="https://github.com/user-attachments/assets/662c66fb-cdb9-419b-8fe2-990c30c2b9e2" />

</details>
