### PR TITLE
Add RFC 3986 url parse tests

### DIFF
--- a/lib/std/net/url.c3
+++ b/lib/std/net/url.c3
@@ -100,7 +100,6 @@ fn Url? parse(Allocator allocator, String url_string)
 			{
 				String[] userpass = userinfo.tsplit(":", 2);
 				username = userpass[0];
-				if (!username.len) return INVALID_USER~;
 				url.username = decode(allocator, username, HOST) ?? INVALID_USER~!;
 				if (userpass.len > 1) url.password = decode(allocator, userpass[1], USERPASS) ?? INVALID_PASSWORD~!;
 			};
@@ -185,7 +184,7 @@ fn sz? Url.to_format(&self, Formatter* f) @dynamic
 	if (self.host.len > 0) len += f.print("//")!;
 
 	// Add username and password if they exist
-	if (self.username)
+	if (self.username || self.password)
 	{
 		@stack_mem(64; Allocator smem)
 		{

--- a/lib/std/net/url.c3
+++ b/lib/std/net/url.c3
@@ -62,12 +62,19 @@ fn Url? parse(Allocator allocator, String url_string)
 	if (!url_string) return EMPTY~;
 	Url url = { .allocator = allocator };
 
-	// Parse scheme
-	if (try pos = url_string.index_of("://"))
+	// Parse scheme, an authority is only present when introduced by "//"
+	bool has_authority;
+	if (url_string.starts_with("//"))
+	{
+		url_string = url_string[2..];
+		has_authority = true;
+	}
+	else if (try pos = url_string.index_of("://"))
 	{
 		if (!pos) return INVALID_SCHEME~;
 		url.scheme = url_string[:pos].copy(allocator);
 		url_string = url_string[url.scheme.len + 3 ..];
+		has_authority = true;
 	}
 	else if (try pos = url_string.index_of(":"))
 	{
@@ -79,7 +86,7 @@ fn Url? parse(Allocator allocator, String url_string)
 	}
 
 	// Parse host, port
-	if (url.scheme != "urn")
+	if (has_authority)
 	{
 		sz authority_end = url_string.index_of_chars("/?#") ?? url_string.len;
 		String authority = url_string[:authority_end];
@@ -174,8 +181,8 @@ fn sz? Url.to_format(&self, Formatter* f) @dynamic
 	{
 		len += f.print(self.scheme)!;
 		len += f.print(":")!;
-		if (self.host.len > 0) len += f.print("//")!;
 	}
+	if (self.host.len > 0) len += f.print("//")!;
 
 	// Add username and password if they exist
 	if (self.username)

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -15,6 +15,7 @@
 - `Rect.contains_point` is now exclusive on the maximum edge.
 - Add `Bounds` - a rectangular region stored as a `min` and `max` value, with all operations being inclusive along the boundary edge.
 - Experimental regex support.
+- Improved RFC 3986 compatibility.
 
 ### Fixes
 - Generic functions and values incorrectly would not require a prefix. #3374

--- a/test/unit/stdlib/net/url.c3
+++ b/test/unit/stdlib/net/url.c3
@@ -500,3 +500,166 @@ fn void test_parse_ipv6_with_port_full()
 	assert(url.path == "/c=GB", "got '%s'", url.path);
 	assert(url.query == "objectClass=one", "got '%s'", url.query);
 }
+
+fn void test_parse_http_authority()
+{
+	Url url = url::parse(mem, "http://example.com")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.path == "", "got '%s'", url.path);
+}
+
+fn void test_parse_http_root()
+{
+	Url url = url::parse(mem, "http://example.com/")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.path == "/", "got '%s'", url.path);
+}
+
+fn void test_parse_http_full()
+{
+	Url url = url::parse(mem, "http://user:password@example.com:8080/path?query=value#fragment")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.port == 8080, "got '%d'", url.port);
+	assert(url.username == "user", "got '%s'", url.username);
+	assert(url.password == "password", "got '%s'", url.password);
+	assert(url.path == "/path", "got '%s'", url.path);
+	assert(url.query == "query=value", "got '%s'", url.query);
+	assert(url.fragment == "fragment", "got '%s'", url.fragment);
+}
+
+fn void test_parse_http_default_port()
+{
+	Url url = url::parse(mem, "http://example.com:80/")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.port == 80, "got '%d'", url.port);
+	assert(url.path == "/", "got '%s'", url.path);
+}
+
+fn void test_parse_http_port()
+{
+	Url url = url::parse(mem, "http://example.com:8080/")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.port == 8080, "got '%d'", url.port);
+	assert(url.path == "/", "got '%s'", url.path);
+}
+
+fn void test_parse_encoded_dot()
+{
+	Url url = url::parse(mem, "http://example.com/%2E/")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.path == "/./", "got '%s'", url.path);
+}
+
+fn void test_parse_dotdot()
+{
+	Url url = url::parse(mem, "http://example.com/..")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.path == "/..", "got '%s'", url.path);
+}
+
+fn void test_parse_query()
+{
+	Url url = url::parse(mem, "http://example.com/?q=string")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.path == "/", "got '%s'", url.path);
+	assert(url.query == "q=string", "got '%s'", url.query);
+}
+
+fn void test_parse_empty_userinfo()
+{
+	Url url = url::parse(mem, "http://@example.com/")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.username == "", "got '%s'", url.username);
+	assert(url.path == "/", "got '%s'", url.path);
+}
+
+fn void test_parse_empty_user_password()
+{
+	Url url = url::parse(mem, "http://:@example.com/")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.username == "", "got '%s'", url.username);
+	assert(url.password == "", "got '%s'", url.password);
+	assert(url.path == "/", "got '%s'", url.path);
+}
+
+fn void test_parse_trailing_dot_host()
+{
+	Url url = url::parse(mem, "http://example.com./")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "example.com.", "got '%s'", url.host);
+	assert(url.path == "/", "got '%s'", url.path);
+}
+
+fn void test_parse_ipv6_loopback()
+{
+	Url url = url::parse(mem, "http://[::1]/")!!;
+	defer url.free();
+
+	assert(url.scheme == "http", "got '%s'", url.scheme);
+	assert(url.host == "[::1]", "got '%s'", url.host);
+	assert(url.path == "/", "got '%s'", url.path);
+}
+
+fn void test_parse_network_path()
+{
+	Url url = url::parse(mem, "//example.com")!!;
+	defer url.free();
+
+	assert(url.scheme == "", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.path == "", "got '%s'", url.path);
+}
+
+fn void test_parse_network_path_userinfo()
+{
+	Url url = url::parse(mem, "//user@example.com/path?a=b")!!;
+	defer url.free();
+
+	assert(url.scheme == "", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.username == "user", "got '%s'", url.username);
+	assert(url.path == "/path", "got '%s'", url.path);
+	assert(url.query == "a=b", "got '%s'", url.query);
+}
+
+fn void test_parse_network_path_port()
+{
+	Url url = url::parse(mem, "//example.com:80")!!;
+	defer url.free();
+
+	assert(url.scheme == "", "got '%s'", url.scheme);
+	assert(url.host == "example.com", "got '%s'", url.host);
+	assert(url.port == 80, "got '%d'", url.port);
+}

