### PR TITLE
Change the c function to be invoked by _erff: erf -> erff

### DIFF
--- a/lib/std/math/math.c3
+++ b/lib/std/math/math.c3
@@ -928,7 +928,7 @@ extern fn double _erf(double x) @MathLibc("erf");
 extern fn double _lgamma(double x) @MathLibc("lgamma");
 extern fn double _tgamma(double x) @MathLibc("tgamma");
 
-extern fn float _erff(float x) @MathLibc("erf");
+extern fn float _erff(float x) @MathLibc("erff");
 extern fn float _lgammaf(float x) @MathLibc("lgammaf");
 extern fn float _tgammaf(float x) @MathLibc("tgammaf");
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -21,6 +21,7 @@
 - Timed `tcp::connect` always failed with `io::GENERAL_ERROR` instead of the real result.
 - Compile time struct with zeroed union member access causes compiler error #3382.
 - Generic methods checked before the generic type is fully registered.
+- Math function `_erff` invoked C `erf` function instead of `erff` function #3391
   
 ## 0.8.2 Change list
 


### PR DESCRIPTION
Closes: #3390

The `_erff` function was calling the C `erf` function (which expects a `double`) instead of `erff` function (which expects a `float`) which caused an erratic behaviour whenever a `float` was passed to the `erf` macro.