### PR TITLE
feat(compiler): allow @tag attr on enum/constdef values & enum members

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -11,6 +11,7 @@
 - `$vaarg[^1]` is supported. #3276
 - Improve error message when a keyword is used a block parameter. #3275
 - Correct tag method error messages from `tagof`/`has_tagof` to `get_tag` and `has_tag` 
+- Allow @tag attr on enum/constdef values & enum members.
 
 ### Stdlib changes
 - Add math::TAU / math::TWO_PI

--- a/src/compiler/sema_decls.c
+++ b/src/compiler/sema_decls.c
@@ -1632,10 +1632,8 @@ static inline bool sema_analyse_typedef(SemaContext *context, Decl *decl, bool *
 static inline bool sema_analyse_enum_param(SemaContext *context, Decl *param)
 {
 	ASSERT(param->decl_kind == DECL_VAR && param->var.kind == VARDECL_PARAM && param->var.type_info);
-	if (vec_size(param->attributes))
-	{
-		RETURN_SEMA_ERROR(param->attributes[0], "There are no valid attributes for associated values.");
-	}
+	bool erase_decl = false;
+	if (!sema_analyse_attributes(context, param, param->attributes, ATTR_ENUM_VALUE, &erase_decl)) return false;
 	TypeInfo *type_info = type_infoptrzero(param->var.type_info);
 	if (!sema_resolve_type_info(context, type_info, RESOLVE_TYPE_DEFAULT)) return false;
 	ASSERT(!param->var.vararg);
@@ -3253,7 +3251,7 @@ static bool sema_analyse_attribute(SemaContext *context, ResolvedAttrData *attr_
 			[ATTRIBUTE_SAFEINFER] = ATTR_GLOBAL | ATTR_LOCAL,
 			[ATTRIBUTE_SECTION] = ATTR_FUNC | ATTR_CONST | ATTR_GLOBAL,
 			[ATTRIBUTE_SIMD] = 0,
-			[ATTRIBUTE_TAG] = ATTR_BITSTRUCT_MEMBER | ATTR_MEMBER | USER_DEFINED_TYPES | CALLABLE_TYPE | ATTR_LOCAL | ATTR_GLOBAL,
+			[ATTRIBUTE_TAG] = ATTR_BITSTRUCT_MEMBER | ATTR_MEMBER | USER_DEFINED_TYPES | CALLABLE_TYPE | ATTR_LOCAL | ATTR_GLOBAL | ATTR_ENUM_VALUE,
 			[ATTRIBUTE_TEST] = ATTR_FUNC,
 			[ATTRIBUTE_UNUSED] = (AttributeDomain)~(ATTR_CALL),
 			[ATTRIBUTE_USED] = (AttributeDomain)~(ATTR_CALL),

--- a/src/compiler/sema_expr.c
+++ b/src/compiler/sema_expr.c
@@ -1225,7 +1225,7 @@ static inline bool sema_expr_analyse_enum_constant(SemaContext *context, Expr *e
 		if (!sema_display_deprecated_warning_on_use(context, enum_constant, expr->loc)) return expr_poison(expr), true;
 	}
 	expr->type = decl->type;
-	if (enum_constant->enum_constant.is_raw)
+	if (enum_constant->enum_constant.is_raw && /* !$reflect() */ !context->call_env.in_no_eval)
 	{
 		expr_replace(expr, copy_expr_single(enum_constant->enum_constant.value));
 		if (!sema_analyse_expr_rvalue(context, expr)) expr_poison(expr);
@@ -5627,6 +5627,33 @@ static bool sema_expr_analyse_reflection_access(SemaContext *context, Expr *expr
 		}
 	}
 
+	if (reflect->const_expr.const_kind == CONST_ENUM)
+	{
+		Decl *enum_const = reflect->const_expr.enum_val;
+		if (!sema_analyse_decl(context, enum_const)) return false;
+		if (name == kw_has_tag)
+		{
+			expr->expr_kind = EXPR_TYPECALL;
+			expr->type_call_expr = (ExprTypeCall) { .type = enum_const, .property = TYPE_PROPERTY_HAS_TAG };
+			return true;
+		}
+		if (name == kw_get_tag)
+		{
+			expr->expr_kind = EXPR_TYPECALL;
+			expr->type_call_expr = (ExprTypeCall) { .type = enum_const, .property = TYPE_PROPERTY_GET_TAG };
+			return true;
+		}
+		if (name == kw_tags)
+		{
+			return sema_create_const_tags(context, expr, enum_const->attrs_resolved);
+		}
+		if (name == kw_name)
+		{
+			expr_rewrite_const_string_from_raw(expr, enum_const->name);
+			return true;
+		}
+		goto FAILED;
+	}
 	if (reflect->expr_kind != EXPR_IDENTIFIER) goto FAILED;
 	Decl *decl = reflect->ident_expr;
 	if (name == kw_name) return sema_expr_analyse_reflection_name(context, expr, decl, false), true;

--- a/test/test_suite/enumerations/constdef_enum_value_tag.c3t
+++ b/test/test_suite/enumerations/constdef_enum_value_tag.c3t
@@ -1,0 +1,30 @@
+// #file: file1.c3
+constdef MyConstdef : inline uint @tag("constdef_tag", 1) {
+	AAA @tag("constdef_member_tag", 2) = 3
+}
+
+enum MyEnum : uint (String name @tag("member_tag", -1)) {
+	BBB @tag("enum_member_tag", -2) { "bbb" }
+}
+
+fn void main()
+{
+	$assert($reflect(MyConstdef.AAA).has_tag("constdef_member_tag"));
+	$assert(!$reflect(MyConstdef.AAA).has_tag("nonexistent"));
+	$assert($reflect(MyConstdef.AAA).get_tag("constdef_member_tag") == 2);
+	$assert($reflect(MyConstdef.AAA).name == "AAA");
+	$assert($reflect(MyConstdef.AAA).tags.len == 1);
+	$assert($reflect(MyConstdef.AAA).tags[0] == "constdef_member_tag");
+
+	$assert($reflect(MyEnum.BBB).has_tag("enum_member_tag"));
+	$assert(!$reflect(MyEnum.BBB).has_tag("nonexistent"));
+	$assert($reflect(MyEnum.BBB).get_tag("enum_member_tag") == -2);
+	$assert($reflect(MyEnum.BBB).name == "BBB");
+	$assert($reflect(MyEnum.BBB).tags.len == 1);
+	$assert($reflect(MyEnum.BBB).tags[0] == "enum_member_tag");
+
+	$assert(MyEnum::members[0].name == "name");
+	$assert(MyEnum::members[0].has_tag("member_tag"));
+	$assert(MyEnum::members[0].get_tag("member_tag") == -1);
+	$assert(MyEnum::members[0].tags.len == 1);
+}

--- a/test/test_suite/enumerations/constdef_enum_value_tag_bad.c3t
+++ b/test/test_suite/enumerations/constdef_enum_value_tag_bad.c3t
@@ -1,0 +1,5 @@
+// #file: file3.c3
+enum BadEnum : uint (String name @if) { // #error: '@if' cannot be used here.
+	FOO { "foo" }
+}
+

--- a/test/test_suite/enumerations/constdef_enum_value_tag_bad2.c3t
+++ b/test/test_suite/enumerations/constdef_enum_value_tag_bad2.c3t
@@ -1,0 +1,4 @@
+// #file: file2.c3
+enum BadEnum1 : uint (String name @tag("test", 1) @align(8)) { // #error: '@align' is not a valid enum value attribute.
+	FOO { "foo" }
+}


### PR DESCRIPTION
```c3
constdef MyConstdef : inline uint @tag("constdef_tag", 1) {
	AAA @tag("constdef_value_tag", 2) = 3
}

enum MyEnum : uint (String name @tag("enum_member_tag", -1)) @tag("enum_tag", -1) {
	BBB @tag("enum_value_tag", -2) { "bbb" }
}

fn void main()
{
	$assert(MyConstdef::has_tag("constdef_tag"));
	$assert(MyConstdef::get_tag("constdef_tag") == 1);
	
	$assert($reflect(MyConstdef.AAA).has_tag("constdef_value_tag"));
	$assert(!$reflect(MyConstdef.AAA).has_tag("nonexistent"));
	$assert($reflect(MyConstdef.AAA).get_tag("constdef_value_tag") == 2);

	$assert($reflect(MyConstdef.AAA).name == "AAA");
	$assert($reflect(MyConstdef.AAA).tags.len == 1);
	$assert($reflect(MyConstdef.AAA).tags[0] == "constdef_value_tag");

	$assert(MyEnum::has_tag("enum_tag"));
	$assert(MyEnum::get_tag("enum_tag") == -1);
	
	$assert($reflect(MyEnum.BBB).has_tag("enum_value_tag"));
	$assert(!$reflect(MyEnum.BBB).has_tag("nonexistent"));
	$assert($reflect(MyEnum.BBB).get_tag("enum_value_tag") == -2);
	$assert($reflect(MyEnum.BBB).name == "BBB");
	$assert($reflect(MyEnum.BBB).tags.len == 1);
	$assert($reflect(MyEnum.BBB).tags[0] == "enum_value_tag");

	
	$assert(MyEnum::members[0].name == "name");
	$assert(MyEnum::members[0].has_tag("enum_member_tag"));
	$assert(MyEnum::members[0].get_tag("enum_member_tag") == -1);
	$assert(MyEnum::members[0].tags.len == 1);
}
```