### PR TITLE
Remove return in expr_rewrite_const_string_from_raw function

### DIFF
--- a/src/compiler/expr.c
+++ b/src/compiler/expr.c
@@ -1080,7 +1080,7 @@ void expr_rewrite_const_string(Expr *expr_to_rewrite, const char *string, ArrayI
 
 void expr_rewrite_const_string_from_raw(Expr *expr_to_rewrite, const char *string)
 {
-	return expr_rewrite_const_string(expr_to_rewrite, string, (ArrayIndex)strlen(string));
+	expr_rewrite_const_string(expr_to_rewrite, string, (ArrayIndex)strlen(string));
 }
 
 void expr_rewrite_to_binary(Expr *expr_to_rewrite, Expr *left, Expr *right, BinaryOp op)


### PR DESCRIPTION
Likely shouldn’t have returned a value in that function, because of which on Windows cmake build step, it shows:
```cmake
D:\a\c3c\c3c\src\compiler\expr.c(1083): warning C4098: 'expr_rewrite_const_string_from_raw': 'void' function returning a value
```