### PR TITLE
Update README.md: Missing package for Ubuntu install

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Building `c3c` using Visual Studio Code is also supported when using the `CMake 
 #### Compiling on Linux
 
 1. Install required build dependencies using your distribution's package manager:
-   - **Ubuntu / Debian:** `sudo apt-get install cmake git clang libcurl4-openssl-dev`
+   - **Ubuntu / Debian:** `sudo apt-get install cmake git clang libcurl4-openssl-dev liblld-21`
    - **Fedora:** `sudo dnf install cmake clang git libcurl-devel`
    - **Arch Linux:** `sudo pacman -S curl clang cmake git`
    - **Void Linux:** `sudo xbps-install git cmake clang libcurl-devel`


### PR DESCRIPTION
I had to get liblld-21 to install, else the following:

-- LLVM was built with RTTI
-- Looking for static lld libraries in /usr/lib/llvm-21/lib;/usr/lib CMake Error at CMakeLists.txt:359 (find_library):
  Could not find LLD_COFF using the following names: lldCOFF.a, liblldCOFF.a,
  liblldCOFF.dylib, lldCOFF.lib, liblldCOFF.dll.a


-- Configuring incomplete, errors occurred!

this is on a stock install of Ubuntu 26.04, the new LTS