### PR TITLE
CMakeLists: Find the local diaguids.lib and replace the paths in LLVM targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ env:
 jobs:
 
   build-msvc:
-    runs-on: windows-2022
+    runs-on: windows-2025
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,6 +428,39 @@ if(C3_WITH_LLVM)
 
     message(STATUS "Linking to llvm libs ${llvm_libs}")
     message(STATUS "Linking to lld libs ${lld_libs}")
+
+    if (MSVC)
+        # LLVM artifacts may contain absolute paths to diaguids.lib from a different VS version.
+        # Find the local diaguids.lib and replace the paths in LLVM targets.
+        find_library(DIA_SDK_LIB NAMES diaguids.lib
+            HINTS
+                "$ENV{VSINSTALLDIR}/DIA SDK/lib/amd64"
+                "$ENV{VCINSTALLDIR}/../DIA SDK/lib/amd64"
+        )
+        if (NOT DIA_SDK_LIB)
+            set(_vswhere "C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe")
+            if (EXISTS "${_vswhere}")
+                execute_process(
+                    COMMAND "${_vswhere}" -latest -property installationPath
+                    OUTPUT_VARIABLE _vs_install_dir
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                )
+                find_library(DIA_SDK_LIB NAMES diaguids.lib HINTS "${_vs_install_dir}/DIA SDK/lib/amd64")
+            endif()
+        endif()
+
+        if (DIA_SDK_LIB)
+            foreach(_tgt ${llvm_libs})
+                if (TARGET ${_tgt})
+                    get_target_property(_link_libs ${_tgt} INTERFACE_LINK_LIBRARIES)
+                    if (_link_libs AND _link_libs MATCHES "diaguids\\.lib")
+                        list(TRANSFORM _link_libs REPLACE ".*diaguids\\.lib$" "${DIA_SDK_LIB}")
+                        set_target_properties(${_tgt} PROPERTIES INTERFACE_LINK_LIBRARIES "${_link_libs}")
+                    endif()
+                endif()
+            endforeach()
+        endif()
+    endif()
 endif()
 
 add_library(miniz STATIC dependencies/miniz/miniz.c)


### PR DESCRIPTION
- set the MSVC CI to run on `windows-2025` again.
- fixes `ninja: error: 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/DIA SDK/lib/amd64/diaguids.lib', needed by 'c3c.exe', missing and no known rule to make it`
  - [example failed run](https://github.com/c3lang/c3c/actions/runs/25402718653/job/74506096335)