### PR TITLE
fixes needed for building c3c with emcmake (wasm32-emscripten)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,8 @@ else()
     else()
         if (APPLE)
             add_link_options("-Wl,-S")
+        elseif (EMSCRIPTEN)
+            add_link_options("-Wl,--strip-all")
         else()
             # This covers Linux, BSD, and MinGW on Windows
             add_link_options("-s")
@@ -180,7 +182,9 @@ if(C3_WITH_LLVM)
 
     if(C3_FETCH_LLVM)
         # 1. Determine local platform ID
-        if (WIN32)
+        if (EMSCRIPTEN)
+            set(C3_LLVM_PLATFORM "wasm32-emscripten")
+        elseif (WIN32)
             if (CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64|aarch64" OR CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "ARM64|aarch64")
                 set(C3_LLVM_PLATFORM "windows-aarch64")
             else()
@@ -211,7 +215,8 @@ if(C3_WITH_LLVM)
         # 2. Determine if we want Debug or Release
         set(C3_LLVM_SUFFIX "")
         set(C3_LLVM_TYPE "Release")
-        if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        # WebAssembly debug LLVM builds are too large, so force the release LLVM even in Debug mode
+        if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT EMSCRIPTEN)
             set(C3_LLVM_SUFFIX "-dbg")
             set(C3_LLVM_TYPE "Debug")
         endif()
@@ -240,6 +245,9 @@ if(C3_WITH_LLVM)
         set(CMAKE_PREFIX_PATH ${llvm_dir} ${CMAKE_PREFIX_PATH})
         set(LLVM_DIR "${llvm_dir}/lib/cmake/llvm")
         set(LLD_DIR "${llvm_dir}/lib/cmake/lld")
+        if (NOT C3_LLD_INCLUDE_DIR)
+            set(C3_LLD_INCLUDE_DIR "${llvm_dir}/include")
+        endif()
 
         # TEST: For Windows, we might need to add the bin dir to prefix path for find_package to work well
         if (WIN32)
@@ -271,7 +279,7 @@ if(C3_WITH_LLVM)
             list(APPEND LLVM_LIBRARY_DIRS /opt/homebrew/lib)
         endif()
 
-        if (EXISTS /usr/lib)
+        if (EXISTS /usr/lib AND NOT EMSCRIPTEN)
             # Some systems (such as Alpine Linux) seem to put some of the relevant
             # LLVM files in /usr/lib, but this doesn't seem to be included in the
             # value of LLVM_LIBRARY_DIRS.
@@ -590,6 +598,10 @@ if(C3_AVR_DISABLE)
 	target_compile_definitions(c3c PRIVATE AVR_DISABLE)
 endif()
 
