### PR TITLE
chore(docs): improve build steps from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Building `c3c` using Visual Studio Code is also supported when using the `CMake 
 
 4. Build the compiler:
    ```bash
-   cmake --build build
+   cmake --build build -j
    ```
 
 5. You should now have a `c3c` executable in the `build` directory. You can test it by compiling an example:
@@ -501,7 +501,7 @@ Building `c3c` using Visual Studio Code is also supported when using the `CMake 
    ./build/c3c compile resources/examples/hash.c3
    ```
 
-   *(Optional) To install the compiler globally: `sudo cmake --install build`*
+   *(Optional) To install the compiler globally: `sudo cmake --install build`* or to a PATH accessible location: `cmake --install build --prefix ~/.local`
 
 #### Compiling on NixOS
 

--- a/README.md
+++ b/README.md
@@ -501,7 +501,8 @@ Building `c3c` using Visual Studio Code is also supported when using the `CMake 
    ./build/c3c compile resources/examples/hash.c3
    ```
 
-   *(Optional) To install the compiler globally: `sudo cmake --install build`* or to a PATH accessible location: `cmake --install build --prefix ~/.local`
+   *(Optional) Install globally: `sudo cmake --install build`*
+   *Or install to `~/.local`: `cmake --install build --prefix ~/.local`*
 
 #### Compiling on NixOS
 


### PR DESCRIPTION
This PR add 2 tiny details to documentation:

- `-j` to compile faster 
```
________________________________________________________
Executed in   34.63 secs    fish           external
   usr time   32.93 secs  845.00 micros   32.93 secs
   sys time    1.55 secs  620.00 micros    1.55 secs
```
vs:
```
________________________________________________________
Executed in   12.14 secs    fish           external
   usr time   51.98 secs  642.00 micros   51.98 secs
   sys time    2.01 secs   40.00 micros    2.01 secs
```
---

- add optionally to install globally without needing `sudo` to the convention `~/.local/bin`

Tested on Arch latest from master :)