### PR TITLE
Fix misleading "Object files written" output when `--no-obj` is active

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -606,7 +606,10 @@ void compiler_compile(void)
 					OUTF("Object file %s created.\n", compiler.obj_output);
 					break;
 				}
-				OUTF("Object files written to %s.\n", compiler.build.object_file_dir);
+				if (compiler.build.emit_object_files)
+				{
+					OUTF("Object files written to %s.\n", compiler.build.object_file_dir);
+				}
 				break;
 			case TARGET_TYPE_PREPARE:
 				break;


### PR DESCRIPTION
### Description
Fixes a minor logging bug where the compiler erroneously prints `"Object files written to..."` even when object file emission is disabled. 

The fix wraps the "Object file written" print statement in a conditional check for `compiler.build.emit_object_files`, ensuring the console output is only done when we want obj files to be generated.

### Related Issues
Fixes #3087 

### Testing & Verification
Tested the fix locally by running the compilation with `--no-obj`:

```bash
➜ .\c3c.exe compile-only ..\..\resources\examples\hash.c3 -O0 -g0 --single-module=yes --emit-llvm --no-obj --llvm-out ".build/$target/build/c3"
LLVM files written to .build//build/c3.
```