### PR TITLE
Fixed io::skip typo

### DIFF
--- a/lib/std/io/stream.c3
+++ b/lib/std/io/stream.c3
@@ -619,7 +619,7 @@ macro void? skip(stream, sz bytes)
 			{
 				for (sz i = 0; i < bytes; i++)
 				{
-					stream.read()!;
+					stream.read_byte()!;
 				}
 				return;
 			}
@@ -629,7 +629,7 @@ macro void? skip(stream, sz bytes)
 		$default:
 			for (sz i = 0; i < bytes; i++)
 			{
-				stream.read()!;
+				stream.read_byte()!;
 			}
 	$endswitch
 }

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -34,6 +34,7 @@
 - CVaList would behave different incorrectly for types larger than 8 bytes on some platforms.
 - UTF32 BOM detection was broken.
 - Sort from DString.less was inconsistent.
+- Fix io::skip using 'read' vs 'read_byte', causing an error.
  
 ## 0.8.0 Change list
 


### PR DESCRIPTION
Fixed a typo in io::skip, replacing 'read' the function call with 'read_byte', which caused errors when compiling.

Added an entry to the release notes.