### PR TITLE
fix(codegen): slice len as %llu

### DIFF
--- a/src/compiler/c_codegen.c
+++ b/src/compiler/c_codegen.c
@@ -374,7 +374,7 @@ static void c_emit_const_expr(GenContext *c, CValue *value, Expr *expr)
 			PRINT("\"");
 			if(t->type_kind == TYPE_SLICE)
 			{
-				PRINTF(", %zu }", expr->const_expr.bytes.len);
+				PRINTF(", %llu }", (unsigned long long)expr->const_expr.bytes.len);
 			}
 			PRINT(";\n");
 			return;


### PR DESCRIPTION
Fix https://github.com/c3lang/c3c/pull/3209 macos build, format slice len as %llu 