### PR TITLE
docgen: fix generic functions propagating to modules

### DIFF
--- a/resources/docs.html
+++ b/resources/docs.html
@@ -5,6 +5,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>C3 Docgen Viewer</title>
+	<link rel="icon" href="https://c3-lang.org/assets/favicon.svg">
 	<style>
 		:root {
 			--bg: #1e2029;

--- a/resources/docs.html
+++ b/resources/docs.html
@@ -2209,7 +2209,10 @@
 				const params = renderParams(d.members);
 				const ret = d.return_type ? renderTypeName(d.return_type) : 'void';
 				const attrs = (d.attributes || []).map(a => `<span class="c3-attribute">${a}</span>`).join(' ');
-				return `<span class="c3-keyword">${keyword}</span> ${ret} <span class="c3-function">${localName}</span>(${params})${attrs ? ' ' + attrs : ''}`;
+				const genericSuffix = (d.generic_parameters && d.generic_parameters.length > 0)
+					? ` <span class="c3-type">&lt;${d.generic_parameters.join(', ')}&gt;</span>`
+					: '';
+				return `<span class="c3-keyword">${keyword}</span> ${ret} <span class="c3-function">${localName}</span>(${params})${genericSuffix}${attrs ? ' ' + attrs : ''}`;
 			}
 
 			if (d.kind === 'type_alias' && d.return_type) {

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -1062,12 +1062,22 @@ void compiler_docgen(BuildTarget *target)
 		first_module = false;
 
 		fprintf(file, "\"%s\":{", module->name->module);
-		bool is_module_generic = vec_size(module->generic_sections) > 0;
+		Decl *module_generic = NULL;
+		FOREACH(CompilationUnit *, unit, module->units)
+		{
+			if (unit->default_generic_section)
+			{
+				module_generic = unit->default_generic_section;
+				break;
+			}
+		}
+
+		bool is_module_generic = module_generic != NULL;
 		fprintf(file, "\"is_generic\":%s", is_module_generic ? "true" : "false");
 		if (is_module_generic)
 		{
 			fputs(",\"generic_parameters\":[", file);
-			GenericDecl *g = &module->generic_sections[0]->generic_decl;
+			GenericDecl *g = &module_generic->generic_decl;
 			for (unsigned j = 0; j < vec_size(g->parameters); j++)
 			{
 				if (j > 0) fputs(",", file);


### PR DESCRIPTION
Also add generic parameters to the signatures

examples:
module: `std::core::string`
function: `std::sort::_binarysearch`