### PR TITLE
Remove dummy interface for termios

### DIFF
--- a/lib/std/libc/termios.c3
+++ b/lib/std/libc/termios.c3
@@ -1,4 +1,4 @@
-module libc::termios @if(env::LIBC &&& env::POSIX);
+module libc::termios;
 
 fn int send_break(Fd fd, int duration) => tcsendbreak(fd, duration);
 fn int drain(Fd fd) => tcdrain(fd);
@@ -13,9 +13,8 @@ fn int Termios.set_attr(&self, Fd fd, Tcactions optional_actions) => tcsetattr(f
 
 module libc::termios @if(!env::LIBC ||| !env::POSIX);
 
-typedef Cc = char;
 typedef Speed = CUInt;
-typedef Tcflags = CUInt;
+typedef Tcactions = CInt;
 
 struct Termios
 {
@@ -27,7 +26,7 @@ fn CInt tcgetattr(Fd fd, Termios* self)
 	unreachable("tcgetattr unavailable");
 }
 
-fn CInt tcsetattr(Fd fd, CInt optional_actions, Termios* self)
+fn CInt tcsetattr(Fd fd, Tcactions optional_actions, Termios* self)
 {
 	unreachable("tcsetattr unavailable");
 }
@@ -71,54 +70,3 @@ fn CInt cfsetispeed(Termios* self, Speed speed)
 {
 	unreachable("cfsetispeed unavailable");
 }
-
-fn int sendBreak(Fd fd, int duration)
-{
-	unreachable("sendBreak unavailable");
-}
-
-fn int drain(Fd fd)
-{
-	unreachable("drain unavailable");
-}
-
-fn int flush(Fd fd, int queue_selector)
-{
-	unreachable("flush unavailable");
-}
-
-fn int flow(Fd fd, int action)
-{
-	unreachable("flow unavailable");
-}
-
-fn Speed Termios.getOSpeed(Termios* self)
-{
-	unreachable("Termios.getOSpeed unavailable");
-}
-
-fn Speed Termios.getISpeed(Termios* self)
-{
-	unreachable("Termios.getISpeed unavailable");
-}
-
-fn int Termios.setOSpeed(Termios* self, Speed speed)
-{
-	unreachable("Termios.setOSpeed unavailable");
-}
-
-fn int Termios.setISpeed(Termios* self, Speed speed)
-{
-	unreachable("Termios.setISpeed unavailable");
-}
-
-fn int Termios.getAttr(Termios* self, Fd fd)
-{
-	unreachable("Termios.getAttr unavailable");
-}
-
-fn int Termios.setAttr(Termios* self, Fd fd, int optional_actions)
-{
-	unreachable("Termios.setAttr unavailable");
-}
-

--- a/lib/std/libc/termios.c3
+++ b/lib/std/libc/termios.c3
@@ -1,4 +1,4 @@
-module libc::termios;
+module libc::termios @if(env::LIBC &&& env::POSIX);
 
 fn int send_break(Fd fd, int duration) => tcsendbreak(fd, duration);
 fn int drain(Fd fd) => tcdrain(fd);
@@ -10,63 +10,3 @@ fn int Termios.set_ospeed(&self, Speed speed) => cfsetospeed(self, speed);
 fn int Termios.set_ispeed(&self, Speed speed) => cfsetispeed(self, speed);
 fn int Termios.get_attr(&self, Fd fd) => tcgetattr(fd, self);
 fn int Termios.set_attr(&self, Fd fd, Tcactions optional_actions) => tcsetattr(fd, optional_actions, self);
-
-module libc::termios @if(!env::LIBC ||| !env::POSIX);
-
-typedef Speed = CUInt;
-typedef Tcactions = CInt;
-
-struct Termios
-{
-	void* dummy;
-}
-
-fn CInt tcgetattr(Fd fd, Termios* self)
-{
-	unreachable("tcgetattr unavailable");
-}
-
-fn CInt tcsetattr(Fd fd, Tcactions optional_actions, Termios* self)
-{
-	unreachable("tcsetattr unavailable");
-}
-
-fn CInt tcsendbreak(Fd fd, CInt duration)
-{
-	unreachable("tcsendbreak unavailable");
-}
-
-fn CInt tcdrain(Fd fd)
-{
-	unreachable("tcdrain unavailable");
-}
-
-fn CInt tcflush(Fd fd, CInt queue_selector)
-{
-	unreachable("tcflush unavailable");
-}
-
-fn CInt tcflow(Fd fd, CInt action)
-{
-    unreachable("tcflow unavailable");
-}
-
-fn Speed cfgetospeed(Termios* self)
-{
-	unreachable("cfgetospeed unavailable");
-}
-
-fn Speed cfgetispeed(Termios* self)
-{
-	unreachable("cfgetispeed unavailable");
-}
-
-fn CInt cfsetospeed(Termios* self, Speed speed)
-{
-	unreachable("cfsetospeed unavailable");
-}
-
-fn CInt cfsetispeed(Termios* self, Speed speed)
-{
-	unreachable("cfsetispeed unavailable");
-}


### PR DESCRIPTION
This is an attempt to fix some inconsistencies with the "dummy interface" that's provided by `lib/std/libc/termios.c3`. Specifically, it was added in commit b0e104bfd0d7794e01fabcfd3789c6efa0bbad18, but then changes in 487057d03c9ba6bd1b7a73811653f31a64c63114 and 5b39dc97f434fc06f2a2bbd87b573cac78aefa0b forgot to make the necessary changes to that interface as well.

With that said, I have some follow up questions:

- Is there a point in maintaining  stubs for platforms not having an implementation? Especially since the `Termios` structure is incompatible anyway?