### PR TITLE
Treat .png as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 $ cat .gitattributes
 * text eol=lf
 *.ico binary
+*.png binary


### PR DESCRIPTION
We should not do line-ending conversion on `.png` files since that will most likely corrupt them. This also silences the warnings (which you on a fresh checkout of the compiler):

```
warning: in the working copy of 'resources/examples/raylib/guytex.png', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'resources/examples/raylib/raybunny.png', CRLF will be replaced by LF the next time Git touches it
warning: in the working copy of 'resources/images/vkQuake.png', CRLF will be replaced by LF the next time Git touches it
```