### PR TITLE
fix: handle missing "dependencies" key in project.json

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -13,6 +13,7 @@
 - `@volatile_store` on arrays were sometimes incorrectly lowered.
 - NPOT vectors as associated variables were incorrectly lowered on load. #3228
 - `.get_tag` and `.has_tag` did not work properly for globals and locals.
+- Segmentation fault during library fetch when the "dependencies" key is missing in project.json. #3233
 
 ## 0.8.0 Change list
 

--- a/src/build/project_manipulation.c
+++ b/src/build/project_manipulation.c
@@ -46,9 +46,12 @@ const char** get_project_dependencies()
 	JSONObject *project_json = project_json_load(&filename);
 	JSONObject *dependencies_json = json_map_get(project_json, "dependencies");
 
-	FOREACH(JSONObject *, element, dependencies_json->elements)
+	if (dependencies_json)
 	{
-		vec_add(dependencies, element->str);
+		FOREACH(JSONObject *, element, dependencies_json->elements)
+		{
+			vec_add(dependencies, element->str);
+		}
 	}
 	return dependencies;
 }
@@ -360,6 +363,11 @@ void add_libraries_to_project_file(const char** libs, const char* target_name) {
 
 	// TODO! check if target is specified and exists (NULL at the moment)
 	JSONObject *libraries_json = json_map_get(project_json, "dependencies");
+	if (!libraries_json)
+	{
+		libraries_json = json_new_object(J_ARRAY);
+		json_map_set(project_json, "dependencies", libraries_json);
+	}
 
 	const char** dependencies = NULL;
 	FOREACH(JSONObject *, element, libraries_json->elements)


### PR DESCRIPTION
https://github.com/c3lang/c3c/issues/3233

null checks and add "dependencies" key if missing from project.json