### PR TITLE
Optimize test suite and runner performance

### DIFF
--- a/lib/std/core/runtime_test.c3
+++ b/lib/std/core/runtime_test.c3
@@ -320,6 +320,7 @@ $endif
 		TrackingAllocator mem;
 
 		mem.init(context.stored.allocator);
+		Clock start_time = clock::now();
 		if (libc::setjmp(&context.buf) == 0)
 		{
 			// We might arrive here from a different thread
@@ -339,10 +340,11 @@ $endif
 			if (context.check_leaks) allocators::thread_allocator = context.stored.allocator;
 
 			unmute_output(false); // all good, discard output
+			NanoDuration duration = start_time.to_now();
 			if (mem.has_leaks())
 			{
 				if (context.is_quiet_mode) io::printf("\n%s ", context.current_test_name);
-				io::print(context.has_ansi_codes ? "[\e[0;31mFAIL\e[0m]" : "[FAIL]");
+				io::printf(context.has_ansi_codes ? "[\e[0;31mFAIL\e[0m] (%s)" : "[FAIL] (%s)", duration.tunit_str(true));
 				io::printn(" LEAKS DETECTED!");
 				mem.print_report();
 			}
@@ -350,7 +352,7 @@ $endif
 			{
 				if (!context.is_quiet_mode)
 				{
-					io::printfn(context.has_ansi_codes ? "[\e[0;32mPASS\e[0m]" : "[PASS]");
+					io::printfn(context.has_ansi_codes ? "[\e[0;32mPASS\e[0m] (%s)" : "[PASS] (%s)", duration.tunit_str(true));
 				}
 				tests_passed++;
 			}

--- a/test/src/test_suite_runner.c3
+++ b/test/src/test_suite_runner.c3
@@ -529,7 +529,16 @@ fn bool test_file(Path file_path, TestOutput* output, sz index)
 	cmdline.init(tmem, 32);
 	cmdline.push(context.compiler_path);
 
-	cmdline.push_all({"compile-only", "--test","--max-mem", "512"});
+	cmdline.push_all({"compile-only",
+		"-O0",
+		"--test",
+		"--max-mem", "512",
+		"--no-obj",
+		"--threads", "1"});
+	if (settings.output_files.is_empty())
+	{
+		cmdline.push("--strip-unused=yes");
+	}
 
 	if (context.stdlib)
 	{
@@ -557,8 +566,6 @@ fn bool test_file(Path file_path, TestOutput* output, sz index)
 		cmdline.push(settings.arch);
 	}
 
-	cmdline.push("-O0");
-
 	if (settings.no_deprecation)
 	{
 		cmdline.push("--warn-deprecation=no");
@@ -570,7 +577,6 @@ fn bool test_file(Path file_path, TestOutput* output, sz index)
 	{
 		cmdline.push(opt);
 	}
-
 
 	if (global_should_quit.load()) return false;
 	Process compilation = process::spawn(cmdline.array_view(), NO_WINDOW | INHERIT_ENV)!!;

--- a/test/src/test_suite_runner.c3
+++ b/test/src/test_suite_runner.c3
@@ -425,24 +425,29 @@ fn void? collect_files(Path file_path, List{Path}* files)
 }
 
 /* ----------------------- Core test logic ------------------------------ */
+tlocal int tlocal_worker_id = -1;
+
 fn bool test_file(Path file_path, TestOutput* output, sz index)
 {
 	if (global_should_quit.load()) return false;
 	context.test_count.add(1);
 	update_status(index, file_path, output);
 
-	bool single;
-	int thread_id = context.thread_id_counter.add(1);
-
- 	Path test_dir = context.test_root.tappend(string::tformat("_c3test_%d", thread_id))!!;
-
-	(void)path::rmtree(test_dir);
-	defer @catch(path::rmtree(test_dir));
-
-	if (@catch(path::mkdir(test_dir)))
+	if (tlocal_worker_id == -1)
 	{
-		io::fprintfn((OutStream)&output.buffer, "FAILED - Failed to create temp test directory '%s'.", test_dir)!!;
-		os::exit(1);
+		tlocal_worker_id = context.thread_id_counter.add(1);
+	}
+
+	bool single;
+	Path test_dir = context.test_root.tappend(string::tformat("_c3test_%d", tlocal_worker_id))!!;
+
+	if (!path::is_dir(test_dir))
+	{
+		if (@catch(path::mkdir(test_dir)))
+		{
+			io::fprintfn((OutStream)&output.buffer, "FAILED - Failed to create temp test directory '%s'.", test_dir)!!;
+			os::exit(1);
+		}
 	}
 
 	switch (file_path.extension() ?? "")

--- a/test/unit/stdlib/crypto/argon2.c3
+++ b/test/unit/stdlib/crypto/argon2.c3
@@ -93,14 +93,14 @@ fn void encode_and_decode_leak_check()
 // See: https://github.com/P-H-C/phc-string-format/blob/e8fbd333dcc9a8b0843fac6b33371cf157e91a48/phc-sf-spec.md
 fn void phc_string_format__encode()
 {
-	const String EXPECTED =   "$argon2id$v=19$m=65536,t=2,p=1$gZiV/M1gPc22ElAH/Jh1Hw$CWOrkoo7oJBQ/iyh7uJ0LO2aLEfrHwTWllSAxT0zRno";
-	const String EXPECTED_2 = "$argon2id$v=19$m=65536,t=2,p=1,keyid=abase64value$gZiV/M1gPc22ElAH/Jh1Hw$CWOrkoo7oJBQ/iyh7uJ0LO2aLEfrHwTWllSAxT0zRno";
+	const String EXPECTED =   "$argon2id$v=19$m=256,t=2,p=1$gZiV/M1gPc22ElAH/Jh1Hw$ssLWukxto5vwyYyUiohiiW+SNsr/N/HTsp9v0rooRJ8";
+	const String EXPECTED_2 = "$argon2id$v=19$m=256,t=2,p=1,keyid=abase64value$gZiV/M1gPc22ElAH/Jh1Hw$ssLWukxto5vwyYyUiohiiW+SNsr/N/HTsp9v0rooRJ8";
 
 	Argon2Options opts = {
 		.algorithm = ARGON2_ID,
 		.key = "pepper",
 		.salt = x'8198 95fc cd60 3dcd b612 5007 fc98 751f',
-		.mem_size = 65536,
+		.mem_size = 256,
 		.lanes = 1,
 		.iterations = 2,
 	};

--- a/test/unit/stdlib/crypto/keccak/parallel_hash.c3
+++ b/test/unit/stdlib/crypto/keccak/parallel_hash.c3
@@ -38,7 +38,7 @@ fn void known_vectors_256()
 	/* tcId 171 */ test::@check(parallel_hash::thash(256, 264 / 8, input2, 7, customizer: "%1") == x'1d2a7c1b811ff3f61f7686c3ca30223c2d8fc21423b32918953925c2462e47be54');
 }
 
-fn void variably_streamed() @if ($feature(SLOW_TESTS))
+fn void variably_streamed()
 {
 	Lcg64Random rand;
 	random::seed(&rand, 0x1337_83fb_ba1a_11e1);
@@ -48,7 +48,7 @@ fn void variably_streamed() @if ($feature(SLOW_TESTS))
 	static char[] expected = x'96eb2677296e3150f53a07011b56732c41bdb1130fbf66b8a3002fcf42a20328';
 	static sz block_size = 15;
 	static char[32] result;
-	foreach (i : math::iota(sz[2048]))
+	foreach (i : math::iota(sz[128]))
 	{
 		char[] scroll = input;
 		ParallelHash{256} p;

--- a/test/unit/stdlib/threads/channel.c3
+++ b/test/unit/stdlib/threads/channel.c3
@@ -64,7 +64,7 @@ fn void test_unbuffered_channel_race() @test
 	{
 		UnbufferedChannel{int}* ch = (UnbufferedChannel*)arg;
 
-		for (int i = 0; i < 100000; i++)
+		for (int i = 0; i < 10000; i++)
 		{
 			ch.push(1)!!;
 		}
@@ -76,7 +76,7 @@ fn void test_unbuffered_channel_race() @test
 	{
 		UnbufferedChannel{int}* ch = (UnbufferedChannel*)arg;
 
-		for (int i = 0; i < 100000; i++)
+		for (int i = 0; i < 10000; i++)
 		{
 			ch.push(2)!!;
 		}
@@ -87,7 +87,7 @@ fn void test_unbuffered_channel_race() @test
 	int count2 = 0;
 
 	// Receiver
-	for (int i = 0; i < 200000; i++)
+	for (int i = 0; i < 20000; i++)
 	{
 		int v = ch.pop()!!;
 		switch (v)
@@ -118,7 +118,7 @@ fn void test_buffered_channel_race() @test
 	{
 		BufferedChannel{int}* ch = (BufferedChannel*)arg;
 
-		for (int i = 0; i < 100000; i++)
+		for (int i = 0; i < 10000; i++)
 		{
 			ch.push(1)!!;
 		}
@@ -130,7 +130,7 @@ fn void test_buffered_channel_race() @test
 	{
 		BufferedChannel{int}* ch = (BufferedChannel*)arg;
 
-		for (int i = 0; i < 100000; i++)
+		for (int i = 0; i < 10000; i++)
 		{
 			ch.push(2)!!;
 		}
@@ -141,7 +141,7 @@ fn void test_buffered_channel_race() @test
 	int count2 = 0;
 
 	// Receiver
-	for (int i = 0; i < 200000; i++)
+	for (int i = 0; i < 20000; i++)
 	{
 		int v = ch.pop()!!;
 		switch (v)
@@ -156,7 +156,7 @@ fn void test_buffered_channel_race() @test
 	t2.join();
 
 	assert(count1 == count2);
-	assert(count1 + count2 == 200000);
+	assert(count1 + count2 == 20000);
 
 }
 

--- a/test/unit/stdlib/threads/pool.c3
+++ b/test/unit/stdlib/threads/pool.c3
@@ -23,7 +23,11 @@ fn void push_destroy() @test
 		pool.init()!!;
 		defer pool.destroy();
 		pool.push(&do_work, &y);
-		thread::sleep(time::ms(50));
+		for (sz j = 0; j < 500; j++)
+		{
+			if (@atomic_load(x) == @atomic_load(y)) break;
+			thread::sleep(time::ms(1));
+		}
 		test::eq(@atomic_load(x), @atomic_load(y));
 	}
 }
@@ -67,7 +71,7 @@ fn int do_work(void* arg)
 fn int do_wait(void* arg)
 {
 	sz value = (sz)(iptr)arg;
-	for (sz i = 0; i < value; i++) thread::sleep(time::ms(50));
+	for (sz i = 0; i < value; i++) thread::sleep(time::ms(10));
 	@atomic_store(x, @atomic_load(x) + (int)value);
 	return 0;
 }

--- a/test/unit/stdlib/threads/simple_thread.c3
+++ b/test/unit/stdlib/threads/simple_thread.c3
@@ -28,8 +28,16 @@ fn void testrun_stack_size() @test
 fn void testrun_set_priority() @test @if(env::POSIX || env::WIN32)
 {
 	Thread t;
-	t.create(fn int(void* arg) { thread::sleep_ms(400); return 0; }, null)!!;
+	a = 0;
+	t.create(fn int(void* arg) {
+		for (int i = 0; i < 500; i++) {
+			if (@atomic_load(a)) break;
+			thread::sleep_ms(1);
+		}
+		return 0;
+	}, null)!!;
 	assert(t.set_priority(LOW));
+	@atomic_store(a, 1);
 	assert(t.join()!! == 0);
 }
 

--- a/test/unit/stdlib/threads/simple_thread.c3
+++ b/test/unit/stdlib/threads/simple_thread.c3
@@ -30,7 +30,8 @@ fn void testrun_set_priority() @test @if(env::POSIX || env::WIN32)
 	Thread t;
 	a = 0;
 	t.create(fn int(void* arg) {
-		for (int i = 0; i < 500; i++) {
+		for (int i = 0; i < 500; i++) 
+		{
 			if (@atomic_load(a)) break;
 			thread::sleep_ms(1);
 		}


### PR DESCRIPTION
Optimized some blocking slow stdlib tests and the test suite runner configuration, less thread explosion, this should work nicely in your mac and in general.

About 16% runtime reduction in the CI.

Added a "time elapsed" to the `c3c compile-test` but I don't mind if you want to remove it.