### PR TITLE
fix(compiler): fail when Emscripten compiler is missing

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -7,6 +7,7 @@
 - Tracking allocator can now accept cross-thread allocations.
 - Filter test backtraces #3368
 - Improved GDB compatibility for macros.
+- Fail when "emcc" is unavailable instead of falling back to the built-in wasm linker.
 
 ### Stdlib changes
 - LinkedList and Deque added a `prepend` method.

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -751,7 +751,10 @@ void compiler_compile(void)
 		{
 			const char *cc = compiler.build.cc ? compiler.build.cc : default_c_compiler();
 			if (!file_executable_in_path(cc)) system_linker_available = false;
-			if (compiler.platform.os == OS_TYPE_EMSCRIPTEN && !strstr(cc, "emcc")) system_linker_available = false;
+			if (compiler.platform.os == OS_TYPE_EMSCRIPTEN && (!file_executable_in_path(cc) || !strstr(cc, "emcc")))
+			{
+				error_exit("\"emscripten\" target requires Emscripten to be installed on your system; \"%s\" was not found.", cc);
+			}
 		}
 		bool use_system_linker = system_linker_available && (compiler.build.arch_os_target == default_target || compiler.platform.os == OS_TYPE_EMSCRIPTEN);
 		switch (compiler.build.linker_type)


### PR DESCRIPTION
Do not fall back to the builtin Wasm linker, which may not support target-specific linker options and runtime features.