+if(EMSCRIPTEN)
+	target_compile_definitions(c3c PRIVATE ARM_DISABLE AARCH64_DISABLE RISCV_DISABLE X86_DISABLE)
+endif()
+
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
     # We are inside of a git repository so rebuilding the hash every time something changes.
     add_custom_command(
@@ -816,7 +828,6 @@ else()
         target_compile_options(c3c_wrappers PRIVATE -fno-rtti)
     endif()
     target_compile_options(c3c PRIVATE
-        -pthread
         -Wall
         -Werror
         -Wno-unknown-pragmas
@@ -826,7 +837,10 @@ else()
         -Wno-unused-parameter
         -Wno-char-subscripts
     )
-    target_link_options(c3c PRIVATE -pthread)
+    if (NOT EMSCRIPTEN)
+        target_compile_options(c3c PRIVATE -pthread)
+        target_link_options(c3c PRIVATE -pthread)
+    endif()
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "TinyCC")

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -751,7 +751,7 @@ void compiler_compile(void)
 		{
 			const char *cc = compiler.build.cc ? compiler.build.cc : default_c_compiler();
 			if (!file_executable_in_path(cc)) system_linker_available = false;
-			if (compiler.platform.os == OS_TYPE_EMSCRIPTEN && (!file_executable_in_path(cc) || !strstr(cc, "emcc")))
+			if (compiler.platform.os == OS_TYPE_EMSCRIPTEN && compiler.build.linker_type != LINKER_TYPE_BUILTIN && (!file_executable_in_path(cc) || !strstr(cc, "emcc")))
 			{
 				error_exit("\"emscripten\" target requires Emscripten to be installed on your system; \"%s\" was not found.", cc);
 			}

--- a/src/compiler/diagnostics.c
+++ b/src/compiler/diagnostics.c
@@ -121,11 +121,11 @@ static void print_error_type_at(SourceLoc *location, const char *message, PrintT
 		while (current[row_len] != '\n' && current[row_len]) row_len++;
 		if (row_len > max_lines_for_display)
 		{
-			eprintf(number_buffer_elided, row, max_lines_for_display - 1, current);
+			eprintf(number_buffer_elided, (int)row, max_lines_for_display - 1, current);
 		}
 		else
 		{
-			eprintf(number_buffer, row, row_len, current);
+			eprintf(number_buffer, (int)row, row_len, current);
 		}
 		row++;
 	}

--- a/src/compiler/llvm_codegen.c
+++ b/src/compiler/llvm_codegen.c
@@ -56,7 +56,9 @@ bool module_should_weaken(Module *module)
 
 static void gencontext_init(GenContext *context, Module *module, LLVMContextRef shared_context)
 {
+#ifndef __EMSCRIPTEN__
 	ASSERT(LLVMIsMultithreaded());
+#endif
 	memset(context, 0, sizeof(GenContext));
 
 	if (shared_context)

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -123,6 +123,7 @@
 	if (!debug_log) break; \
 	printf("-- INFO: "); printf(_string, ##__VA_ARGS__); printf("\n"); \
   } while (0)
+extern bool debug_log; //for emscripten c3c compilation
 #ifdef NDEBUG
 #define REMINDER(_string, ...) do {} while (0)
 #define DEBUG_LOG(_string, ...) do {} while(0)

--- a/src/utils/vmem.c
+++ b/src/utils/vmem.c
@@ -97,7 +97,8 @@ static inline void* mmap_allocate(Vmem *vmem, size_t to_allocate)
 	return ptr;
 }
 
-size_t max = 0x10000000;
+// 32-bit / WASM has a 2GB total address limit; cap per-arena virtual memory to 128MB.
+size_t max = sizeof(size_t) == 4 ? 128 : 0x10000000;
 void vmem_set_max_limit(size_t size_in_mb)
 {
 	max = size_in_mb;

--- a/src/utils/vmem.c
+++ b/src/utils/vmem.c
@@ -97,8 +97,12 @@ static inline void* mmap_allocate(Vmem *vmem, size_t to_allocate)
 	return ptr;
 }
 
-// 32-bit / WASM has a 2GB total address limit; cap per-arena virtual memory to 128MB.
-size_t max = sizeof(size_t) == 4 ? 128 : 0x10000000;
+#if defined(__EMSCRIPTEN__)
+// Emscripten/WASM has a strict address space constraint; limit per-arena allocations to 128MB.
+size_t max = 128;
+#else
+size_t max = 0x10000000;
+#endif
 void vmem_set_max_limit(size_t size_in_mb)
 {
 	max = size_in_mb;

--- a/src/utils/vmem.c
+++ b/src/utils/vmem.c
@@ -97,12 +97,7 @@ static inline void* mmap_allocate(Vmem *vmem, size_t to_allocate)
 	return ptr;
 }
 
-#if defined(__EMSCRIPTEN__)
-// Emscripten/WASM has a strict address space constraint; limit per-arena allocations to 128MB.
-size_t max = 128;
-#else
 size_t max = 0x10000000;
-#endif
 void vmem_set_max_limit(size_t size_in_mb)
 {
 	max = size_in_mb;

--- a/src/utils/whereami.c
+++ b/src/utils/whereami.c
@@ -192,6 +192,15 @@ OK:;
 	return (int)length;
 }
 
+#elif defined(__EMSCRIPTEN__)
+
+static int get_executable_path_raw(char *out)
+{
+	const char *dummy = "/usr/bin/c3c";
+	strcpy(out, dummy);
+	return 12;
+}
+
 #else
 
 #error unsupported platform


### PR DESCRIPTION
This is so I can build the playground [(live here)](https://manulinares.github.io/c3-playground/)

source code: https://github.com/ManuLinares/c3-playground/