### PR TITLE
[C Backend] Add ptr access and identifier emit functions

### DIFF
--- a/src/compiler/c_codegen.c
+++ b/src/compiler/c_codegen.c
@@ -329,6 +329,9 @@ static VariableId c_emit_temp(GenContext *c, CValue *value, Type *type)
 	*value = (CValue) { .var = c_create_variable(c), .kind = CV_VALUE, .type = type_lowering(type) };
 	return c->id_gen;
 }
+
+static void c_emit_expr(GenContext *c, CValue *value, Expr *expr);
+
 static void c_emit_const_expr(GenContext *c, CValue *value, Expr *expr)
 {
 	Type *t = type_lowering(expr->type);
@@ -389,6 +392,20 @@ static void c_emit_const_expr(GenContext *c, CValue *value, Expr *expr)
 	}
 	PRINT("/* CONST EXPR */\n");
 }
+static void c_emit_ptr_access_expr(GenContext *c, CValue *value, Expr *expr)
+{
+	CValue inner_value;
+	c_emit_expr(c, &inner_value, expr->inner_expr);
+	value->var = c_create_variable(c);
+	const char *type_name = c_type_name(c, expr->type);
+	PRINTF("%s ___var_%d = *(%s*)&___var_%d;\n", type_name, value->var, type_name, inner_value.var);
+}
+static void c_emit_identifier_expr(GenContext *c, CValue *value, Expr *expr)
+{
+	Decl *decl = expr->ident_expr;
+	value->var = c_create_variable(c);
+	PRINTF("%s ___var_%d = ___var_%d;\n", c_type_name(c, decl->type), value->var, decl->backend_id);
+}
 static void c_emit_expr(GenContext *c, CValue *value, Expr *expr)
 {
 	switch (expr->expr_kind)
@@ -397,7 +414,10 @@ static void c_emit_expr(GenContext *c, CValue *value, Expr *expr)
 		case EXPR_SLICE_TO_VEC_ARRAY:
 		case EXPR_SCALAR_TO_VECTOR:
 		case EXPR_ENUM_FROM_ORD:
+			break;
 		case EXPR_PTR_ACCESS:
+			c_emit_ptr_access_expr(c, value, expr);
+			return;
 		case EXPR_INT_TO_FLOAT:
 		case EXPR_INT_TO_PTR:
 		case EXPR_PTR_TO_INT:
@@ -455,7 +475,8 @@ static void c_emit_expr(GenContext *c, CValue *value, Expr *expr)
 		case EXPR_FORCE_UNWRAP:
 			break;
 		case EXPR_IDENTIFIER:
-			break;
+			c_emit_identifier_expr(c, value, expr);
+			return;
 		case EXPR_INITIALIZER_LIST:
 			break;
 		case EXPR_LAMBDA:


### PR DESCRIPTION
This also pre-declares c_emit_expr, like in pr #3212, so after one of these goes in I will have to edit the other (they were split to make reviews smaller).

With #3209, #3211 and #3212, if we compile `resources/examples/hash.c3` with the c backend (which also requires a small change to `src/compiler/compiler.c`) then the translation of the c3 code snippit:
```
    String y = "Hello World!";
    libc::printf("Adler32 of %s is %x, expected 1c49043e\n", (char*)(y), adler32(y));
```
Goes from
```
__c3_slice1 ___var_1;
 __c3_slice1 ___var_2 = "Hello World!";
___var_1 = ___var_2;
/*EXPR*/
/* TODO EXPR */
```
to
```
 __c3_slice1 ___var_1;
 __c3_slice1 ___var_2 = { "Hello World!", 12 };
___var_1 = ___var_2;
/*EXPR*/
void* ___var_3 = "Adler32 of %s is %x, expected 1c49043e\012";
 __c3_slice1 ___var_4 = ___var_1;
void* ___var_5 = *(void**)&___var_4;
 __c3_slice1 ___var_6 = ___var_1;
uint32_t ___var_7 = adler32(___var_6);
int32_t ___var_8 = printf(___var_3, ___var_5, ___var_7);
```