--- a/test/unit/stdlib/net/url.c3
+++ b/test/unit/stdlib/net/url.c3
@@ -506,9 +506,9 @@ fn void test_parse_http_authority()
 	Url url = url::parse(mem, "http://example.com")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.path == "", "got '%s'", url.path);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com");
+	test::eq(url.path, "");
 }
 
 fn void test_parse_http_root()
@@ -516,9 +516,9 @@ fn void test_parse_http_root()
 	Url url = url::parse(mem, "http://example.com/")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.path == "/", "got '%s'", url.path);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com");
+	test::eq(url.path, "/");
 }
 
 fn void test_parse_http_full()
@@ -526,14 +526,14 @@ fn void test_parse_http_full()
 	Url url = url::parse(mem, "http://user:password@example.com:8080/path?query=value#fragment")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.port == 8080, "got '%d'", url.port);
-	assert(url.username == "user", "got '%s'", url.username);
-	assert(url.password == "password", "got '%s'", url.password);
-	assert(url.path == "/path", "got '%s'", url.path);
-	assert(url.query == "query=value", "got '%s'", url.query);
-	assert(url.fragment == "fragment", "got '%s'", url.fragment);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com");
+	test::eq(url.port, 8080);
+	test::eq(url.username, "user");
+	test::eq(url.password, "password");
+	test::eq(url.path, "/path");
+	test::eq(url.query, "query=value");
+	test::eq(url.fragment, "fragment");
 }
 
 fn void test_parse_http_default_port()
