### PR TITLE
lib/std/libc/os/posix.c3: fix Sigaction for DARWIN

### DIFF
--- a/lib/std/libc/os/posix.c3
+++ b/lib/std/libc/os/posix.c3
@@ -43,12 +43,12 @@ struct Sigaction
 		SigActionFunction   sa_sigaction;
 	}
 
-    CInt       sa_flags @if(env::DARWIN || env::BSD_FAMILY );
-    Sigset_t   sa_mask  @if(env::DARWIN || env::BSD_FAMILY);
+	CInt       sa_flags @if(env::BSD_FAMILY);
+	Sigset_t   sa_mask  @if(env::BSD_FAMILY);
 
-    Sigset_t   sa_mask     @if(env::LINUX || env::ANDROID || env::EMSCRIPTEN);
-    CInt       sa_flags    @if(env::LINUX || env::EMSCRIPTEN);
-    void*      sa_restorer @if(env::LINUX || env::ANDROID || env::EMSCRIPTEN);
+	Sigset_t   sa_mask     @if(env::LINUX || env::DARWIN  || env::ANDROID || env::EMSCRIPTEN);
+	CInt       sa_flags    @if(env::LINUX || env::DARWIN  || env::EMSCRIPTEN);
+	void*      sa_restorer @if(env::LINUX || env::ANDROID || env::EMSCRIPTEN);
 }
 
 extern fn CInt setpriority(CInt which, CInt who, CInt prio);

--- a/lib/std/libc/os/posix.c3
+++ b/lib/std/libc/os/posix.c3
@@ -27,8 +27,8 @@ const CUInt SA_RESTART       = env::LINUX || env::ANDROID ? 0x10000000 : 0x0002;
 const CUInt SA_RESETHAND     = env::LINUX || env::ANDROID ? 0x80000000 : 0x0004;
 const CUInt SA_SIGINFO       = env::LINUX || env::ANDROID ? 0x00000004 : 0x0040;
 
-alias Sigset_t @if((env::DARWIN || env::BSD_FAMILY) && !env::NETBSD) = uint;
-alias Sigset_t @if(env::NETBSD) = uint[4];
+alias Sigset_t @if(env::DARWIN || env::OPENBSD) = uint;
+alias Sigset_t @if(env::NETBSD || env::FREEBSD) = uint[4];
 alias Sigset_t @if(env::LINUX) = ulong[16];
 alias Sigset_t @if(env::EMSCRIPTEN) = uint[2];
 alias Sigset_t @if(env::ANDROID) = ulong;

--- a/lib/std/libc/os/posix.c3
+++ b/lib/std/libc/os/posix.c3
@@ -43,12 +43,12 @@ struct Sigaction
 		SigActionFunction   sa_sigaction;
 	}
 
-	CInt       sa_flags @if(env::BSD_FAMILY);
-	Sigset_t   sa_mask  @if(env::BSD_FAMILY);
+	CInt     sa_flags @if(env::FREEBSD);
+	Sigset_t sa_mask  @if(env::FREEBSD);
 
-	Sigset_t   sa_mask     @if(env::LINUX || env::DARWIN  || env::ANDROID || env::EMSCRIPTEN);
-	CInt       sa_flags    @if(env::LINUX || env::DARWIN  || env::EMSCRIPTEN);
-	void*      sa_restorer @if(env::LINUX || env::ANDROID || env::EMSCRIPTEN);
+	Sigset_t sa_mask     @if(env::LINUX || env::DARWIN  || env::EMSCRIPTEN || env::OPENBSD || env::NETBSD || env::ANDROID);
+	CInt     sa_flags    @if(env::LINUX || env::DARWIN  || env::EMSCRIPTEN || env::OPENBSD || env::NETBSD);
+	void*    sa_restorer @if(env::LINUX || env::ANDROID || env::EMSCRIPTEN);
 }
 
 extern fn CInt setpriority(CInt which, CInt who, CInt prio);


### PR DESCRIPTION
macos: https://github.com/apple/darwin-xnu/blob/main/bsd/sys/signal.h#L386
freebsd: https://man.freebsd.org/cgi/man.cgi?sigaction
openbsd: https://man.openbsd.org/sigaction.2
netbsd: https://man.netbsd.org/NetBSD-10.1/sigaction.2
posix: https://man7.org/linux/man-pages/man2/sigaction.2.html
android: https://android.googlesource.com/platform/bionic/+/main/libc/include/bits/signal_types.h#104

also corrected `Sigset_t` for freebsd