### PR TITLE
docgen: varargs #3337

### DIFF
--- a/resources/docs.html
+++ b/resources/docs.html
@@ -1461,28 +1461,7 @@
 			});
 		}
 
-		function preprocessDecl(decl) {
-			if (!decl) return;
-			const fixMembers = (members) => {
-				if (!members) return;
-				members.forEach(m => {
-					if (m.is_vararg && m.type && m.type.name && m.type.name.endsWith('[]')) {
-						m.type.name = m.type.name.slice(0, -2) + '...';
-					}
-					if (m.members) fixMembers(m.members);
-					if (m.params) fixMembers(m.params);
-				});
-			};
-			fixMembers(decl.members);
-			if (decl.variants) {
-				decl.variants.forEach(v => {
-					if (v.decl) preprocessDecl(v.decl);
-				});
-			}
-		}
-
 		function addOrMergeDeclaration(decl) {
-			preprocessDecl(decl);
 			const cleanDecl = { ...decl };
 			delete cleanDecl.targetName;
 			const declJson = JSON.stringify(cleanDecl);
@@ -2196,6 +2175,10 @@
 						return `${selfType} <span class="c3-variable">${m.is_ref ? '&' : ''}self</span>`;
 					}
 					return `<span class="c3-variable">${m.is_ref ? '&' : ''}self</span>`;
+				}
+				const isUntypedVararg = m.is_vararg && m.type && m.type.name === 'any...';
+				if (isUntypedVararg) {
+					return `<span class="c3-variable">${m.name || ''}...</span>`;
 				}
 				const type = renderTypeName(m.type);
 				const name = m.name ? ` <span class="c3-variable">${m.is_ref ? '&' : ''}${m.name}</span>` : '';

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -392,13 +392,20 @@ static void print_doc_type(FILE *file, Module *module, TypeInfo *type, bool is_v
 					break;
 				case TYPE_INFO_IDENTIFIER:
 				case TYPE_INFO_CT_IDENTIFIER:
-					if (ti->subtype == TYPE_COMPRESSED_SUB || ti->subtype == TYPE_COMPRESSED_SUBPTR || ti->subtype == TYPE_COMPRESSED_PTRSUB)
+					switch (ti->subtype)
 					{
-						declared_dims += 1;
-					}
-					else if (ti->subtype == TYPE_COMPRESSED_SUBSUB)
-					{
-						declared_dims += 2;
+						case TYPE_COMPRESSED_SUB:
+						case TYPE_COMPRESSED_SUBPTR:
+						case TYPE_COMPRESSED_PTRSUB:
+							declared_dims += 1;
+							break;
+						case TYPE_COMPRESSED_SUBSUB:
+							declared_dims += 2;
+							break;
+						case TYPE_COMPRESSED_NONE:
+						case TYPE_COMPRESSED_PTR:
+						case TYPE_COMPRESSED_PTRPTR:
+							break;
 					}
 					ti = NULL;
 					break;

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -370,20 +370,67 @@ static void print_doc_type(FILE *file, Module *module, TypeInfo *type, bool is_v
 	}
 	fputs("{\"name\":\"", file);
 	scratch_buffer_clear();
-	emit_type_name_to_scratch(type);
-	const char *name = scratch_buffer_to_string();
-	if (is_vararg)
+	if (is_vararg && type->type)
 	{
-		size_t len = strlen(name);
-		if (len >= 2 && strcmp(name + len - 2, "[]") == 0)
+		int declared_dims = 0;
+		for (TypeInfo *ti = type; ti; )
 		{
-			if (len < 4 || strcmp(name + len - 4, "[][]") != 0)
+			switch (ti->kind)
 			{
-				scratch_buffer_append("[]");
-				name = scratch_buffer_to_string();
+				case TYPE_INFO_POINTER:
+					ti = ti->pointer;
+					break;
+				case TYPE_INFO_SLICE:
+					declared_dims++;
+					ti = ti->array.base;
+					break;
+				case TYPE_INFO_ARRAY:
+				case TYPE_INFO_INFERRED_ARRAY:
+				case TYPE_INFO_INFERRED_VECTOR:
+				case TYPE_INFO_VECTOR:
+					ti = ti->array.base;
+					break;
+				case TYPE_INFO_IDENTIFIER:
+				case TYPE_INFO_CT_IDENTIFIER:
+					if (ti->subtype == TYPE_COMPRESSED_SUB || ti->subtype == TYPE_COMPRESSED_SUBPTR || ti->subtype == TYPE_COMPRESSED_PTRSUB)
+					{
+						declared_dims += 1;
+					}
+					else if (ti->subtype == TYPE_COMPRESSED_SUBSUB)
+					{
+						declared_dims += 2;
+					}
+					ti = NULL;
+					break;
+				default:
+					ti = NULL;
+					break;
 			}
 		}
+
+		int resolved_dims = 0;
+		Type *rt = type->type;
+		while (rt && rt->type_kind == TYPE_SLICE)
+		{
+			resolved_dims++;
+			rt = rt->array.base;
+		}
+
+		Type *t = type->type;
+		if (resolved_dims > declared_dims && t->type_kind == TYPE_SLICE)
+		{
+			t = t->array.base;
+		}
+		scratch_buffer_append(t->name);
+		scratch_buffer_append("...");
 	}
+	else
+	{
+		emit_type_name_to_scratch(type);
+		if (is_vararg) scratch_buffer_append("...");
+	}
+
+	const char *name = scratch_buffer_to_string();
 	fputs(name, file);
 	fputs("\"", file);
 


### PR DESCRIPTION
Example:

for untyped varargs the json prints:
```json
"type": {
  "name": "any..."
 },
```
and the docs.html template shows `, argname...)`

And to clarify, the docs.html template javascript, when it sees an `any...` it assumes it's an untyped vararg and replaces it.

---

for typed varargs the json prints
```json
"type": {
  "name": "Type...",
},
```
and the docs.html template shows `, Type... argname)`



https://github.com/c3lang/c3c/issues/3337

---

attached generated docs.html: [docs.html](https://github.com/user-attachments/files/29235418/docs.html)