@@ -541,10 +541,10 @@ fn void test_parse_http_default_port()
 	Url url = url::parse(mem, "http://example.com:80/")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.port == 80, "got '%d'", url.port);
-	assert(url.path == "/", "got '%s'", url.path);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com");
+	test::eq(url.port, 80);
+	test::eq(url.path, "/");
 }
 
 fn void test_parse_http_port()
@@ -552,10 +552,10 @@ fn void test_parse_http_port()
 	Url url = url::parse(mem, "http://example.com:8080/")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.port == 8080, "got '%d'", url.port);
-	assert(url.path == "/", "got '%s'", url.path);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com");
+	test::eq(url.port, 8080);
+	test::eq(url.path, "/");
 }
 
 fn void test_parse_encoded_dot()
@@ -563,9 +563,9 @@ fn void test_parse_encoded_dot()
 	Url url = url::parse(mem, "http://example.com/%2E/")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.path == "/./", "got '%s'", url.path);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com");
+	test::eq(url.path, "/./");
 }
 
 fn void test_parse_dotdot()
@@ -573,9 +573,9 @@ fn void test_parse_dotdot()
 	Url url = url::parse(mem, "http://example.com/..")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.path == "/..", "got '%s'", url.path);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com");
+	test::eq(url.path, "/..");
 }
 
 fn void test_parse_query()
@@ -583,10 +583,10 @@ fn void test_parse_query()
 	Url url = url::parse(mem, "http://example.com/?q=string")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.path == "/", "got '%s'", url.path);
-	assert(url.query == "q=string", "got '%s'", url.query);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com");
+	test::eq(url.path, "/");
+	test::eq(url.query, "q=string");
 }
 
 fn void test_parse_empty_userinfo()
@@ -594,10 +594,10 @@ fn void test_parse_empty_userinfo()
 	Url url = url::parse(mem, "http://@example.com/")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.username == "", "got '%s'", url.username);
-	assert(url.path == "/", "got '%s'", url.path);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com");
+	test::eq(url.username, "");
+	test::eq(url.path, "/");
 }
 
 fn void test_parse_empty_user_password()
@@ -605,11 +605,11 @@ fn void test_parse_empty_user_password()
 	Url url = url::parse(mem, "http://:@example.com/")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.username == "", "got '%s'", url.username);
-	assert(url.password == "", "got '%s'", url.password);
-	assert(url.path == "/", "got '%s'", url.path);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com");
+	test::eq(url.username, "");
+	test::eq(url.password, "");
+	test::eq(url.path, "/");
 }
 
 fn void test_parse_trailing_dot_host()
@@ -617,9 +617,9 @@ fn void test_parse_trailing_dot_host()
 	Url url = url::parse(mem, "http://example.com./")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "example.com.", "got '%s'", url.host);
-	assert(url.path == "/", "got '%s'", url.path);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "example.com.");
+	test::eq(url.path, "/");
 }
 
 fn void test_parse_ipv6_loopback()
