### PR TITLE
[C Backend] Add if and for loop control flow

### DIFF
--- a/src/compiler/c_codegen.c
+++ b/src/compiler/c_codegen.c
@@ -330,6 +330,7 @@ static VariableId c_emit_temp(GenContext *c, CValue *value, Type *type)
 	return c->id_gen;
 }
 
+static void c_emit_stmt(GenContext *c, Ast* ast);
 static void c_emit_expr(GenContext *c, CValue *value, Expr *expr);
 
 static void c_emit_const_expr(GenContext *c, CValue *value, Expr *expr)
@@ -809,6 +810,54 @@ static void c_emit_return(GenContext *c, Ast *stmt)
 	}*/
 }
 
+/*
+	TODO:
+	When implementing continue/break and the labeled varients, some data
+	will need to be pushed about what the labels will be called
+	These labels will then need to be emitted here
+*/
+static void c_emit_for_stmt(GenContext *c, Ast *stmt)
+{
+	// We emit a while loop because thats more flexible
+	AstForStmt *for_stmt = &stmt->for_stmt;
+	CValue initializer_expr, condition_expr;
+	if (for_stmt->init) c_emit_expr(c, &initializer_expr, exprptr(for_stmt->init));
+	if (for_stmt->cond) c_emit_expr(c, &condition_expr, exprptr(for_stmt->cond));
+
+	PRINTF("while (___var_%d)\n{\n", condition_expr.var);
+	c_emit_stmt(c, astptrzero(for_stmt->body));
+	if (for_stmt->incr)
+	{
+		CValue in_loop_incr;
+		c_emit_expr(c, &in_loop_incr, exprptr(for_stmt->incr));
+		PRINTF("___var_%d = ___var_%d;\n", initializer_expr.var, in_loop_incr.var);
+	}
+	if (for_stmt->cond)
+	{
+		CValue in_loop_cond;
+		c_emit_expr(c, &in_loop_cond, exprptr(for_stmt->cond));
+		PRINTF("___var_%d = ___var_%d;\n", condition_expr.var, in_loop_cond.var);
+	}
+
+	PRINT("}\n");
+
+}
+
+static void c_emit_if_stmt(GenContext *c, Ast *stmt)
+{
+	AstIfStmt *if_stmt = &stmt->if_stmt;
+	CValue condition;
+	c_emit_expr(c, &condition, exprptr(if_stmt->cond));
+
+	PRINTF("if (___var_%d)\n", condition.var);
+	c_emit_stmt(c, astptrzero(if_stmt->then_body));
+	if (if_stmt->else_body)
+	{
+		PRINT("else");
+		c_emit_stmt(c, astptrzero(if_stmt->else_body));
+	}
+}
+
 static void c_emit_stmt(GenContext *c, Ast *stmt)
 {
 	if (!stmt) return;
@@ -865,12 +914,13 @@ static void c_emit_stmt(GenContext *c, Ast *stmt)
 			c_emit_expr_stmt(c, stmt);
 			return;
 		case AST_FOR_STMT:
-			PRINT("/* FOR */\n");
-			break;
+			c_emit_for_stmt(c, stmt);
+			return;
 		case AST_FOREACH_STMT:
 			break;
 		case AST_IF_STMT:
-			break;
+			c_emit_if_stmt(c, stmt);
+			return;
 		case AST_NOP_STMT:
 			PRINT(";\n");
 			return;

--- a/src/compiler/c_codegen.c
+++ b/src/compiler/c_codegen.c
@@ -330,7 +330,6 @@ static VariableId c_emit_temp(GenContext *c, CValue *value, Type *type)
 	return c->id_gen;
 }
 
-static void c_emit_stmt(GenContext *c, Ast* ast);
 static void c_emit_expr(GenContext *c, CValue *value, Expr *expr);
 
 static void c_emit_const_expr(GenContext *c, CValue *value, Expr *expr)


### PR DESCRIPTION
Add code to emit if and for loops. As c3 while loops are internally recorded as for loops, it adds support for while loops too.

The backend emits all loops as while loops. This is so that expressions that take multiple lines in C can still be used as the condition and increment expressions.

I intend to do some more work on the loops when I try add support for (labeled) break/continue. My thought so far is that I could emit a label after emitting the c3 body, but before the increment and condition are emitted, which is what any continue jumps to. Other labels would be emitted for labeled breaks.