### PR TITLE
Fix --no-entry on Windows

### DIFF
--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -898,7 +898,6 @@ static bool linker_setup(const char ***args_ref, const char **files_to_link, uns
 			{
 				add_plain_arg("/DLL");
 				add_concat_quote_arg("/IMPLIB:", static_lib_name());
-				if (compiler.build.no_entry) add_plain_arg("/NOENTRY");
 			}
 		case LINKER_CC:
 			break;

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -898,9 +898,6 @@ static bool linker_setup(const char ***args_ref, const char **files_to_link, uns
 			{
 				add_plain_arg("/DLL");
 				add_concat_quote_arg("/IMPLIB:", static_lib_name());
-			}
-			else
-			{
 				if (compiler.build.no_entry) add_plain_arg("/NOENTRY");
 			}
 		case LINKER_CC:


### PR DESCRIPTION
`--no-entry` behavior is incorrect on Windows.

The `/NOENTRY` linker arg is only valid alongside `/DLL`, to build a resource-only DLL.
It is currently added to any non-DLL build instead.

Which leads to `lld-link: error: /noentry must be specified with /dll` when trying to, e.g. build an `exe` with externally defined `main`.




