### PR TITLE
Docgen fixes

### DIFF
--- a/resources/docs.html
+++ b/resources/docs.html
@@ -2541,6 +2541,33 @@
 
 			html += buildDocsBodyHtml(vd);
 
+			if (vd.file) {
+				const match = vd.file.match(/^(.*):(\d+):(\d+)$/);
+				const filePath = match ? match[1] : vd.file;
+				const lineStr = match ? match[2] : '';
+
+				let href = '';
+				const locHref = window.location.href;
+				if (locHref.includes('c3-lang.org') || locHref.includes('c3lang.org')) {
+					href = `https://github.com/c3lang/c3c/blob/master/${filePath}`;
+					if (lineStr) href += `#L${lineStr}`;
+				} else {
+					// Handle absolute paths (Windows or Unix)
+					if (filePath.match(/^[a-zA-Z]:/) || filePath.startsWith('/')) {
+						href = 'file:///' + filePath.replace(/^\//, '');
+					} else {
+						href = filePath;
+					}
+				}
+
+				html += `<div style="margin-top: 20px; padding-top: 10px; border-top: 1px solid var(--border);">
+					<a href="${href}" target="_blank" style="font-size: 0.9em; color: var(--filter-fg); text-decoration: none;">
+						<span style="opacity: 0.7;">Defined in: </span>
+						<span style="color: var(--accent);">${filePath}${lineStr ? ':' + lineStr : ''}</span>
+					</a>
+				</div>`;
+			}
+
 			return html;
 		}
 

--- a/resources/docs.html
+++ b/resources/docs.html
@@ -2218,17 +2218,27 @@
 				return `<span class="c3-keyword">${keyword}</span> ${ret} <span class="c3-function">${localName}</span>(${params})${genericSuffix}${attrs ? ' ' + attrs : ''}`;
 			}
 
