### PR TITLE
macOS: a second C3 dylib loaded into a non-C3 host would crash

### DIFF
--- a/lib/std/core/private/macho_runtime.c3
+++ b/lib/std/core/private/macho_runtime.c3
@@ -152,7 +152,6 @@ enum StartupState
 	INIT,
 	RUN_CTORS,
 	READ_DYLIB,
-	RUN_DYLIB_CTORS,
 	RUN_DTORS,
 	SHUTDOWN
 }
@@ -222,18 +221,12 @@ struct TypeId
 
 fn void dl_reg_callback(MachHeader* mh, sz vmaddr_slide)
 {
-	sz size;
-	assert(runtime_state == INIT || runtime_state == READ_DYLIB, "State was %s", runtime_state);
+	assert(runtime_state == INIT, "State was %s", runtime_state);
 	foreach (&dm : find_segment_section_body(mh, vmaddr_slide, "__DATA", "__c3_dynamic", DynamicMethod))
 	{
 		TypeId* type = dm.type;
 		dm.next = type.dtable;
 		type.dtable = dm;
-		DynamicMethod* m = dm;
-		while (m)
-		{
-			m = m.next;
-		}
 	}
 	foreach (&cb : find_segment_section_body(mh, vmaddr_slide, "__DATA", "__c3dtor", Callback))
 	{
@@ -243,15 +236,4 @@ fn void dl_reg_callback(MachHeader* mh, sz vmaddr_slide)
 	{
 		append_xxlizer(&ctor_first, cb);
 	}
-	if (runtime_state != READ_DYLIB) return;
-	runtime_state = RUN_DYLIB_CTORS;
-	Callback* ctor = ctor_first;
-	ctor_first = null;
-	while (ctor)
-	{
-		ctor.xtor();
-		ctor = ctor.next;
-	}
-	assert(runtime_state == RUN_DYLIB_CTORS);
-	runtime_state = READ_DYLIB;
 }

--- a/lib/std/core/private/macho_runtime.c3
+++ b/lib/std/core/private/macho_runtime.c3
@@ -92,7 +92,7 @@ fn Section64*? find_section(SegmentCommand64* command, char* sectname)
 	return NOT_FOUND~;
 }
 
