### PR TITLE
Don't create copy of variable when reverse indexing with indexing overloaded

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -44,6 +44,7 @@
 - Overlong conversions to unicode for `%c` at boundaries.
 - Do not rely on implicit allocation for getcwd.
 - Skipping symlinks wasn't properly implemented for Win32.
+- Reverse indexing a value that overloads indexing would index an anonymous copy of the value.
 
 ## 0.8.0 Change list
 

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -4452,11 +4452,7 @@ static inline bool sema_expr_analyse_subscript(SemaContext *context, Expr *expr,
 				RETURN_SEMA_ERROR(subscripted, "Cannot index '%s' from the end, since there is no 'len' overload.", type_to_error_string(subscripted->type));
 			}
 			if (!sema_analyse_expr_rvalue(context, current_expr)) return false;
-			Decl *temp = decl_new_generated_var(current_expr->type, VARDECL_PARAM, current_expr->loc);
-			Expr *decl = expr_generate_decl(temp, expr_copy(current_expr));
-			expr_rewrite_two(current_expr, decl, expr_variable(temp));
-			if (!sema_analyse_expr_rvalue(context, current_expr)) return false;
-			Expr *var_for_len = expr_variable(temp);
+			Expr *var_for_len = expr_copy(current_expr);
 			Expr *len_expr = expr_new(EXPR_CALL, expr->loc);
 			if (!sema_insert_method_call(context, len_expr, len, var_for_len, NULL, false)) return false;
 			if (!sema_analyse_expr_rvalue(context, len_expr)) return false;

--- a/test/test_suite/overloading/reverse_index.c3t
+++ b/test/test_suite/overloading/reverse_index.c3t
@@ -1,0 +1,42 @@
+// #target: linux-x64
+module test;
+struct Test
+{
+	sz count;
+	int[2] vals;
+}
+
+fn sz Test.len(&self) @operator(len) => self.count;
+
+fn int* Test.get_ref(&self, sz idx) @operator(&[]) => &self.vals[idx];
+fn int Test.get(&self, sz idx) @operator([]) => self.vals[idx];
+
+extern fn int printf(ZString, ...);
+
+fn void main()
+{
+	Test t = {2, {1, 2}};
+	printf("%d %d %p %p\n", t[^1], t[t.len() - 1], &t[^1], &t[t.len() - 1]);
+}
+
+/* #expect: test.ll
+
+define void @test.main() #0 {
+entry:
+  %t = alloca %Test, align 8
+  call void @llvm.memcpy.p0.p0.i32(ptr align 8 %t, ptr align 8 @.__const, i32 16, i1 false)
+  %0 = call i64 @test.Test.len(ptr %t)
+  %sub = sub i64 %0, 1
+  %1 = call i32 @test.Test.get(ptr %t, i64 %sub)
+  %2 = call i64 @test.Test.len(ptr %t)
+  %sub1 = sub i64 %2, 1
+  %3 = call i32 @test.Test.get(ptr %t, i64 %sub1)
+  %4 = call i64 @test.Test.len(ptr %t)
+  %sub2 = sub i64 %4, 1
+  %5 = call ptr @test.Test.get_ref(ptr %t, i64 %sub2)
+  %6 = call i64 @test.Test.len(ptr %t)
+  %sub3 = sub i64 %6, 1
+  %7 = call ptr @test.Test.get_ref(ptr %t, i64 %sub3)
+  %8 = call i32 (ptr, ...) @printf(ptr @.str, i32 %1, i32 %3, ptr %5, ptr %7)
+  ret void
+}


### PR DESCRIPTION
fixes #3258.

Please let me know if there is a better way to do this.

This is what the LLVM IR generated from https://github.com/Book-reader/c3c/blob/aeeb35c46702c79768cc4e8f6332769949a1874f/test/test_suite/overloading/reverse_index.c3t looked like before these changes:
```llvm
define void @test.main() #0 {
entry:
  %t = alloca %Test, align 8
  %.anon = alloca %Test, align 8
  %.anon2 = alloca %Test, align 8
  call void @llvm.memcpy.p0.p0.i32(ptr align 8 %t, ptr align 8 @.__const, i32 16, i1 false)
  call void @llvm.memcpy.p0.p0.i32(ptr align 8 %.anon, ptr align 8 %t, i32 16, i1 false)
  %0 = call i64 @test.Test.len(ptr %.anon)
  %sub = sub i64 %0, 1
  %1 = call i32 @test.Test.get(ptr %.anon, i64 %sub)
  %2 = call i64 @test.Test.len(ptr %t)
  %sub1 = sub i64 %2, 1
  %3 = call i32 @test.Test.get(ptr %t, i64 %sub1)
  call void @llvm.memcpy.p0.p0.i32(ptr align 8 %.anon2, ptr align 8 %t, i32 16, i1 false)
  %4 = call i64 @test.Test.len(ptr %.anon2)
  %sub3 = sub i64 %4, 1
  %5 = call ptr @test.Test.get_ref(ptr %.anon2, i64 %sub3)
  %6 = call i64 @test.Test.len(ptr %t)
  %sub4 = sub i64 %6, 1
  %7 = call ptr @test.Test.get_ref(ptr %t, i64 %sub4)
  %8 = call i32 (ptr, ...) @printf(ptr @.str, i32 %1, i32 %3, ptr %5, ptr %7)
  ret void
}
```
It would allocate a new copy of the original value named  `%.anon*` for each reverse-indexing, making `&t[^1]` return a pointer to a different value each time it was used.

This doesn't affect `List`s in most cases because they store their contents on the heap and the pointer to it would be shared between the copies, but appending to a `List` using `arr[^0] = x` would not update the length of the original list and could reallocate the array and cause the original List to point to freed memory.