### PR TITLE
Add segfault handler on linux to prevent hangs caused by systemd-coredump

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -11,6 +11,9 @@
 extern bool SetConsoleCP(uint32_t codepage);
 extern bool SetConsoleOutputCP(uint32_t codepage);
 #endif
+#ifdef __linux__
+#include <signal.h>
+#endif
 
 bool debug_log = false;
 
@@ -27,6 +30,13 @@ static void cleanup()
 	symtab_destroy();
 	memory_release();
 }
+
+#ifdef __linux__
+NORETURN void segfault_handler(int signal)
+{
+	FATAL_ERROR("Segmentation Fault");
+}
+#endif
 
 const char *compiler_exe_name;
 
@@ -45,6 +55,9 @@ int main_real(int argc, const char *argv[])
 	// Set the console input and output codepage to utf8 to handle utf8 text correctly
 	SetConsoleCP(65001);
 	SetConsoleOutputCP(65001);
+#endif
+#ifdef __linux__
+	signal(SIGSEGV, segfault_handler);
 #endif
 	bench_begin();
 


### PR DESCRIPTION
Currently when the compiler crashes on many linux distros it will silently hang for up to a minute as the core dump is generated, this PR makes it print a proper error message and exit immediately to prevent confusion and make testing crashes faster.

tested using the example from #3358

before:
```console
$ time c3c compile-run 3358.c3
________________________________________________________
Executed in   48.13 secs    fish           external
   usr time    0.10 secs    1.27 millis    0.10 secs
   sys time    7.54 secs    0.06 millis    7.54 secs

fish: Job 1, 'time c3c compile-run 3358.c3' terminated by signal SIGSEGV (Address boundary error)
```
after:
```console
$ time c3c compile-run 3358.c3
⚠️ The compiler encountered an unexpected error: "Segmentation Fault".

- Function: segfault_handler(...)
- Source file: /build/f4pxfrxwsd94z838hhqzj6wkhlnvrp0k-source/src/main.c:37

🙏 Please consider taking the time to file an issue on GitHub (https://github.com/c3lang/c3c/issues/new), so that we can get it fixed.
________________________________________________________
Executed in  421.61 millis    fish           external
   usr time  308.86 millis    0.59 millis  308.27 millis
   sys time  109.73 millis    1.88 millis  107.85 millis
```