### PR TITLE
crash fix: support ASM_ARG_ADDR for aarch64

### DIFF
--- a/src/compiler/codegen_asm.c
+++ b/src/compiler/codegen_asm.c
@@ -115,7 +115,42 @@ static inline void codegen_create_aarch64_arg(AsmInlineBlock *block, unsigned in
 			}
 			return;
 		case ASM_ARG_ADDR:
-			TODO
+			scratch_buffer_append_char('[');
+            if (arg->base)
+            {
+                codegen_create_aarch64_arg(block, input_offset, exprptr(arg->base));
+            }
+            if (arg->offset)
+            {
+                scratch_buffer_append_char(',');
+                if (arg->neg_offset) scratch_buffer_append_char('-');
+                scratch_buffer_append_unsigned_int(arg->offset);
+            }
+            if (arg->idx)
+            {
+                scratch_buffer_append_char(',');
+                codegen_create_aarch64_arg(block, input_offset, exprptr(arg->idx));
+                scratch_buffer_append_char(',');
+                switch (arg->offset_type)
+                {
+                    case ASM_SCALE_1:
+                        scratch_buffer_append("lsl #0");
+                        break;
+                    case ASM_SCALE_2:
+                        scratch_buffer_append("lsl #1");
+                        break;
+                    case ASM_SCALE_4:
+                        scratch_buffer_append("lsl #2");
+                        break;
+                    case ASM_SCALE_8:
+                        scratch_buffer_append("lsl #3");
+                        break;
+                    default:
+                        UNREACHABLE_VOID
+                }
+            }
+			scratch_buffer_append_char(']');
+            return;
 		case ASM_ARG_MEMADDR:
 			TODO
 	}


### PR DESCRIPTION
Fixes #3085.

# additional example
create `arg_mem.c3`:
```c3
fn int main()
{
    asm {
        nop;
        ldr $x0, [$x1];            
        ldr $x0, [$x1 + 5];
        ldr $x0, [$x1 - 5];
        ldr $x0, [$x1 + $x2];
        ldr $x0, [$x1 + $x2 * 8];
        nop;
    }

    return 0;
}
```
Compile with `c3c compile arg_mem.c3 --use-stdlib=no` (assuming aarch64 is the default target)
## before
fails to compile:
```
⚠️ The compiler encountered an unexpected error: "TODO reached".

- Function: codegen_create_aarch64_arg(...)

[...]
```

## after

compiles successfully. Running `objdump -d` on the resulting executable:

```
[...]

Disassembly of section __TEXT,__text:

0000000100000348 <_main>:
100000348: a9bf7bfd     stp     x29, x30, [sp, #-0x10]!
10000034c: 910003fd     mov     x29, sp
100000350: d503201f     nop
100000354: f9400020     ldr     x0, [x1]
100000358: f8405020     ldur    x0, [x1, #0x5]
10000035c: f85fb020     ldur    x0, [x1, #-0x5]
100000360: f8626820     ldr     x0, [x1, x2]
100000364: f8627820     ldr     x0, [x1, x2, lsl #3]
100000368: d503201f     nop
10000036c: 2a1f03e0     mov     w0, wzr
100000370: a8c17bfd     ldp     x29, x30, [sp], #0x10
100000374: d65f03c0     ret
```

No more crash, and the above sequence of assembly instructions between the two `nop`s is exactly what we would expect. With these changes, aarch64 matches the ASM_ARG_ADDR support that x86 currently has.