### PR TITLE
Set CPU for AVR architecture in target.c

### DIFF
--- a/src/compiler/target.c
+++ b/src/compiler/target.c
@@ -2307,6 +2307,7 @@ void target_setup(BuildTarget *build_target)
 			break;
 		case ARCH_TYPE_AVR:
 			compiler.platform.abi = ABI_AVR;
+			compiler.platform.cpu = compiler.build.cpu;
 			compiler.platform.tls_supported = false;
 			break;
 		case ARCH_TYPE_WASM32:


### PR DESCRIPTION
Fixes #3366.

CPU setting should come from the project.json "cpu" property for the given target.