-macro find_segment_section_body(MachHeader* header, char* segname, char* sectname, $Type)
+macro find_segment_section_body(MachHeader* header, sz vmaddr_slide, char* segname, char* sectname, $Type)
 {
 
 	Section64*? section = find_section(find_segment(header, segname), sectname);
@@ -100,13 +100,18 @@ macro find_segment_section_body(MachHeader* header, char* segname, char* sectnam
 	{
 		return ($Type[]){};
 	}
-	$Type* ptr = (void*)header + section.offset;
+	$Type* ptr = (void*)(uptr)(section.addr + (ulong)vmaddr_slide);
 	return ptr[:section.size / $Type::size];
 }
 
-alias DyldCallback = fn void (MachHeader* mh, sz vmaddr_slide);
+extern char __dso_handle;
 
-extern fn void _dyld_register_func_for_add_image(DyldCallback);
+fn sz image_slide(MachHeader* header)
+{
+	SegmentCommand64*? text = find_segment(header, "__TEXT");
+	if (catch text) return 0;
+	return (sz)((uptr)header - (uptr)text.vmaddr);
+}
 
 
 struct DlInfo
@@ -161,7 +166,8 @@ fn void runtime_startup() @public @export("__c3_runtime_startup")
 {
 	if (runtime_state != NOT_STARTED) return;
 	runtime_state = INIT;
-	_dyld_register_func_for_add_image(&dl_reg_callback);
+	MachHeader* self = (MachHeader*)&__dso_handle;
+	dl_reg_callback(self, image_slide(self));
 	assert(runtime_state == INIT);
 	runtime_state = RUN_CTORS;
 	Callback* ctor = ctor_first;
@@ -218,7 +224,7 @@ fn void dl_reg_callback(MachHeader* mh, sz vmaddr_slide)
 {
 	sz size;
 	assert(runtime_state == INIT || runtime_state == READ_DYLIB, "State was %s", runtime_state);
-	foreach (&dm : find_segment_section_body(mh, "__DATA", "__c3_dynamic", DynamicMethod))
+	foreach (&dm : find_segment_section_body(mh, vmaddr_slide, "__DATA", "__c3_dynamic", DynamicMethod))
 	{
 		TypeId* type = dm.type;
 		dm.next = type.dtable;
@@ -229,11 +235,11 @@ fn void dl_reg_callback(MachHeader* mh, sz vmaddr_slide)
 			m = m.next;
 		}
 	}
-	foreach (&cb : find_segment_section_body(mh, "__DATA", "__c3dtor", Callback))
+	foreach (&cb : find_segment_section_body(mh, vmaddr_slide, "__DATA", "__c3dtor", Callback))
 	{
 		append_xxlizer(&dtor_first, cb);
 	}
-	foreach (&cb : find_segment_section_body(mh, "__DATA", "__c3ctor", Callback))
+	foreach (&cb : find_segment_section_body(mh, vmaddr_slide, "__DATA", "__c3ctor", Callback))
 	{
 		append_xxlizer(&ctor_first, cb);
 	}

--- a/resources/examples/dynlib-test/add.c3
+++ b/resources/examples/dynlib-test/add.c3
@@ -1,4 +1,4 @@
-import std;
+import std, libc;
 struct Foo(Printable)
 {
 	int a;
@@ -24,6 +24,10 @@ fn void record(char c)
 fn void init_a() @init(100) { record('A'); }
 fn void init_b() @init(200) { record('B'); init_value = 42; }
 
+fn void init_x() @init
+{
+	libc::puts("Init x");
+}
 fn void shutdown() @finalizer
 {
 	io::printn("add: finalizer ran");

--- a/resources/examples/dynlib-test/add.c3
+++ b/resources/examples/dynlib-test/add.c3
@@ -9,6 +9,26 @@ fn sz? Foo.to_format(&self, Formatter* f) @dynamic
 	return f.printf("Foo[%d]", self.a);
 }
 
+// Runtime-init state, read back by the host through the getters below.
+int init_value;
+char[8] init_order;
+int order_len;
+
+fn void record(char c)
+{
+	init_order[order_len] = c;
+	order_len++;
+}
+
+// Lower priority runs first, so the host must observe "AB".
+fn void init_a() @init(100) { record('A'); }
+fn void init_b() @init(200) { record('B'); init_value = 42; }
+
+fn void shutdown() @finalizer
+{
+	io::printn("add: finalizer ran");
+}
+
 fn int add(int a, int b) @export("adder")
 {
 	io::printn("In adder");
@@ -16,3 +36,6 @@ fn int add(int a, int b) @export("adder")
 	io::printfn("Print foo: %s", x);
 	return a + b;
 }
+
+fn int get_init_value() @export("add_init_value") { return init_value; }
+fn char* get_init_order() @export("add_init_order") { return &init_order[0]; }

--- a/resources/examples/dynlib-test/add2.c3
+++ b/resources/examples/dynlib-test/add2.c3
@@ -1,4 +1,4 @@
-import std;
+import std, libc;
 struct Bar (Printable)
 {
 	int b;
@@ -7,6 +7,11 @@ struct Bar (Printable)
 fn sz? Bar.to_format(&self, Formatter* f) @dynamic
 {
 	return f.printf("Bar[%d]", self.b);
+}
+
+fn void init_x2() @init
+{
+	libc::puts("Init x2");
 }
 
 fn int adder2(int a, int b) @export("adder2")

--- a/resources/examples/dynlib-test/add2.c3
+++ b/resources/examples/dynlib-test/add2.c3
@@ -1,0 +1,15 @@
+import std;
+struct Bar (Printable)
+{
+	int b;
+}
+
+fn sz? Bar.to_format(&self, Formatter* f) @dynamic
+{
+	return f.printf("Bar[%d]", self.b);
+}
+
+fn int adder2(int a, int b) @export("adder2")
+{
+	return a + b;
+}

--- a/resources/examples/dynlib-test/add2.c3
+++ b/resources/examples/dynlib-test/add2.c3
@@ -11,5 +11,8 @@ fn sz? Bar.to_format(&self, Formatter* f) @dynamic
 
 fn int adder2(int a, int b) @export("adder2")
 {
+	// Exercise add2's own @dynamic registration; host greps for "Bar[10]".
+	Bar y = { a };
+	io::printfn("Print bar: %s", y);
 	return a + b;
 }

--- a/resources/examples/dynlib-test/test_multi.c
+++ b/resources/examples/dynlib-test/test_multi.c
@@ -1,11 +1,20 @@
-// Regression test: load two independently built C3 dynamic libraries into the
-// same (non-C3) host via dlopen. Each .dylib/.so carries its own C3 runtime, so
-// the second one's startup must initialise only its own image. Before that fix,
-// loading the second C3 library crashed on macOS in the dyld add-image hook.
+// Regression test: dlopen two independently built C3 dynamic libraries into one
+// non-C3 host. Each carries its own C3 runtime, so the second must initialise
+// only its own image -- this used to crash on macOS in the dyld add-image hook.
+//
+// Also checks @init priority + side-effects, @dynamic dispatch, and @finalizer
+// execution. The workload runs in a forked child so the parent can read its full
+// stdout, including output from C3 finalizers during exit().
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
 #include <dlfcn.h>
+#include <sys/wait.h>
 
 typedef int (*adder_fn)(int, int);
+typedef int (*int_fn)(void);
+typedef char *(*str_fn)(void);
 
 static void *load(const char *path)
 {
@@ -14,7 +23,7 @@ static void *load(const char *path)
 	return h;
 }
 
-int main(void)
+static int workload(void)
 {
 #if defined(__APPLE__)
 	const char *p1 = "./add.dylib", *p2 = "./add2.dylib";
@@ -24,14 +33,83 @@ int main(void)
 
 	void *h1 = load(p1);
 	if (!h1) return 1;
-	adder_fn adder = (adder_fn)dlsym(h1, "adder");
+	adder_fn adder  = (adder_fn)dlsym(h1, "adder");
+	int_fn   ivalue = (int_fn)dlsym(h1, "add_init_value");
+	str_fn   iorder = (str_fn)dlsym(h1, "add_init_order");
 
 	// The second C3 library is the one that used to crash on load.
 	void *h2 = load(p2);
 	if (!h2) return 1;
 	adder_fn adder2 = (adder_fn)dlsym(h2, "adder2");
 
-	if (!adder || !adder2) return 1;
-	if (adder(1, 4) != 5 || adder2(10, 20) != 30) return 1;
+	if (!adder || !adder2 || !ivalue || !iorder) {
+		fprintf(stderr, "missing symbol\n");
+		return 1;
+	}
+
+	if (adder(1, 4) != 5 || adder2(10, 20) != 30) {
+		fprintf(stderr, "wrong result\n");
+		return 1;
+	}
+
+	if (ivalue() != 42) {
+		fprintf(stderr, "init_value = %d, expected 42\n", ivalue());
+		return 1;
+	}
+
+	// @init(100) runs before @init(200) => "AB".
+	if (strcmp(iorder(), "AB") != 0) {
+		fprintf(stderr, "init_order = \"%s\", expected \"AB\"\n", iorder());
+		return 1;
+	}
+
+	return 0;
+}
+
+int main(void)
+{
+	int fds[2];
+	if (pipe(fds) != 0) { perror("pipe"); return 1; }
+
+	pid_t pid = fork();
+	if (pid < 0) { perror("fork"); return 1; }
+
+	if (pid == 0) {
+		// Exit normally so C3 finalizers run and their output reaches the pipe.
+		close(fds[0]);
+		dup2(fds[1], STDOUT_FILENO);
+		close(fds[1]);
+		exit(workload());
+	}
+
+	// Parent: drain the child's stdout, then check exit status + markers.
+	close(fds[1]);
+	char buf[4096];
+	size_t total = 0;
+	ssize_t n;
+	while (total < sizeof(buf) - 1 &&
+	       (n = read(fds[0], buf + total, sizeof(buf) - 1 - total)) > 0) {
+		total += (size_t)n;
+	}
+	buf[total] = '\0';
+	close(fds[0]);
+
+	int status = 0;
+	waitpid(pid, &status, 0);
+
+	fputs(buf, stdout); // surface the child's output for CI logs
+
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		fprintf(stderr, "workload failed (status %d)\n", status);
+		return 1;
+	}
+	if (!strstr(buf, "Bar[10]")) {
+		fprintf(stderr, "add2 @dynamic dispatch missing\n");
+		return 1;
+	}
+	if (!strstr(buf, "add: finalizer ran")) {
+		fprintf(stderr, "finalizer did not run\n");
+		return 1;
+	}
 	return 0;
 }

--- a/resources/examples/dynlib-test/test_multi.c
+++ b/resources/examples/dynlib-test/test_multi.c
@@ -1,0 +1,37 @@
+// Regression test: load two independently built C3 dynamic libraries into the
+// same (non-C3) host via dlopen. Each .dylib/.so carries its own C3 runtime, so
+// the second one's startup must initialise only its own image. Before that fix,
+// loading the second C3 library crashed on macOS in the dyld add-image hook.
+#include <stdio.h>
+#include <dlfcn.h>
+
+typedef int (*adder_fn)(int, int);
+
+static void *load(const char *path)
+{
+	void *h = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+	if (!h) fprintf(stderr, "dlopen %s failed: %s\n", path, dlerror());
+	return h;
+}
+
+int main(void)
+{
+#if defined(__APPLE__)
+	const char *p1 = "./add.dylib", *p2 = "./add2.dylib";
+#else
+	const char *p1 = "./add.so", *p2 = "./add2.so";
+#endif
+
+	void *h1 = load(p1);
+	if (!h1) return 1;
+	adder_fn adder = (adder_fn)dlsym(h1, "adder");
+
+	// The second C3 library is the one that used to crash on load.
+	void *h2 = load(p2);
+	if (!h2) return 1;
+	adder_fn adder2 = (adder_fn)dlsym(h2, "adder2");
+
+	if (!adder || !adder2) return 1;
+	if (adder(1, 4) != 5 || adder2(10, 20) != 30) return 1;
+	return 0;
+}

--- a/scripts/tools/ci_tests.sh
+++ b/scripts/tools/ci_tests.sh
@@ -152,6 +152,19 @@ run_dynlib_tests() {
     cd "$MY_WORK_DIR"
     run_c3c -vv dynamic-lib "$ROOT_DIR/resources/examples/dynlib-test/add.c3" -o add
 
+    # Regression: two independently built C3 dynamic libraries loaded into one
+    # (non-C3) host via dlopen. Each carries its own runtime, so the second's
+    # startup must initialise only its own image -- this used to crash on macOS.
+    if [[ "$OS_MODE" == "mac" || "$OS_MODE" == "linux" ]]; then
+        run_c3c -vv dynamic-lib "$ROOT_DIR/resources/examples/dynlib-test/add2.c3" -o add2
+        if [[ "$OS_MODE" == "mac" ]]; then
+            cc "$ROOT_DIR/resources/examples/dynlib-test/test_multi.c" -o multi
+        else
+            cc "$ROOT_DIR/resources/examples/dynlib-test/test_multi.c" -ldl -o multi
+        fi
+        ./multi
+    fi
+
     if [[ "$OS_MODE" == "windows" ]]; then
         run_c3c -vv compile-run "$ROOT_DIR/resources/examples/dynlib-test/test.c3" -l "add.lib"
     elif [[ "$OS_MODE" == "mac" ]]; then


### PR DESCRIPTION
A process-global dyld add-image hook walked every loaded image and mutated each one's `__c3ctor`/`__c3dtor`/`__c3_dynamic` tables, assuming a single C3 runtime per process; with two C3 dylibs in one host the second hook walked the first's image and segfaulted. Section pointers were also derived from the file offset instead of `vmaddr + slide`.

Initialise only our own image via `__dso_handle` (as ELF does with `.init_array`) and address sections by `section.addr + vmaddr_slide`.

Also I've spend some time to investigate if code in 7736ab391e74cf395884bd6fad695b55ca20a9f8 is even needed - looks like it's not; so I've written number of tests for both linux/macOS that tests this functionality in-depth eadd583ed35c44baa972f3480f5fa1806df11a55 on both linux and macOS.

Closes #3298