-			if (d.kind === 'type_alias' && d.return_type) {
-				const ret = renderTypeName(d.return_type);
-				const params = renderParams(d.members);
-				return `<span class="c3-keyword">alias</span> <span class="c3-type">${localName}</span> = <span class="c3-keyword">fn</span> ${ret}(${params})`;
+			if (d.kind === 'alias') {
+				if (d.return_type) {
+					const ret = renderTypeName(d.return_type);
+					const params = renderParams(d.members);
+					return `<span class="c3-keyword">alias</span> <span class="c3-type">${localName}</span> = <span class="c3-keyword">fn</span> ${ret}(${params})`;
+				} else if (d.base_type) {
+					const baseTypeStr = renderTypeName(d.base_type);
+					return `<span class="c3-keyword">alias</span> <span class="c3-type">${localName}</span> = ${baseTypeStr}`;
+				} else {
+					return `<span class="c3-keyword">alias</span> <span class="c3-type">${localName}</span>`;
+				}
+			}
+
+			if (d.kind === 'distinct type') {
+				const inlineHtml = d.is_inline ? '<span class="c3-keyword">inline</span> ' : '';
+				const baseTypeStr = d.base_type ? renderTypeName(d.base_type) : '';
+				return `<span class="c3-keyword">typedef</span> <span class="c3-type">${localName}</span> = ${inlineHtml}${baseTypeStr}`;
 			}
 
 			if (d.kind === 'constant' || d.kind === 'global variable') {
-				let keywordHtml = '';
-				if (d.kind === 'constant' || d.is_const) {
-					keywordHtml = '<span class="c3-keyword">const</span> ';
-				}
+				const keywordHtml = (d.kind === 'constant' || d.is_const) ? '<span class="c3-keyword">const</span> ' : '';
 				const typeStr = d.type ? renderTypeName(d.type) : '';
 				let res = `${keywordHtml}${typeStr ? typeStr + ' ' : ''}<span class="c3-variable">${localName}</span>`;
 				if (d.value) {
@@ -2237,7 +2247,7 @@
 				return res;
 			}
 
-			if (d.kind === 'enum' || d.kind === 'struct' || d.kind === 'union' || d.kind === 'bitstruct' || d.kind === 'alias' || d.kind === 'fault' || d.kind === 'constdef' || d.kind === 'interface') {
+			if (d.kind === 'enum' || d.kind === 'struct' || d.kind === 'union' || d.kind === 'bitstruct' || d.kind === 'fault' || d.kind === 'constdef' || d.kind === 'interface') {
 				let res = `<span class="c3-keyword">${d.kind}</span> <span class="c3-type">${localName}</span>`;
 				if (d.base_type && d.base_type.name) {
 					res += ` : ${renderTypeName(d.base_type)}`;

--- a/resources/docs.html
+++ b/resources/docs.html
@@ -2222,10 +2222,13 @@
 				return `<span class="c3-keyword">alias</span> <span class="c3-type">${localName}</span> = <span class="c3-keyword">fn</span> ${ret}(${params})`;
 			}
 
-			if (d.kind === 'variable' || d.kind === 'constant') {
-				const keyword = d.kind === 'constant' || d.is_const ? 'const' : 'var';
+			if (d.kind === 'constant' || d.kind === 'global variable') {
+				let keywordHtml = '';
+				if (d.kind === 'constant' || d.is_const) {
+					keywordHtml = '<span class="c3-keyword">const</span> ';
+				}
 				const typeStr = d.type ? renderTypeName(d.type) : '';
-				let res = `<span class="c3-keyword">${keyword}</span> ${typeStr} <span class="c3-variable">${localName}</span>`;
+				let res = `${keywordHtml}${typeStr ? typeStr + ' ' : ''}<span class="c3-variable">${localName}</span>`;
 				if (d.value) {
 					res += ` = <span class="c3-number">${d.value}</span>`;
 				}

--- a/resources/docs.html
+++ b/resources/docs.html
@@ -2235,7 +2235,7 @@
 				return res;
 			}
 
-			if (d.kind === 'enum' || d.kind === 'struct' || d.kind === 'union' || d.kind === 'bitstruct' || d.kind === 'alias' || d.kind === 'fault' || d.kind === 'constdef') {
+			if (d.kind === 'enum' || d.kind === 'struct' || d.kind === 'union' || d.kind === 'bitstruct' || d.kind === 'alias' || d.kind === 'fault' || d.kind === 'constdef' || d.kind === 'interface') {
 				let res = `<span class="c3-keyword">${d.kind}</span> <span class="c3-type">${localName}</span>`;
 				if (d.base_type && d.base_type.name) {
 					res += ` : ${renderTypeName(d.base_type)}`;
@@ -2425,10 +2425,20 @@
 					</tr>`;
 				} else {
 					let typeStr = m.type ? renderTypeName(m.type) : '';
+					let nameStr = m.name || '';
+					let attrHtml = '';
+					if (vd.kind === 'interface') {
+						let paramsStr = m.params ? renderParams(m.params) : '';
+						nameStr += '(' + paramsStr + ')';
+						if (m.is_optional) {
+							attrHtml = `<span class="c3-keyword">@optional</span>`;
+						}
+					}
 					rowHtml += `<tr>
 						${isFunc ? `<td class="col-mod">${modHtml}</td>` : ''}
 						<td class="col-type monospace">${prefix}${typeStr}${bitDesc}</td>
-						<td class="col-name monospace bold c3-${m.kind || 'variable'}">${m.name || ''}</td>
+						<td class="col-name monospace bold c3-${vd.kind === 'interface' ? 'function' : (m.kind || 'variable')}">${nameStr}</td>
+						${vd.kind === 'interface' ? `<td class="col-mod monospace">${attrHtml}</td>` : ''}
 						<td class="doc-text">${desc}</td>
 					</tr>`;
 				}
@@ -2489,13 +2499,14 @@
 				html += `</tbody></table>`;
 
 			} else {
-				let title = isFunction ? 'Arguments' : 'Fields';
+				let title = isFunction ? 'Arguments' : (vd.kind === 'interface' ? 'Methods' : 'Fields');
 				html += `<h3>${title}</h3>`;
 				html += `<table class="contract-table">
 					<thead><tr>
 						${isFunction ? '<th class="col-mod">Contract</th>' : ''}
 						<th class="col-type">Type</th>
 						<th class="col-name">Name</th>
+						${vd.kind === 'interface' ? '<th class="col-mod">Attribute</th>' : ''}
 						<th>${anyDesc ? 'Description' : ''}</th>
 					</tr></thead><tbody>`;
 				vd.members.forEach(m => { html += renderRow(m, isFunction, false); });

--- a/resources/docs.html
+++ b/resources/docs.html
@@ -1210,10 +1210,12 @@
 	<div id="module-tooltip" class="module-tooltip"></div>
 	<div id="sidebar">
 		<div class="resizer sidebar-resizer" id="left-resizer"></div>
-		<div class="sidebar-header" onclick="navigateTo('');">
-			<img src="https://c3-lang.org/assets/logo.svg" alt="C3 Logo" class="logo">
-			<span class="secondary-text">Documentation</span>
-			<div onclick="event.stopPropagation(); toggleTheme();" title="Toggle Light/Dark Theme" style="margin-left: auto; padding: 4px 8px; font-size: 1.25em; border-radius: 4px; transition: background 0.2s ease; display: flex; align-items: center; justify-content: center;">
+		<div class="sidebar-header" style="cursor: default;">
+			<a href="https://c3-lang.org/docs" title="C3 Documentation" style="display: flex;">
+				<img src="https://c3-lang.org/assets/logo.svg" alt="C3 Logo" class="logo">
+			</a>
+			<span class="secondary-text" onclick="navigateTo('');" style="cursor: pointer; font-weight: 500; transition: color 0.2s;" onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color=''" title="View Project Overview">Project Overview</span>
+			<div onclick="event.stopPropagation(); toggleTheme();" title="Toggle Light/Dark Theme" style="cursor: pointer; margin-left: auto; padding: 4px 8px; font-size: 1.25em; border-radius: 4px; transition: background 0.2s ease; display: flex; align-items: center; justify-content: center;">
 				<div id="theme-toggle-btn" style="color: var(--sidebar-header-fg);">☼</div>
 			</div>
 		</div>

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -773,6 +773,36 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 	fputs("\"uid\":", file);
 	write_decl_uid(file, module, decl);
 	fputs(",", file);
+	if (decl->loc)
+	{
+		SourceLoc *loc_info = sourcelocptr(decl->loc);
+		if (loc_info && loc_info->file_id)
+		{
+			File *f = source_file_by_id(loc_info->file_id);
+			if (f && f->full_path)
+			{
+				fputs("\"file\":", file);
+				scratch_buffer_clear();
+				const char *path = f->full_path;
+				// Strip cwd prefix to get a relative path
+				char cwd_buf[PATH_MAX + 1];
+				const char *cwd = getcwd(cwd_buf, sizeof(cwd_buf));
+				if (cwd)
+				{
+					// Normalize backslashes (Windows) to forward slashes
+					for (char *p = cwd_buf; *p; p++) if (*p == '\\') *p = '/';
+					size_t cwd_len = strlen(cwd);
+					if (strncmp(path, cwd, cwd_len) == 0 && path[cwd_len] == '/')
+					{
+						path = path + cwd_len + 1;
+					}
+				}
+				scratch_buffer_printf("%s:%u:%u", path, loc_info->row, loc_info->col);
+				json_write_string(file, scratch_buffer_to_string());
+				fputs(",", file);
+			}
+		}
+	}
 	if (decl->visibility != VISIBLE_PUBLIC)
 	{
 		fprintf(file, "\"visibility\":\"%s\",", get_visibility_name(decl->visibility));

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -893,6 +893,7 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 			base = decl->strukt.container_type;
 			goto PRINT_BASE;
 		case DECL_TYPEDEF:
+			if (decl->is_substruct) fputs("\"is_inline\":true,", file);
 			base = decl->distinct;
 			goto PRINT_BASE;
 		PRINT_BASE:

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -867,12 +867,12 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 			if (decl->var.kind == VARDECL_CONST)
 			{
 				fputs("\"is_const\":true,", file);
-				if (decl->var.init_expr)
-				{
-					fputs("\"value\":", file);
-					write_const_value_json(file, decl->var.init_expr);
-					fputs(",", file);
-				}
+			}
+			if (decl->var.init_expr)
+			{
+				fputs("\"value\":", file);
+				write_const_value_json(file, decl->var.init_expr);
+				fputs(",", file);
 			}
 			break;
 		case DECL_POISONED:

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -552,8 +552,22 @@ static void emit_doc_members(FILE *file, Module *module, Decl *decl)
 				fputs("null", file);
 			}
 			// Emit the parameter list so the HTML can reconstruct the full signature
-			fputs(",\"params\":", file);
-			emit_params_json(file, module, p->func_decl.signature.params);
+			fputs(",\"params\":[", file);
+			bool first_param = true;
+			for (unsigned i = 1; i < vec_size(p->func_decl.signature.params); i++)
+			{
+				Decl *param = p->func_decl.signature.params[i];
+				if (!param) continue;
+				if (!first_param) fputs(",", file);
+				first_param = false;
+				emit_param_json(file, module, param);
+			}
+			fputs("]", file);
+
+			if (p->func_decl.attr_optional)
+			{
+				fputs(",\"is_optional\":true", file);
+			}
 
 			fputs("}", file);
 		}

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -239,7 +239,7 @@ static void write_decl_uid(FILE *file, Module *module, Decl *decl)
 static void emit_type_name_to_scratch(TypeInfo *type)
 {
 	if (!type) return;
-	if (type->type && type->type->name)
+	if (type->kind != TYPE_INFO_TYPEOF && type->kind != TYPE_INFO_TYPEFROM && type->type && type->type->name)
 	{
 		scratch_buffer_append(type->type->name);
 		if (type->optional && !strstr(type->type->name, "?")) scratch_buffer_append("?");
@@ -299,7 +299,7 @@ static void emit_type_name_to_scratch(TypeInfo *type)
 			scratch_buffer_append("}");
 			break;
 		case TYPE_INFO_TYPEOF:
-			scratch_buffer_append("typeof(");
+			scratch_buffer_append("$Typeof(");
 			if (type->unresolved_type_expr) loc_to_scratch(type->unresolved_type_expr->loc);
 			scratch_buffer_append(")");
 			break;


### PR DESCRIPTION
- add values to global variable json and display them correctly in docs.html
- describe interface shape
- add source location to docs.html
  - point to `c3lang/c3c` github if uri matches `c3-lang.org` or `c3lang.org`
- add "file location" to the json/html
```json
"file" : "relative_path/filename:row:column",
```


<img width="457" height="491" alt="image" src="https://github.com/user-attachments/assets/3cc0440f-c0d7-4321-8262-33870a67c544" />
<img width="603" height="315" alt="image" src="https://github.com/user-attachments/assets/7706a4c9-7122-434d-9b38-c84b221d5c31" />
<img width="583" height="360" alt="image" src="https://github.com/user-attachments/assets/68b3ecea-4513-40e9-a7ae-ef838d71fe42" />
<img width="673" height="317" alt="image" src="https://github.com/user-attachments/assets/4440f880-782d-4fe2-84f4-4a918365d749" />


https://github.com/c3lang/c3c/issues/3227
https://github.com/c3lang/c3c/issues/3243
https://github.com/c3lang/c3-web/issues/244