@@ -627,9 +627,9 @@ fn void test_parse_ipv6_loopback()
 	Url url = url::parse(mem, "http://[::1]/")!!;
 	defer url.free();
 
-	assert(url.scheme == "http", "got '%s'", url.scheme);
-	assert(url.host == "[::1]", "got '%s'", url.host);
-	assert(url.path == "/", "got '%s'", url.path);
+	test::eq(url.scheme, "http");
+	test::eq(url.host, "[::1]");
+	test::eq(url.path, "/");
 }
 
 fn void test_parse_network_path()
@@ -637,9 +637,9 @@ fn void test_parse_network_path()
 	Url url = url::parse(mem, "//example.com")!!;
 	defer url.free();
 
-	assert(url.scheme == "", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.path == "", "got '%s'", url.path);
+	test::eq(url.scheme, "");
+	test::eq(url.host, "example.com");
+	test::eq(url.path, "");
 }
 
 fn void test_parse_network_path_userinfo()
@@ -647,11 +647,11 @@ fn void test_parse_network_path_userinfo()
 	Url url = url::parse(mem, "//user@example.com/path?a=b")!!;
 	defer url.free();
 
-	assert(url.scheme == "", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.username == "user", "got '%s'", url.username);
-	assert(url.path == "/path", "got '%s'", url.path);
-	assert(url.query == "a=b", "got '%s'", url.query);
+	test::eq(url.scheme, "");
+	test::eq(url.host, "example.com");
+	test::eq(url.username, "user");
+	test::eq(url.path, "/path");
+	test::eq(url.query, "a=b");
 }
 
 fn void test_parse_network_path_port()
@@ -659,7 +659,7 @@ fn void test_parse_network_path_port()
 	Url url = url::parse(mem, "//example.com:80")!!;
 	defer url.free();
 
-	assert(url.scheme == "", "got '%s'", url.scheme);
-	assert(url.host == "example.com", "got '%s'", url.host);
-	assert(url.port == 80, "got '%d'", url.port);
+	test::eq(url.scheme, "");
+	test::eq(url.host, "example.com");
+	test::eq(url.port, 80);
 }


### PR DESCRIPTION
@ManuLinares following up on our Discord chat: this PR adds RFC 3986 URL parse tests to `test/unit/stdlib/net/url.c3`, using cases from peer libraries (Ruby's `Addressable`, Go's `net/url`, Python's `urllib`)

Most pass, but 5 fail:

<table>
<tr>
 <th>Input
 <th>Expected
 <th>Result
 <th>Cause
<tr>
 <td><code>//example.com</code>
 <td><code>host='example.com'</code>, <code>path=''</code>
 <td><code>host=''</code>, <code>path='//example.com'</code>
 <td>authority is gated on <code>scheme != "urn"</code> instead of a leading <code>//</code>, so a schemeless <code>//host</code> is parsed as path
<tr>
 <td><code>//user@example.com/path?a=b</code>
 <td><code>username='user'</code>, <code>host='example.com'</code>, <code>path='/path'</code>
 <td><code>username=''</code>, <code>host=''</code>, <code>path='//user@example.com/path'</code>
 <td>same authority gate: no scheme means the <code>//</code> authority is never parsed
<tr>
 <td><code>//example.com:80</code>
 <td><code>host='example.com'</code>, <code>port=80</code>
 <td><code>host=''</code>, <code>port=0</code>, <code>path='//example.com:80'</code>
 <td>same authority gate
<tr>
 <td><code>http://@example.com/</code>
 <td><code>host='example.com'</code>, <code>username=''</code>
 <td>faults <code>INVALID_USER</code>
 <td>empty userinfo hits <code>if (!username.len) return INVALID_USER~</code>, but RFC 3986 §3.2.1 permits it
<tr>
 <td><code>http://:@example.com/</code>
 <td><code>host='example.com'</code>
 <td>faults <code>INVALID_USER</code>
 <td>same empty-userinfo guard (empty user and password)
</table>

Happy to send the fixes too if you'd rather they go in here