### PR TITLE
docgen: fixes  Fixes #3333, #3334, #3408

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -50,6 +50,7 @@
 - Using io::struct_to_format with `$force_dump = true` failed to compile.
 - `$foo += 1` would not do a copy, leading to incorrect update of `$foo`. #3400
 - `foreach (foo::Type t : x)` would not parse properly. #3423
+- Docgen improvements and fixes: emit `attrdef` declarations/docs, include `alias` doc comments, render `@return` contracts, exclude `compiler_rt` when `--emit-stdlib=no`, and omit empty JSON fields for slimmer output #3422.
 
 ## 0.8.2 Change list
 

--- a/resources/docs.html
+++ b/resources/docs.html
@@ -1324,7 +1324,6 @@
 			"long": "signed 64-bit integer",
 			"int128": "signed 128-bit integer",
 			"iptr": "signed pointer-sized integer",
-			"isz": "signed pointer-sized integer",
 			"sz": "signed pointer-sized integer",
 			"char": "unsigned 8-bit integer",
 			"ushort": "unsigned 16-bit integer",
@@ -1334,11 +1333,16 @@
 			"uptr": "unsigned pointer-sized integer",
 			"usz": "unsigned pointer-sized integer",
 			"bool": "boolean value (true/false)",
+			"float16": "16-bit floating point",
+			"bfloat": "16-bit brain floating point",
 			"float": "32-bit floating point",
 			"double": "64-bit floating point",
+			"float128": "128-bit floating point",
 			"void": "no type",
 			"any": "any type",
+			"fault": "fault type",
 			"typeid": "runtime type identifier",
+			"untypedlist": "untyped list literal",
 			"String": "typedef inline char[]",
 			"ZString": "typedef inline char*"
 		};
@@ -1665,11 +1669,19 @@
 			return li;
 		}
 
+		function createFooter(remaining) {
+			const footer = document.createElement('li');
+			footer.className = 'item list-footer';
+			footer.style.justifyContent = 'center';
+			footer.style.color = '#888';
+			footer.innerText = `... and ${remaining} more`;
+			return footer;
+		}
+
 		function appendToList(newLimit) {
 			const list = document.getElementById('list');
-			// Remove the "... and X more" footer before appending
-			const footer = list.querySelector('.list-footer');
-			if (footer) footer.remove();
+			const existingFooter = list.querySelector('.list-footer');
+			if (existingFooter) existingFooter.remove();
 
 			for (let i = currentRendered.length; i < newLimit; i++) {
 				const d = currentFiltered[i];
@@ -1677,14 +1689,8 @@
 				list.appendChild(makeListItem(d, i));
 			}
 
-			// Re-add footer if there are still more items
 			if (currentFiltered.length > currentRendered.length) {
-				const footer = document.createElement('li');
-				footer.className = 'item list-footer';
-				footer.style.justifyContent = 'center';
-				footer.style.color = '#888';
-				footer.innerText = `... and ${currentFiltered.length - currentRendered.length} more`;
-				list.appendChild(footer);
+				list.appendChild(createFooter(currentFiltered.length - currentRendered.length));
 			}
 		}
 
@@ -1714,12 +1720,7 @@
 			}
 
 			if (items.length > limit) {
-				const footer = document.createElement('li');
-				footer.className = 'item list-footer';
-				footer.style.justifyContent = 'center';
-				footer.style.color = '#888';
-				footer.innerText = `... and ${items.length - limit} more`;
-				list.appendChild(footer);
+				list.appendChild(createFooter(items.length - limit));
 			}
 		}
 
@@ -1727,18 +1728,31 @@
 			return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 		}
 
+		// Temporary experimental keyword aliases (remove when deprecated from language)
+		const TEMP_EXPERIMENTAL_KEYWORDS = [
+			'attrgroup', 'attrmacro', 'cenum', 'constset', 'distinct', 'excuse', 'faultconst', 'faultset'
+		];
+
 		const C3_KEYWORDS = new Set([
-			'asm', 'assert', 'break', 'case', 'cast', 'catch', 'const', 'continue', 'default', 'defer', 'do', 'else',
-			'enum', 'extern', 'false', 'fn', 'for', 'if', 'import', 'inline', 'local', 'macro', 'module', 'next',
-			'null', 'operator', 'private', 'public', 'return', 'static', 'struct', 'switch', 'true', 'typeid',
-			'using', 'var', 'while', 'bitstruct', 'fault', 'interface', 'union', 'try', 'foreach', 'nextcase', 'typedef', 'alias'
+			'alias', 'asm', 'assert', 'attrdef', 'bitstruct', 'break', 'case',
+			'cast', 'catch', 'const', 'constdef', 'continue', 'default', 'defer',
+			'do', 'else', 'enum', 'extern', 'false', 'fault', 'faultdef', 'fn',
+			'for', 'foreach', 'foreach_r', 'if', 'import', 'inline', 'interface',
+			'lengthof', 'local', 'macro', 'module', 'next', 'nextcase', 'null', 'operator',
+			'private', 'public', 'return', 'static', 'struct', 'switch', 'tlocal', 'true',
+			'try', 'typedef', 'typeid', 'union', 'using', 'var', 'while',
+			'$assert', '$case', '$default', '$defined', '$echo', '$else', '$embed', '$endfor',
+			'$endforeach', '$endif', '$endswitch', '$eval', '$error', '$exec', '$expand', '$feat',
+			'$feature', '$for', '$foreach', '$if', '$include', '$reflect', '$stringify', '$switch',
+			'$Typefrom', '$Typeof', '$vaarg',
+			...TEMP_EXPERIMENTAL_KEYWORDS
 		]);
 
 		const C3_TOKEN_TYPES = [
 			{ name: 'comment', regex: /\/\/.*|\/\*[\s\S]*?\*\//g },
 			{ name: 'string', regex: /"([^"\\]|\\.)*"|'([^'\\]|\\.)*'/g },
 			{ name: 'number', regex: /\b(0x[0-9a-fA-F]+|0b[01]+|\d+(\.\d+)?)\b/g },
-			{ name: 'word', regex: /@?\b[\w:]+\b/g }
+			{ name: 'word', regex: /[@$]?\b[\w:]+\b/g }
 		];
 
 		let symbolMapCache = null;
@@ -2163,13 +2177,11 @@
 			});
 
 			const modContainer = document.getElementById('module-list');
-			const updateModIndicators = () => {
-				const top = document.getElementById('mod-indicator-top');
-				const bottom = document.getElementById('mod-indicator-bottom');
-				top.style.opacity = modContainer.scrollTop > 10 ? '1' : '0';
-				const remaining = modContainer.scrollHeight - modContainer.scrollTop - modContainer.clientHeight;
-				bottom.style.opacity = remaining > 10 ? '1' : '0';
-			};
+			const updateModIndicators = () => updateScrollIndicators(
+				modContainer,
+				document.getElementById('mod-indicator-top'),
+				document.getElementById('mod-indicator-bottom')
+			);
 			modContainer.addEventListener('scroll', updateModIndicators);
 			setTimeout(updateModIndicators, 100);
 		}
@@ -2234,14 +2246,13 @@
 					return `<span class="c3-keyword">alias</span> <span class="c3-type">${localName}</span>`;
 				}
 			}
-
 			if (d.kind === 'distinct type') {
 				const inlineHtml = d.is_inline ? '<span class="c3-keyword">inline</span> ' : '';
 				const baseTypeStr = d.base_type ? renderTypeName(d.base_type) : '';
 				return `<span class="c3-keyword">typedef</span> <span class="c3-type">${localName}</span> = ${inlineHtml}${baseTypeStr}`;
 			}
 
-			if (d.kind === 'constant' || d.kind === 'global variable') {
+			if (d.kind === 'constant' || d.kind === 'global variable' || d.kind === 'variable') {
 				const keywordHtml = (d.kind === 'constant' || d.is_const) ? '<span class="c3-keyword">const</span> ' : '';
 				const typeStr = d.type ? renderTypeName(d.type) : '';
 				let res = `${keywordHtml}${typeStr ? typeStr + ' ' : ''}<span class="c3-variable">${localName}</span>`;
@@ -2398,7 +2409,7 @@
 			}
 
 			const anyDesc = hasAnyDescription(vd.members);
-			const isFunction = vd.kind === 'function' || vd.kind === 'macro' || vd.kind === 'method' || vd.kind === 'macro_method' || (vd.kind === 'type_alias' && vd.return_type);
+			const isFunction = vd.kind === 'function' || vd.kind === 'macro' || vd.kind === 'method' || vd.kind === 'macro_method';
 			const hasAnyContract = isFunction && baseDocs && baseDocs.params && vd.members.some(m => {
 				const dp = baseDocs.params.find(p => p.name === m.name);
 				return dp && (dp.modifier || dp.by_ref);
@@ -2614,14 +2625,19 @@
 			return html;
 		}
 
+		function updateScrollIndicators(container, topEl, bottomEl) {
+			if (!container || !topEl || !bottomEl) return;
+			topEl.style.opacity = container.scrollTop > 10 ? '1' : '0';
+			const remaining = container.scrollHeight - container.scrollTop - container.clientHeight;
+			bottomEl.style.opacity = remaining > 10 ? '1' : '0';
+		}
+
 		function updateCtxIndicators() {
-			const rightSidebarContent = document.getElementById('right-sidebar-content');
-			const top = document.getElementById('ctx-indicator-top');
-			const bottom = document.getElementById('ctx-indicator-bottom');
-			if (!rightSidebarContent || !top || !bottom) return;
-			top.style.opacity = rightSidebarContent.scrollTop > 10 ? '1' : '0';
-			const remaining = rightSidebarContent.scrollHeight - rightSidebarContent.scrollTop - rightSidebarContent.clientHeight;
-			bottom.style.opacity = remaining > 10 ? '1' : '0';
+			updateScrollIndicators(
+				document.getElementById('right-sidebar-content'),
+				document.getElementById('ctx-indicator-top'),
+				document.getElementById('ctx-indicator-bottom')
+			);
 		}
 
 		function renderModuleContext(moduleName, isSidebar = false, currentUid = null) {
@@ -2758,7 +2774,7 @@
 			} else {
 				rightSidebar.style.display = 'flex';
 				rightSidebarContent.innerHTML = renderModuleContext(d.moduleName, true, d.uid);
-				rightSidebarContent.addEventListener('scroll', updateCtxIndicators);
+				rightSidebarContent.onscroll = updateCtxIndicators;
 				setTimeout(updateCtxIndicators, 100);
 
 				const selected = rightSidebarContent.querySelector('.member-item-selected');

--- a/resources/docs.html
+++ b/resources/docs.html
@@ -308,6 +308,11 @@
 			color: var(--hl-text);
 		}
 
+		.kind-attribute {
+			background: var(--hl-comment);
+			color: var(--hl-text);
+		}
+
 		.kind-struct,
 		.kind-union,
 		.kind-bitstruct,
@@ -405,6 +410,10 @@
 		.item-kind-function,
 		.item-kind-macro {
 			background: rgba(210, 168, 255, 0.07);
+		}
+
+		.item-kind-attribute {
+			background: rgba(126, 231, 135, 0.07);
 		}
 
 		.item-kind-struct,
@@ -1398,7 +1407,7 @@
 					targetName: targetName === 'docs' ? 'default' : targetName
 				});
 
-				['functions', 'methods', 'macros', 'macro_methods', 'types', 'variables'].forEach(cat => {
+				['functions', 'methods', 'macros', 'attrdefs', 'macro_methods', 'types', 'variables'].forEach(cat => {
 					if (mod[cat]) {
 						mod[cat].forEach(decl => {
 							decl.moduleName = moduleName;
@@ -1642,6 +1651,7 @@
 			let kindClass = `item-kind`;
 			if (d.kind === 'function') kindClass += ' kind-function';
 			else if (d.kind === 'macro') kindClass += ' kind-macro';
+			else if (d.kind === 'attribute') kindClass += ' kind-attribute';
 			else if (d.kind === 'struct') kindClass += ' kind-struct';
 			else if (d.kind === 'enum') kindClass += ' kind-enum';
 			const vis = d.visibility || 'public';
@@ -2041,6 +2051,9 @@
 					'func':     ['function', 'method'],
 					'function': ['function', 'method'],
 					'macro':    ['macro', 'macro_method'],
+					'attrdef':  ['attribute'],
+					'attribute':['attribute'],
+					'attr':     ['attribute'],
 					'struct':   ['struct'],
 					'enum':     ['enum'],
 					'union':    ['union'],
@@ -2182,9 +2195,9 @@
 				if (isUntypedVararg) {
 					return `<span class="c3-variable">${m.name || ''}...</span>`;
 				}
-				const type = renderTypeName(m.type);
-				const name = m.name ? ` <span class="c3-variable">${m.is_ref ? '&' : ''}${m.name}</span>` : '';
-				let res = `${type}${name}`;
+				const type = m.type ? renderTypeName(m.type) : '';
+				const name = m.name ? `<span class="c3-variable">${m.is_ref ? '&' : ''}${m.name}</span>` : '';
+				let res = type ? (name ? `${type} ${name}` : type) : name;
 				if (m.attributes) res += ` <span class="c3-attribute">${m.attributes.join(' ')}</span>`;
 				if (m.default_value) res += ` = <span class="c3-variable">${m.default_value}</span>`;
 				return res;
@@ -2253,6 +2266,12 @@
 				return res;
 			}
 
+			if (d.kind === 'attribute') {
+				const params = (d.members && d.members.length > 0) ? `(${renderParams(d.members)})` : '';
+				const target = d.target ? ` = <span class="c3-attribute">${escapeHtml(d.target)}</span>` : '';
+				return `<span class="c3-keyword">attrdef</span> <span class="c3-macro">${localName}</span>${params}${target}`;
+			}
+
 			return null;
 		}
 
@@ -2296,6 +2315,12 @@
 				let typeInfo = '';
 				if (vd.return_type) {
 					typeInfo += ` <span style="font-size: 0.8em; opacity: 0.7;">Returns:</span> ${renderTypeName(vd.return_type)}`;
+				}
+				if (vd.docs && vd.docs.return) {
+					if (!vd.return_type) {
+						typeInfo += ` <span style="font-size: 0.8em; opacity: 0.7;">Returns:</span>`;
+					}
+					typeInfo += `<span style="font-size: 0.95em" class="doc-text">${vd.return_type ? ' - ' : ' '}${escapeHtml(vd.docs.return)}</span>`;
 				}
 				if (vd.base_type && vd.base_type.name) {
 					typeInfo += ` (base: ${renderTypeName(vd.base_type)})`;

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -19,10 +19,14 @@ typedef enum
 static const char *category_names[DOC_CAT_COUNT] = {"functions", "methods", "macros", "attrdefs", "macro_methods", "types", "variables"};
 static Module **all_modules = NULL;
 
+#define JSON_MAX_DEPTH 32
+#define TRUNCATE_MAX_LEN 512
+#define TRUNCATE_HALF_LEN (TRUNCATE_MAX_LEN / 2)
+
 typedef struct
 {
 	FILE *file;
-	bool first_stack[32];
+	bool first_stack[JSON_MAX_DEPTH];
 	int depth;
 } JsonEmitter;
 
@@ -45,14 +49,24 @@ static inline void json_comma(JsonEmitter *e)
 static inline void json_start_object_val(JsonEmitter *e)
 {
 	fputs("{", e->file);
-	if (e->depth < 31) e->depth++;
+	if (e->depth >= JSON_MAX_DEPTH - 1)
+	{
+		fflush(e->file);
+		error_exit("\nError: JSON emitter exceeded maximum nesting depth.");
+	}
+	e->depth++;
 	e->first_stack[e->depth] = true;
 }
 
 static inline void json_start_array_val(JsonEmitter *e)
 {
 	fputs("[", e->file);
-	if (e->depth < 31) e->depth++;
+	if (e->depth >= JSON_MAX_DEPTH - 1)
+	{
+		fflush(e->file);
+		error_exit("\nError: JSON emitter exceeded maximum nesting depth.");
+	}
+	e->depth++;
 	e->first_stack[e->depth] = true;
 }
 
@@ -79,7 +93,12 @@ static inline void json_start_object_prop(JsonEmitter *e, const char *key)
 static inline void json_end_object(JsonEmitter *e)
 {
 	fputs("}", e->file);
-	if (e->depth > 0) e->depth--;
+	if (e->depth == 0)
+	{
+		fflush(e->file);
+		error_exit("\nError: JSON emitter depth underflow.");
+	}
+	e->depth--;
 }
 
 static inline void json_start_array_prop(JsonEmitter *e, const char *key)
@@ -97,7 +116,12 @@ static inline void json_start_array(JsonEmitter *e)
 static inline void json_end_array(JsonEmitter *e)
 {
 	fputs("]", e->file);
-	if (e->depth > 0) e->depth--;
+	if (e->depth == 0)
+	{
+		fflush(e->file);
+		error_exit("\nError: JSON emitter depth underflow.");
+	}
+	e->depth--;
 }
 
 static inline void json_write_prop_string(JsonEmitter *e, const char *key, const char *str)
@@ -124,19 +148,44 @@ static void truncate_scratch_buffer_middle(void)
 {
 	const char *str = scratch_buffer_to_string();
 	size_t len = strlen(str);
-	if (len <= 512) return;
+	if (len <= TRUNCATE_MAX_LEN) return;
 
-	char head[257];
-	char tail[257];
-	memcpy(head, str, 256);
-	head[256] = '\0';
-	memcpy(tail, str + len - 256, 256);
-	tail[256] = '\0';
+	size_t head_len = TRUNCATE_HALF_LEN;
+	while (head_len > 0 && ((unsigned char)str[head_len] & 0xC0) == 0x80)
+	{
+		head_len--;
+	}
+	if (head_len < TRUNCATE_HALF_LEN && ((unsigned char)str[head_len] & 0x80) != 0)
+	{
+		unsigned char c = (unsigned char)str[head_len];
+		size_t char_len = 1;
+		if      ((c & 0xE0) == 0xC0) char_len = 2;
+		else if ((c & 0xF0) == 0xE0) char_len = 3;
+		else if ((c & 0xF8) == 0xF0) char_len = 4;
+		if (head_len + char_len <= TRUNCATE_HALF_LEN)
+		{
+			head_len += char_len;
+		}
+	}
+
+	size_t tail_start = len - TRUNCATE_HALF_LEN;
+	while (tail_start < len && ((unsigned char)str[tail_start] & 0xC0) == 0x80)
+	{
+		tail_start++;
+	}
+
+	char head[TRUNCATE_HALF_LEN + 1];
+	char tail[TRUNCATE_HALF_LEN + 1];
+	memcpy(head, str, head_len);
+	head[head_len] = '\0';
+	size_t tail_len = len - tail_start;
+	memcpy(tail, str + tail_start, tail_len);
+	tail[tail_len] = '\0';
 
 	scratch_buffer_clear();
-	scratch_buffer_append_len(head, 256);
+	scratch_buffer_append_len(head, head_len);
 	scratch_buffer_append("\n...\n");
-	scratch_buffer_append_len(tail, 256);
+	scratch_buffer_append_len(tail, tail_len);
 }
 
 static void write_expr_source_json(FILE *file, Expr *expr)
@@ -804,11 +853,8 @@ static void emit_normal_attrs(JsonEmitter *e, Decl *decl)
 			json_start_array_prop(e, "attributes");         \
 			has_attrs = true;                               \
 		}                                                   \
-		else                                                \
-		{                                                   \
-			fputs(",", e->file);                            \
-		}                                                   \
-		fputs("\"@" name "\"", e->file);                    \
+		json_comma(e);                                      \
+		json_write_string(e->file, "@" name);               \
 	}
 
 	EMIT_ATTR(decl->is_export, "export")

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -910,18 +910,20 @@ static bool emit_doc_comments(JsonEmitter *e, Decl *decl)
 {
 	if (!decl) return false;
 
+	bool is_func_alias = decl->decl_kind == DECL_TYPE_ALIAS && decl->type_alias_decl.is_func;
 	DeclId docs_id = decl->docs;
-	if (!docs_id && decl->decl_kind == DECL_TYPE_ALIAS && decl->type_alias_decl.is_func && decl->type_alias_decl.decl)
+	if (!docs_id && is_func_alias && decl->type_alias_decl.decl)
 	{
 		docs_id = decl->type_alias_decl.decl->docs;
 	}
 	Decl *contract = (decl->decl_kind == DECL_CONTRACT) ? decl : get_contract_decl(docs_id);
 	const char *deprecated = (decl->resolved_attributes && decl->attrs_resolved) ? decl->attrs_resolved->deprecated : NULL;
 
+	bool is_callable = decl->decl_kind == DECL_FUNC || decl->decl_kind == DECL_MACRO || decl->decl_kind == DECL_FNTYPE || is_func_alias;
 	bool has_docs = (deprecated != NULL);
 	if (contract)
 	{
-		if (contract->contracts_decl.comment || contract->contracts_decl.return_desc || contract->contracts_decl.pure || vec_size(contract->contracts_decl.params) > 0)
+		if (contract->contracts_decl.comment || (is_callable && contract->contracts_decl.return_desc) || contract->contracts_decl.pure || vec_size(contract->contracts_decl.params) > 0)
 		{
 			has_docs = true;
 		}
@@ -943,7 +945,7 @@ static bool emit_doc_comments(JsonEmitter *e, Decl *decl)
 			json_write_prop_string(e, "text", contract->contracts_decl.comment);
 		}
 
-		if (contract->contracts_decl.return_desc)
+		if (is_callable && contract->contracts_decl.return_desc)
 		{
 			json_write_prop_string(e, "return", contract->contracts_decl.return_desc);
 		}

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -23,7 +23,7 @@ static void write_decl_uid(FILE *file, Module *module, Decl *decl);
 static void emit_type_name_to_scratch(TypeInfo *type);
 static void print_doc_type(FILE *file, Module *module, TypeInfo *type, bool is_vararg);
 static void emit_params_json(FILE *file, Module *module, Decl **params);
-static void emit_doc_comments(FILE *file, Decl *decl);
+static bool emit_doc_comments(FILE *file, Decl *decl, bool *first);
 
 static void truncate_string_middle(const char *str)
 {
@@ -155,27 +155,40 @@ static const char *get_inout_modifier_name(InOutModifier mod)
 
 static void emit_param_json(FILE *file, Module *module, Decl *p)
 {
-	fprintf(file, "{\"name\":\"%s\"", p->name ? p->name : "");
+	fputs("{", file);
+	if (p->name && p->name[0])
+	{
+		fputs("\"name\":", file);
+		json_write_string(file, p->name);
+	}
 	if (p->decl_kind == DECL_BODYPARAM)
 	{
-		fputs(",\"kind\":\"body_param\",\"params\":", file);
+		if (p->name && p->name[0]) fputs(",", file);
+		fputs("\"kind\":\"body_param\",\"params\":", file);
 		emit_params_json(file, module, p->body_params);
 	}
 	else
 	{
+		bool first_field = !(p->name && p->name[0]);
 		if (p->var.type_info)
 		{
-			fputs(",\"type\":", file);
+			if (!first_field) fputs(",", file);
+			first_field = false;
+			fputs("\"type\":", file);
 			print_doc_type(file, module, type_infoptr(p->var.type_info), p->var.vararg);
 		}
 		if (p->var.init_expr)
 		{
-			fputs(",\"default_value\":", file);
+			if (!first_field) fputs(",", file);
+			first_field = false;
+			fputs("\"default_value\":", file);
 			write_expr_source_json(file, p->var.init_expr);
 		}
 		if (p->is_maybe_unused || p->is_must_use || p->var.no_alias)
 		{
-			fputs(",\"attributes\":[", file);
+			if (!first_field) fputs(",", file);
+			first_field = false;
+			fputs("\"attributes\":[", file);
 			bool first_attr = true;
 			if (p->is_maybe_unused)
 			{
@@ -192,17 +205,19 @@ static void emit_param_json(FILE *file, Module *module, Decl *p)
 			{
 				if (!first_attr) fputs(",", file);
 				fputs("\"@noalias\"", file);
-				first_attr = false;
 			}
 			fputs("]", file);
 		}
 		if (p->var.self_addr)
 		{
-			fputs(",\"is_ref\":true", file);
+			if (!first_field) fputs(",", file);
+			first_field = false;
+			fputs("\"is_ref\":true", file);
 		}
 		if (p->var.vararg)
 		{
-			fputs(",\"is_vararg\":true", file);
+			if (!first_field) fputs(",", file);
+			fputs("\"is_vararg\":true", file);
 		}
 	}
 	fputs("}", file);
@@ -355,13 +370,14 @@ static void emit_decl_uid_json(FILE *file, Decl *d)
 	}
 }
 
-static void emit_return_type_json(FILE *file, Module *module, TypeInfo *rtype)
+static void emit_return_type_json(FILE *file, Module *module, TypeInfo *rtype, bool *first)
 {
 	if (rtype)
 	{
+		if (!*first) fputs(",", file);
+		*first = false;
 		fputs("\"return_type\":", file);
 		print_doc_type(file, module, rtype, false);
-		fputs(",", file);
 	}
 }
 
@@ -536,7 +552,17 @@ static void emit_doc_struct_members(FILE *file, Decl *decl, bool *first)
 		{
 			if (!*first) fputs(",", file);
 			*first = false;
-			fprintf(file, "{\"name\":\"%s\",\"type\":", p->name ? p->name : "");
+			fputs("{", file);
+			bool member_first = true;
+			if (p->name && p->name[0])
+			{
+				fputs("\"name\":", file);
+				json_write_string(file, p->name);
+				member_first = false;
+			}
+			if (!member_first) fputs(",", file);
+			member_first = false;
+			fputs("\"type\":", file);
 			print_doc_type(file, decl->unit ? decl->unit->module : NULL, p->var.type_info ? type_infoptr(p->var.type_info) : NULL, false);
 			if (decl->decl_kind == DECL_BITSTRUCT && p->var.kind == VARDECL_BITMEMBER)
 			{
@@ -547,8 +573,14 @@ static void emit_doc_struct_members(FILE *file, Decl *decl, bool *first)
 		}
 		if (!*first) fputs(",", file);
 		*first = false;
-		fprintf(file, "{\"kind\":\"%s\"", decl_to_name(p));
-		if (p->name) fprintf(file, ",\"name\":\"%s\"", p->name);
+		fputs("{\"kind\":\"", file);
+		fputs(decl_to_name(p), file);
+		fputs("\"", file);
+		if (p->name && p->name[0])
+		{
+			fputs(",\"name\":", file);
+			json_write_string(file, p->name);
+		}
 		fputs(",\"members\":[", file);
 		bool sub_first = true;
 		emit_doc_struct_members(file, p, &sub_first);
@@ -556,17 +588,23 @@ static void emit_doc_struct_members(FILE *file, Decl *decl, bool *first)
 	}
 }
 
-static void emit_doc_members(FILE *file, Module *module, Decl *decl)
+static bool emit_doc_members_json(FILE *file, Module *module, Decl *decl, bool *first)
 {
 	if (decl_is_fn_macro(decl))
 	{
-		fputs("[", file);
-		bool first = true;
+		unsigned count = 0;
+		FOREACH(Decl *, p, decl->func_decl.signature.params) if (p) count++;
+		if (decl->decl_kind == DECL_MACRO && decl->func_decl.body_param && declptr(decl->func_decl.body_param)) count++;
+		if (!count) return false;
+		if (!*first) fputs(",", file);
+		*first = false;
+		fputs("\"members\":[", file);
+		bool inner_first = true;
 		FOREACH(Decl *, p, decl->func_decl.signature.params)
 		{
 			if (!p) continue;
-			if (!first) fputs(",", file);
-			first = false;
+			if (!inner_first) fputs(",", file);
+			inner_first = false;
 			emit_param_json(file, module, p);
 		}
 		if (decl->decl_kind == DECL_MACRO && decl->func_decl.body_param)
@@ -574,35 +612,50 @@ static void emit_doc_members(FILE *file, Module *module, Decl *decl)
 			Decl *p = declptr(decl->func_decl.body_param);
 			if (p)
 			{
-				if (!first) fputs(",", file);
+				if (!inner_first) fputs(",", file);
 				emit_param_json(file, module, p);
 			}
 		}
 		fputs("]", file);
-		return;
+		return true;
 	}
 	if (decl->decl_kind == DECL_TYPE_ALIAS && decl->type_alias_decl.is_func)
 	{
 		Decl *fntype = decl->type_alias_decl.decl;
 		if (fntype && fntype->decl_kind == DECL_FNTYPE)
 		{
-			emit_params_json(file, module, fntype->fntype_decl.signature.params);
-			return;
+			Decl **params = fntype->fntype_decl.signature.params;
+			if (!vec_size(params)) return false;
+			if (!*first) fputs(",", file);
+			*first = false;
+			fputs("\"members\":", file);
+			emit_params_json(file, module, params);
+			return true;
 		}
+		return false;
 	}
 	if (decl->decl_kind == DECL_ATTRIBUTE)
 	{
-		emit_params_json(file, module, decl->attr_decl.params);
-		return;
+		Decl **params = decl->attr_decl.params;
+		if (!vec_size(params)) return false;
+		if (!*first) fputs(",", file);
+		*first = false;
+		fputs("\"members\":", file);
+		emit_params_json(file, module, params);
+		return true;
 	}
-	fputs("[", file);
-	bool first = true;
+	// For types: emit only when there is actual content
 	if (decl->decl_kind == DECL_ENUM || decl->decl_kind == DECL_CONSTDEF)
 	{
+		if (!vec_size(decl->enums.values)) return false;
+		if (!*first) fputs(",", file);
+		*first = false;
+		fputs("\"members\":[", file);
+		bool inner_first = true;
 		FOREACH_IDX(i, Decl *, p, decl->enums.values)
 		{
-			if (!first) fputs(",", file);
-			first = false;
+			if (!inner_first) fputs(",", file);
+			inner_first = false;
 			fputs("{\"name\":\"", file);
 			fputs(p->name ? p->name : "", file);
 			fputs("\"", file);
@@ -628,21 +681,35 @@ static void emit_doc_members(FILE *file, Module *module, Decl *decl)
 				fputs(",\"value\":", file);
 				write_const_value_json(file, p->enum_constant.value);
 			}
-			fputs(",", file);
-			emit_doc_comments(file, p);
+			bool item_doc_first = false;
+			emit_doc_comments(file, p, &item_doc_first);
 			fputs("}", file);
 		}
+		fputs("]", file);
+		return true;
 	}
-	else if (decl_has_members(decl))
+	if (decl_has_members(decl))
 	{
-		emit_doc_struct_members(file, decl, &first);
+		if (!vec_size(decl->strukt.members)) return false;
+		if (!*first) fputs(",", file);
+		*first = false;
+		fputs("\"members\":[", file);
+		bool struct_first = true;
+		emit_doc_struct_members(file, decl, &struct_first);
+		fputs("]", file);
+		return true;
 	}
-	else if (decl->decl_kind == DECL_INTERFACE)
+	if (decl->decl_kind == DECL_INTERFACE)
 	{
+		if (!vec_size(decl->interface_methods)) return false;
+		if (!*first) fputs(",", file);
+		*first = false;
+		fputs("\"members\":[", file);
+		bool inner_first = true;
 		FOREACH(Decl *, p, decl->interface_methods)
 		{
-			if (!first) fputs(",", file);
-			first = false;
+			if (!inner_first) fputs(",", file);
+			inner_first = false;
 
 			fputs("{", file);
 			fprintf(file, "\"name\":\"%s\",\"type\":", p->name);
@@ -674,16 +741,20 @@ static void emit_doc_members(FILE *file, Module *module, Decl *decl)
 
 			fputs("}", file);
 		}
+		fputs("]", file);
+		return true;
 	}
-	fputs("]", file);
+	return false;
 }
 
-static void emit_custom_attrs(FILE *file, Decl *decl)
+static void emit_custom_attrs(FILE *file, Decl *decl, bool *first)
 {
 	if (!decl->resolved_attributes || !decl->attrs_resolved) return;
 	if (vec_size(decl->attrs_resolved->tags) == 0) return;
 
-	fputs(",\"custom_attrs\":[", file);
+	if (!*first) fputs(",", file);
+	*first = false;
+	fputs("\"custom_attrs\":[", file);
 	for (unsigned i = 0; i < vec_size(decl->attrs_resolved->tags); i++)
 	{
 		if (i > 0) fputs(",", file);
@@ -714,7 +785,7 @@ static void emit_custom_attrs(FILE *file, Decl *decl)
 	fputs("]", file);
 }
 
-static void emit_normal_attrs(FILE *file, Decl *decl)
+static void emit_normal_attrs(FILE *file, Decl *decl, bool *first)
 {
 	bool has_attrs = false;
 
@@ -727,7 +798,9 @@ static void emit_normal_attrs(FILE *file, Decl *decl)
 		}                                     \
 		else                                  \
 		{                                     \
-			fputs(",\"attributes\":[", file); \
+			if (!*first) fputs(",", file);    \
+			*first = false;                   \
+			fputs("\"attributes\":[", file);  \
 			has_attrs = true;                 \
 		}                                     \
 		fputs("\"@" name "\"", file);         \
@@ -782,13 +855,9 @@ static Decl *get_contract_decl(DeclId id)
 	return NULL;
 }
 
-static void emit_doc_comments(FILE *file, Decl *decl)
+static bool emit_doc_comments(FILE *file, Decl *decl, bool *first)
 {
-	if (!decl)
-	{
-		fputs("\"docs\":null", file);
-		return;
-	}
+	if (!decl) return false;
 
 	DeclId docs_id = decl->docs;
 	if (!docs_id && decl->decl_kind == DECL_TYPE_ALIAS && decl->type_alias_decl.is_func && decl->type_alias_decl.decl)
@@ -798,50 +867,57 @@ static void emit_doc_comments(FILE *file, Decl *decl)
 	Decl *contract = (decl->decl_kind == DECL_CONTRACT) ? decl : get_contract_decl(docs_id);
 	const char *deprecated = (decl->resolved_attributes && decl->attrs_resolved) ? decl->attrs_resolved->deprecated : NULL;
 
-	if (!contract && !deprecated)
+	bool has_docs = (deprecated != NULL);
+	if (contract)
 	{
-		fputs("\"docs\":null", file);
-		return;
+		if (contract->contracts_decl.comment || contract->contracts_decl.return_desc || contract->contracts_decl.pure || vec_size(contract->contracts_decl.params) > 0)
+		{
+			has_docs = true;
+		}
 	}
 
+	if (!has_docs) return false;
+
+	if (!*first) fputs(",", file);
+	*first = false;
 	fputs("\"docs\":{", file);
-	bool first = true;
+	bool inner_first = true;
 
 	if (deprecated)
 	{
 		fputs("\"deprecated\":", file);
 		json_write_string(file, deprecated);
-		first = false;
+		inner_first = false;
 	}
 
 	if (contract)
 	{
 		if (contract->contracts_decl.comment)
 		{
-			if (!first) fputs(",", file);
+			if (!inner_first) fputs(",", file);
 			fputs("\"text\":", file);
 			json_write_string(file, contract->contracts_decl.comment);
-			first = false;
+			inner_first = false;
 		}
 
 		if (contract->contracts_decl.return_desc)
 		{
-			if (!first) fputs(",", file);
+			if (!inner_first) fputs(",", file);
 			fputs("\"return\":", file);
 			json_write_string(file, contract->contracts_decl.return_desc);
-			first = false;
+			inner_first = false;
 		}
 
 		if (contract->contracts_decl.pure)
 		{
-			if (!first) fputs(",", file);
+			if (!inner_first) fputs(",", file);
 			fputs("\"pure\":true", file);
-			first = false;
+			inner_first = false;
 		}
 
 		if (vec_size(contract->contracts_decl.params) > 0)
 		{
-			if (!first) fputs(",", file);
+			if (!inner_first) fputs(",", file);
 			fputs("\"params\":[", file);
 			bool first_p = true;
 			for (unsigned i = 0; i < vec_size(contract->contracts_decl.params); i++)
@@ -869,9 +945,10 @@ static void emit_doc_comments(FILE *file, Decl *decl)
 	}
 
 	fputs("}", file);
+	return true;
 }
 
-static void emit_attrdef_target_json(FILE *file, Decl *decl)
+static void emit_attrdef_target_json(FILE *file, Decl *decl, bool *first)
 {
 	Attr **attrs = decl->attr_decl.attrs;
 	if (vec_size(attrs) == 0) return;
@@ -897,9 +974,10 @@ static void emit_attrdef_target_json(FILE *file, Decl *decl)
 			scratch_buffer_append(")");
 		}
 	}
+	if (!*first) fputs(",", file);
+	*first = false;
 	fputs("\"target\":", file);
 	json_write_string(file, scratch_buffer_to_string());
-	fputs(",", file);
 }
 
 static const char *get_decl_kind_name(Decl *decl)
@@ -920,15 +998,24 @@ static const char *get_decl_kind_name(Decl *decl)
 static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **generic_params)
 {
 	fputs("{", file);
+	bool first = true;
+
+	if (!first) fputs(",", file);
+	first = false;
 	fputs("\"name\":", file);
 	json_write_string(file, decl->name);
-	fputs(",", file);
+
+	if (!first) fputs(",", file);
+	first = false;
 	fputs("\"kind\":\"", file);
 	fputs(get_decl_kind_name(decl), file);
-	fputs("\",", file);
+	fputs("\"", file);
+
+	if (!first) fputs(",", file);
+	first = false;
 	fputs("\"uid\":", file);
 	write_decl_uid(file, module, decl);
-	fputs(",", file);
+
 	if (decl->loc)
 	{
 		SourceLoc *loc_info = sourcelocptr(decl->loc);
@@ -937,6 +1024,8 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 			File *f = source_file_by_id(loc_info->file_id);
 			if (f && f->full_path)
 			{
+				if (!first) fputs(",", file);
+				first = false;
 				fputs("\"file\":", file);
 				scratch_buffer_clear();
 				const char *path = f->full_path;
@@ -955,30 +1044,35 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 				}
 				scratch_buffer_printf("%s:%u:%u", path, loc_info->row, loc_info->col);
 				json_write_string(file, scratch_buffer_to_string());
-				fputs(",", file);
 			}
 		}
 	}
 	if (decl->visibility != VISIBLE_PUBLIC)
 	{
-		fprintf(file, "\"visibility\":\"%s\",", get_visibility_name(decl->visibility));
+		if (!first) fputs(",", file);
+		first = false;
+		fprintf(file, "\"visibility\":\"%s\"", get_visibility_name(decl->visibility));
 	}
 	if (decl->is_template)
 	{
-		fputs("\"is_generic\":true,", file);
+		if (!first) fputs(",", file);
+		first = false;
+		fputs("\"is_generic\":true", file);
 	}
 	if (generic_params)
 	{
 		unsigned param_count = vec_size(generic_params);
 		if (param_count > 0)
 		{
+			if (!first) fputs(",", file);
+			first = false;
 			fputs("\"generic_parameters\":[", file);
 			for (unsigned i = 0; i < param_count; i++)
 			{
 				if (i > 0) fputs(",", file);
 				json_write_string(file, generic_params[i]);
 			}
-			fputs("],", file);
+			fputs("]", file);
 		}
 	}
 	if (decl_has_interface(decl))
@@ -986,13 +1080,15 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 		unsigned iface_count = vec_size(decl->interfaces);
 		if (iface_count > 0)
 		{
+			if (!first) fputs(",", file);
+			first = false;
 			fputs("\"interfaces\":[", file);
 			for (unsigned i = 0; i < iface_count; i++)
 			{
 				if (i > 0) fputs(",", file);
 				print_doc_type(file, module, decl->interfaces[i], false);
 			}
-			fputs("],", file);
+			fputs("]", file);
 		}
 	}
 
@@ -1001,11 +1097,21 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 	{
 		case DECL_FUNC:
 		case DECL_MACRO:
-			emit_return_type_json(file, module, type_infoptrzero(decl->func_decl.signature.rtype));
+			emit_return_type_json(file, module, type_infoptrzero(decl->func_decl.signature.rtype), &first);
 			if (decl->decl_kind == DECL_MACRO)
 			{
-				if (decl->func_decl.signature.is_at_macro) fputs("\"is_at_macro\":true,", file);
-				if (decl->func_decl.signature.is_safemacro) fputs("\"is_safemacro\":true,", file);
+				if (decl->func_decl.signature.is_at_macro)
+				{
+					if (!first) fputs(",", file);
+					first = false;
+					fputs("\"is_at_macro\":true", file);
+				}
+				if (decl->func_decl.signature.is_safemacro)
+				{
+					if (!first) fputs(",", file);
+					first = false;
+					fputs("\"is_safemacro\":true", file);
+				}
 			}
 			break;
 		case DECL_TYPE_ALIAS:
@@ -1014,7 +1120,7 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 				Decl *fntype = decl->type_alias_decl.decl;
 				if (fntype && fntype->decl_kind == DECL_FNTYPE)
 				{
-					emit_return_type_json(file, module, type_infoptrzero(fntype->fntype_decl.signature.rtype));
+					emit_return_type_json(file, module, type_infoptrzero(fntype->fntype_decl.signature.rtype), &first);
 				}
 				break;
 			}
@@ -1035,35 +1141,45 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 			base = decl->strukt.container_type;
 			goto PRINT_BASE;
 		case DECL_TYPEDEF:
-			if (decl->is_substruct) fputs("\"is_inline\":true,", file);
+			if (decl->is_substruct)
+			{
+				if (!first) fputs(",", file);
+				first = false;
+				fputs("\"is_inline\":true", file);
+			}
 			base = decl->distinct;
 			goto PRINT_BASE;
 		PRINT_BASE:
+			if (!first) fputs(",", file);
+			first = false;
 			fputs("\"base_type\":", file);
 			print_doc_type(file, module, base, false);
-			fputs(",", file);
 			break;
 		case DECL_VAR:
 			base = type_infoptrzero(decl->var.type_info);
 			if (base)
 			{
+				if (!first) fputs(",", file);
+				first = false;
 				fputs("\"type\":", file);
 				print_doc_type(file, module, base, false);
-				fputs(",", file);
 			}
 			if (decl->var.kind == VARDECL_CONST)
 			{
-				fputs("\"is_const\":true,", file);
+				if (!first) fputs(",", file);
+				first = false;
+				fputs("\"is_const\":true", file);
 			}
 			if (decl->var.init_expr)
 			{
+				if (!first) fputs(",", file);
+				first = false;
 				fputs("\"value\":", file);
 				write_const_value_json(file, decl->var.init_expr);
-				fputs(",", file);
 			}
 			break;
 		case DECL_ATTRIBUTE:
-			emit_attrdef_target_json(file, decl);
+			emit_attrdef_target_json(file, decl, &first);
 			break;
 		case DECL_POISONED:
 		case DECL_BODYPARAM:
@@ -1095,8 +1211,9 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 	{
 		if (vec_size(decl->enums.parameters) > 0)
 		{
-			fputs("\"associated_values\":", file);
-			fputs("[", file);
+			if (!first) fputs(",", file);
+			first = false;
+			fputs("\"associated_values\":[", file);
 			bool first_param = true;
 			FOREACH_IDX(i, Decl *, p, decl->enums.parameters)
 			{
@@ -1104,17 +1221,13 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 				first_param = false;
 				emit_param_json(file, module, p);
 			}
-			fputs("],", file);
+			fputs("]", file);
 		}
 	}
-	fputs("\"members\":", file);
-	emit_doc_members(file, module, decl);
-	fputs(",", file);
-	fputs("", file);
-	emit_doc_comments(file, decl);
-	emit_custom_attrs(file, decl);
-	emit_normal_attrs(file, decl);
-	fputs("", file);
+	emit_doc_members_json(file, module, decl, &first);
+	emit_doc_comments(file, decl, &first);
+	emit_custom_attrs(file, decl, &first);
+	emit_normal_attrs(file, decl, &first);
 	fputs("}", file);
 }
 
@@ -1276,6 +1389,9 @@ void compiler_docgen(BuildTarget *target)
 		}
 
 		bool is_module_generic = module_generic != NULL;
+		bool mod_first = true;
+		if (!mod_first) fputs(",", file);
+		mod_first = false;
 		fprintf(file, "\"is_generic\":%s", is_module_generic ? "true" : "false");
 		if (is_module_generic)
 		{
@@ -1288,17 +1404,8 @@ void compiler_docgen(BuildTarget *target)
 			}
 			fputs("]", file);
 		}
-		fputs(",", file);
 
-		if (module_doc)
-		{
-
-			emit_doc_comments(file, declptr(module_doc));
-		}
-		else
-		{
-			fputs("\"docs\":null", file);
-		}
+		if (module_doc) emit_doc_comments(file, declptr(module_doc), &mod_first);
 
 		for (int cat = 0; cat < DOC_CAT_COUNT; cat++)
 		{

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -19,25 +19,124 @@ typedef enum
 static const char *category_names[DOC_CAT_COUNT] = {"functions", "methods", "macros", "attrdefs", "macro_methods", "types", "variables"};
 static Module **all_modules = NULL;
 
-static void write_decl_uid(FILE *file, Module *module, Decl *decl);
-static void emit_type_name_to_scratch(TypeInfo *type);
-static void print_doc_type(FILE *file, Module *module, TypeInfo *type, bool is_vararg);
-static void emit_params_json(FILE *file, Module *module, Decl **params);
-static bool emit_doc_comments(FILE *file, Decl *decl, bool *first);
-
-static void truncate_string_middle(const char *str)
+typedef struct
 {
-	size_t len = strlen(str);
-	if (len <= 512)
+	FILE *file;
+	bool first_stack[32];
+	int depth;
+} JsonEmitter;
+
+static inline void json_init(JsonEmitter *e, FILE *file)
+{
+	e->file = file;
+	e->depth = 0;
+	e->first_stack[0] = true;
+}
+
+static inline void json_comma(JsonEmitter *e)
+{
+	if (!e->first_stack[e->depth])
 	{
-		scratch_buffer_clear();
-		scratch_buffer_append(str);
-		return;
+		fputs(",", e->file);
 	}
+	e->first_stack[e->depth] = false;
+}
+
+static inline void json_start_object_val(JsonEmitter *e)
+{
+	fputs("{", e->file);
+	if (e->depth < 31) e->depth++;
+	e->first_stack[e->depth] = true;
+}
+
+static inline void json_start_array_val(JsonEmitter *e)
+{
+	fputs("[", e->file);
+	if (e->depth < 31) e->depth++;
+	e->first_stack[e->depth] = true;
+}
+
+static inline void json_start_object(JsonEmitter *e)
+{
+	json_comma(e);
+	json_start_object_val(e);
+}
+
+static inline void json_write_prop_key(JsonEmitter *e, const char *key)
+{
+	json_comma(e);
+	fputs("\"", e->file);
+	fputs(key, e->file);
+	fputs("\":", e->file);
+}
+
+static inline void json_start_object_prop(JsonEmitter *e, const char *key)
+{
+	json_write_prop_key(e, key);
+	json_start_object_val(e);
+}
+
+static inline void json_end_object(JsonEmitter *e)
+{
+	fputs("}", e->file);
+	if (e->depth > 0) e->depth--;
+}
+
+static inline void json_start_array_prop(JsonEmitter *e, const char *key)
+{
+	json_write_prop_key(e, key);
+	json_start_array_val(e);
+}
+
+static inline void json_start_array(JsonEmitter *e)
+{
+	json_comma(e);
+	json_start_array_val(e);
+}
+
+static inline void json_end_array(JsonEmitter *e)
+{
+	fputs("]", e->file);
+	if (e->depth > 0) e->depth--;
+}
+
+static inline void json_write_prop_string(JsonEmitter *e, const char *key, const char *str)
+{
+	if (!str) return;
+	json_write_prop_key(e, key);
+	json_write_string(e->file, str);
+}
+
+static inline void json_write_prop_bool(JsonEmitter *e, const char *key, bool val)
+{
+	json_write_prop_key(e, key);
+	fputs(val ? "true" : "false", e->file);
+}
+
+static void write_decl_uid(JsonEmitter *e, Module *module, Decl *decl);
+static void emit_type_name_to_scratch(TypeInfo *type);
+static void print_doc_type(JsonEmitter *e, Module *module, TypeInfo *type, bool is_vararg);
+static void emit_params_json(JsonEmitter *e, Module *module, Decl **params);
+static bool emit_doc_comments(JsonEmitter *e, Decl *decl);
+static void emit_param_json(JsonEmitter *e, Module *module, Decl *p);
+
+static void truncate_scratch_buffer_middle(void)
+{
+	const char *str = scratch_buffer_to_string();
+	size_t len = strlen(str);
+	if (len <= 512) return;
+
+	char head[257];
+	char tail[257];
+	memcpy(head, str, 256);
+	head[256] = '\0';
+	memcpy(tail, str + len - 256, 256);
+	tail[256] = '\0';
+
 	scratch_buffer_clear();
-	scratch_buffer_append_len(str, 256);
+	scratch_buffer_append_len(head, 256);
 	scratch_buffer_append("\n...\n");
-	scratch_buffer_append(str + len - 256);
+	scratch_buffer_append_len(tail, 256);
 }
 
 static void write_expr_source_json(FILE *file, Expr *expr)
@@ -49,9 +148,7 @@ static void write_expr_source_json(FILE *file, Expr *expr)
 	}
 	scratch_buffer_clear();
 	loc_to_scratch(expr->loc);
-	char *str = strdup(scratch_buffer_to_string());
-	truncate_string_middle(str);
-	free(str);
+	truncate_scratch_buffer_middle();
 	json_write_string(file, scratch_buffer_to_string());
 }
 
@@ -77,9 +174,7 @@ static void write_const_value_json(FILE *file, Expr *expr)
 			case CONST_REF:
 				scratch_buffer_clear();
 				expr_const_to_scratch_buffer(&expr->const_expr);
-				char *str = strdup(scratch_buffer_to_string());
-				truncate_string_middle(str);
-				free(str);
+				truncate_scratch_buffer_middle();
 				json_write_string(file, scratch_buffer_to_string());
 				return;
 			default:
@@ -153,99 +248,66 @@ static const char *get_inout_modifier_name(InOutModifier mod)
 	}
 }
 
-static void emit_param_json(FILE *file, Module *module, Decl *p)
+static void emit_param_json(JsonEmitter *e, Module *module, Decl *p)
 {
-	fputs("{", file);
+	json_start_object(e);
 	if (p->name && p->name[0])
 	{
-		fputs("\"name\":", file);
-		json_write_string(file, p->name);
+		json_write_prop_string(e, "name", p->name);
 	}
 	if (p->decl_kind == DECL_BODYPARAM)
 	{
-		if (p->name && p->name[0]) fputs(",", file);
-		fputs("\"kind\":\"body_param\",\"params\":", file);
-		emit_params_json(file, module, p->body_params);
+		json_write_prop_string(e, "kind", "body_param");
+		json_write_prop_key(e, "params");
+		emit_params_json(e, module, p->body_params);
 	}
 	else
 	{
-		bool first_field = !(p->name && p->name[0]);
 		if (p->var.type_info)
 		{
-			if (!first_field) fputs(",", file);
-			first_field = false;
-			fputs("\"type\":", file);
-			print_doc_type(file, module, type_infoptr(p->var.type_info), p->var.vararg);
+			json_write_prop_key(e, "type");
+			print_doc_type(e, module, type_infoptr(p->var.type_info), p->var.vararg);
 		}
 		if (p->var.init_expr)
 		{
-			if (!first_field) fputs(",", file);
-			first_field = false;
-			fputs("\"default_value\":", file);
-			write_expr_source_json(file, p->var.init_expr);
+			json_write_prop_key(e, "default_value");
+			write_expr_source_json(e->file, p->var.init_expr);
 		}
 		if (p->is_maybe_unused || p->is_must_use || p->var.no_alias)
 		{
-			if (!first_field) fputs(",", file);
-			first_field = false;
-			fputs("\"attributes\":[", file);
-			bool first_attr = true;
-			if (p->is_maybe_unused)
-			{
-				fputs("\"@unused\"", file);
-				first_attr = false;
-			}
-			if (p->is_must_use)
-			{
-				if (!first_attr) fputs(",", file);
-				fputs("\"@used\"", file);
-				first_attr = false;
-			}
-			if (p->var.no_alias)
-			{
-				if (!first_attr) fputs(",", file);
-				fputs("\"@noalias\"", file);
-			}
-			fputs("]", file);
+			json_start_array_prop(e, "attributes");
+			if (p->is_maybe_unused) { json_comma(e); fputs("\"@unused\"", e->file); }
+			if (p->is_must_use)     { json_comma(e); fputs("\"@used\"", e->file); }
+			if (p->var.no_alias)     { json_comma(e); fputs("\"@noalias\"", e->file); }
+			json_end_array(e);
 		}
-		if (p->var.self_addr)
-		{
-			if (!first_field) fputs(",", file);
-			first_field = false;
-			fputs("\"is_ref\":true", file);
-		}
-		if (p->var.vararg)
-		{
-			if (!first_field) fputs(",", file);
-			fputs("\"is_vararg\":true", file);
-		}
+		if (p->var.self_addr) json_write_prop_bool(e, "is_ref", true);
+		if (p->var.vararg)    json_write_prop_bool(e, "is_vararg", true);
 	}
-	fputs("}", file);
+	json_end_object(e);
 }
 
-static void emit_params_json(FILE *file, Module *module, Decl **params)
+static void emit_params_json(JsonEmitter *e, Module *module, Decl **params)
 {
-	fputs("[", file);
-	bool first = true;
+	json_start_array_val(e);
 	for (unsigned i = 0; i < vec_size(params); i++)
 	{
 		Decl *p = params[i];
 		if (!p) continue;
-		if (!first) fputs(",", file);
-		first = false;
-		emit_param_json(file, module, p);
+		emit_param_json(e, module, p);
 	}
-	fputs("]", file);
+	json_end_array(e);
 }
-static void write_decl_uid(FILE *file, Module *module, Decl *decl)
+
+static void write_decl_uid(JsonEmitter *e, Module *module, Decl *decl)
 {
 	if (!decl || !decl->name)
 	{
-		fputs("null", file);
+		fputs("null", e->file);
 		return;
 	}
-	fputs("\"", file);
-	fprintf(file, "%s::", module->name->module);
+	fputs("\"", e->file);
+	fprintf(e->file, "%s::", module->name->module);
 	if ((decl->decl_kind == DECL_FUNC || decl->decl_kind == DECL_MACRO))
 	{
 		TypeInfo *parent = decl_find_target_if_method(decl);
@@ -253,10 +315,10 @@ static void write_decl_uid(FILE *file, Module *module, Decl *decl)
 		{
 			scratch_buffer_clear();
 			emit_type_name_to_scratch(parent);
-			fprintf(file, "%s.", scratch_buffer_to_string());
+			fprintf(e->file, "%s.", scratch_buffer_to_string());
 		}
 	}
-	fprintf(file, "%s\"", decl->name);
+	fprintf(e->file, "%s\"", decl->name);
 }
 
 static void emit_type_name_to_scratch(TypeInfo *type)
@@ -361,34 +423,33 @@ static void emit_type_name_to_scratch(TypeInfo *type)
 	if (type->optional) scratch_buffer_append("?");
 }
 
-static void emit_decl_uid_json(FILE *file, Decl *d)
+static void emit_decl_uid_json(JsonEmitter *e, Decl *d)
 {
 	if (d && d->name && d->unit && d->unit->module)
 	{
-		fputs(",\"uid\":", file);
-		write_decl_uid(file, d->unit->module, d);
+		json_write_prop_key(e, "uid");
+		write_decl_uid(e, d->unit->module, d);
 	}
 }
 
-static void emit_return_type_json(FILE *file, Module *module, TypeInfo *rtype, bool *first)
+static void emit_return_type_json(JsonEmitter *e, Module *module, TypeInfo *rtype)
 {
 	if (rtype)
 	{
-		if (!*first) fputs(",", file);
-		*first = false;
-		fputs("\"return_type\":", file);
-		print_doc_type(file, module, rtype, false);
+		json_write_prop_key(e, "return_type");
+		print_doc_type(e, module, rtype, false);
 	}
 }
 
-static void print_doc_type(FILE *file, Module *module, TypeInfo *type, bool is_vararg)
+static void print_doc_type(JsonEmitter *e, Module *module, TypeInfo *type, bool is_vararg)
 {
 	if (!type)
 	{
-		fputs("null", file);
+		fputs("null", e->file);
 		return;
 	}
-	fputs("{\"name\":\"", file);
+	json_start_object_val(e);
+	json_write_prop_key(e, "name");
 	scratch_buffer_clear();
 	if (is_vararg && type->type)
 	{
@@ -457,9 +518,7 @@ static void print_doc_type(FILE *file, Module *module, TypeInfo *type, bool is_v
 		if (is_vararg) scratch_buffer_append("...");
 	}
 
-	const char *name = scratch_buffer_to_string();
-	fputs(name, file);
-	fputs("\"", file);
+	json_write_string(e->file, scratch_buffer_to_string());
 
 	TypeInfo *base_info = type;
 
@@ -517,7 +576,7 @@ RETRY2:
 		case TYPE_FUNC_RAW:
 		case TYPE_ALIAS:
 		case TYPE_MEMBER:
-			emit_decl_uid_json(file, t->decl);
+			emit_decl_uid_json(e, t->decl);
 			break;
 		default:
 			if ((base_info->kind == TYPE_INFO_IDENTIFIER || base_info->kind == TYPE_INFO_CT_IDENTIFIER) && module)
@@ -533,15 +592,15 @@ RETRY2:
 						if (d) break;
 					}
 				}
-				emit_decl_uid_json(file, d);
+				emit_decl_uid_json(e, d);
 			}
 
 			break;
 	}
-	fputs("}", file);
+	json_end_object(e);
 }
 
-static void emit_doc_struct_members(FILE *file, Decl *decl, bool *first)
+static void emit_doc_struct_members(JsonEmitter *e, Decl *decl)
 {
 	if (!decl_has_members(decl)) return;
 	FOREACH(Decl *, p, decl->strukt.members)
@@ -550,45 +609,35 @@ static void emit_doc_struct_members(FILE *file, Decl *decl, bool *first)
 
 		if (p->decl_kind == DECL_VAR)
 		{
-			if (!*first) fputs(",", file);
-			*first = false;
-			fputs("{", file);
-			bool member_first = true;
+			json_start_object(e);
 			if (p->name && p->name[0])
 			{
-				fputs("\"name\":", file);
-				json_write_string(file, p->name);
-				member_first = false;
+				json_write_prop_string(e, "name", p->name);
 			}
-			if (!member_first) fputs(",", file);
-			member_first = false;
-			fputs("\"type\":", file);
-			print_doc_type(file, decl->unit ? decl->unit->module : NULL, p->var.type_info ? type_infoptr(p->var.type_info) : NULL, false);
+			json_write_prop_key(e, "type");
+			print_doc_type(e, decl->unit ? decl->unit->module : NULL, p->var.type_info ? type_infoptr(p->var.type_info) : NULL, false);
 			if (decl->decl_kind == DECL_BITSTRUCT && p->var.kind == VARDECL_BITMEMBER)
 			{
-				fprintf(file, ",\"bit_range\":[%u,%u]", p->var.start_bit, p->var.end_bit);
+				json_write_prop_key(e, "bit_range");
+				fprintf(e->file, "[%u,%u]", p->var.start_bit, p->var.end_bit);
 			}
-			fputs("}", file);
+			json_end_object(e);
 			continue;
 		}
-		if (!*first) fputs(",", file);
-		*first = false;
-		fputs("{\"kind\":\"", file);
-		fputs(decl_to_name(p), file);
-		fputs("\"", file);
+		json_start_object(e);
+		json_write_prop_string(e, "kind", decl_to_name(p));
 		if (p->name && p->name[0])
 		{
-			fputs(",\"name\":", file);
-			json_write_string(file, p->name);
+			json_write_prop_string(e, "name", p->name);
 		}
-		fputs(",\"members\":[", file);
-		bool sub_first = true;
-		emit_doc_struct_members(file, p, &sub_first);
-		fputs("]}", file);
+		json_start_array_prop(e, "members");
+		emit_doc_struct_members(e, p);
+		json_end_array(e);
+		json_end_object(e);
 	}
 }
 
-static bool emit_doc_members_json(FILE *file, Module *module, Decl *decl, bool *first)
+static bool emit_doc_members_json(JsonEmitter *e, Module *module, Decl *decl)
 {
 	if (decl_is_fn_macro(decl))
 	{
@@ -596,27 +645,17 @@ static bool emit_doc_members_json(FILE *file, Module *module, Decl *decl, bool *
 		FOREACH(Decl *, p, decl->func_decl.signature.params) if (p) count++;
 		if (decl->decl_kind == DECL_MACRO && decl->func_decl.body_param && declptr(decl->func_decl.body_param)) count++;
 		if (!count) return false;
-		if (!*first) fputs(",", file);
-		*first = false;
-		fputs("\"members\":[", file);
-		bool inner_first = true;
+		json_start_array_prop(e, "members");
 		FOREACH(Decl *, p, decl->func_decl.signature.params)
 		{
-			if (!p) continue;
-			if (!inner_first) fputs(",", file);
-			inner_first = false;
-			emit_param_json(file, module, p);
+			if (p) emit_param_json(e, module, p);
 		}
 		if (decl->decl_kind == DECL_MACRO && decl->func_decl.body_param)
 		{
 			Decl *p = declptr(decl->func_decl.body_param);
-			if (p)
-			{
-				if (!inner_first) fputs(",", file);
-				emit_param_json(file, module, p);
-			}
+			if (p) emit_param_json(e, module, p);
 		}
-		fputs("]", file);
+		json_end_array(e);
 		return true;
 	}
 	if (decl->decl_kind == DECL_TYPE_ALIAS && decl->type_alias_decl.is_func)
@@ -626,10 +665,8 @@ static bool emit_doc_members_json(FILE *file, Module *module, Decl *decl, bool *
 		{
 			Decl **params = fntype->fntype_decl.signature.params;
 			if (!vec_size(params)) return false;
-			if (!*first) fputs(",", file);
-			*first = false;
-			fputs("\"members\":", file);
-			emit_params_json(file, module, params);
+			json_write_prop_key(e, "members");
+			emit_params_json(e, module, params);
 			return true;
 		}
 		return false;
@@ -638,172 +675,140 @@ static bool emit_doc_members_json(FILE *file, Module *module, Decl *decl, bool *
 	{
 		Decl **params = decl->attr_decl.params;
 		if (!vec_size(params)) return false;
-		if (!*first) fputs(",", file);
-		*first = false;
-		fputs("\"members\":", file);
-		emit_params_json(file, module, params);
+		json_write_prop_key(e, "members");
+		emit_params_json(e, module, params);
 		return true;
 	}
-	// For types: emit only when there is actual content
 	if (decl->decl_kind == DECL_ENUM || decl->decl_kind == DECL_CONSTDEF)
 	{
 		if (!vec_size(decl->enums.values)) return false;
-		if (!*first) fputs(",", file);
-		*first = false;
-		fputs("\"members\":[", file);
-		bool inner_first = true;
+		json_start_array_prop(e, "members");
 		FOREACH_IDX(i, Decl *, p, decl->enums.values)
 		{
-			if (!inner_first) fputs(",", file);
-			inner_first = false;
-			fputs("{\"name\":\"", file);
-			fputs(p->name ? p->name : "", file);
-			fputs("\"", file);
-			fputs(",\"type\":", file);
-			fputs("{\"name\":\"", file);
-			fputs(decl->name ? decl->name : "", file);
-			fputs("\"", file);
-			emit_decl_uid_json(file, decl);
-			fputs("}", file);
+			json_start_object(e);
+			json_write_prop_string(e, "name", p->name ? p->name : "");
+			json_start_object_prop(e, "type");
+			json_write_prop_string(e, "name", decl->name ? decl->name : "");
+			emit_decl_uid_json(e, decl);
+			json_end_object(e);
 			if (decl->decl_kind == DECL_ENUM && vec_size(decl->enums.parameters) > 0)
 			{
-				fputs(",\"value\":", file);
-				fputs("[", file);
+				json_start_array_prop(e, "value");
 				FOREACH_IDX(j, Expr *, expr, p->enum_constant.associated)
 				{
-					if (j > 0) fputs(",", file);
-					write_const_value_json(file, expr);
+					json_comma(e);
+					write_const_value_json(e->file, expr);
 				}
-				fputs("]", file);
+				json_end_array(e);
 			}
 			else if (p->enum_constant.value)
 			{
-				fputs(",\"value\":", file);
-				write_const_value_json(file, p->enum_constant.value);
+				json_write_prop_key(e, "value");
+				write_const_value_json(e->file, p->enum_constant.value);
 			}
-			bool item_doc_first = false;
-			emit_doc_comments(file, p, &item_doc_first);
-			fputs("}", file);
+			emit_doc_comments(e, p);
+			json_end_object(e);
 		}
-		fputs("]", file);
+		json_end_array(e);
 		return true;
 	}
 	if (decl_has_members(decl))
 	{
 		if (!vec_size(decl->strukt.members)) return false;
-		if (!*first) fputs(",", file);
-		*first = false;
-		fputs("\"members\":[", file);
-		bool struct_first = true;
-		emit_doc_struct_members(file, decl, &struct_first);
-		fputs("]", file);
+		json_start_array_prop(e, "members");
+		emit_doc_struct_members(e, decl);
+		json_end_array(e);
 		return true;
 	}
 	if (decl->decl_kind == DECL_INTERFACE)
 	{
 		if (!vec_size(decl->interface_methods)) return false;
-		if (!*first) fputs(",", file);
-		*first = false;
-		fputs("\"members\":[", file);
-		bool inner_first = true;
+		json_start_array_prop(e, "members");
 		FOREACH(Decl *, p, decl->interface_methods)
 		{
-			if (!inner_first) fputs(",", file);
-			inner_first = false;
-
-			fputs("{", file);
-			fprintf(file, "\"name\":\"%s\",\"type\":", p->name);
+			json_start_object(e);
+			json_write_prop_string(e, "name", p->name);
+			json_write_prop_key(e, "type");
 			if (p->func_decl.signature.rtype)
 			{
-				print_doc_type(file, module, type_infoptr(p->func_decl.signature.rtype), false);
+				print_doc_type(e, module, type_infoptr(p->func_decl.signature.rtype), false);
 			}
 			else
 			{
-				fputs("null", file);
+				fputs("null", e->file);
 			}
-			// Emit the parameter list so the HTML can reconstruct the full signature
-			fputs(",\"params\":[", file);
-			bool first_param = true;
+			json_start_array_prop(e, "params");
 			for (unsigned i = 1; i < vec_size(p->func_decl.signature.params); i++)
 			{
 				Decl *param = p->func_decl.signature.params[i];
 				if (!param) continue;
-				if (!first_param) fputs(",", file);
-				first_param = false;
-				emit_param_json(file, module, param);
+				emit_param_json(e, module, param);
 			}
-			fputs("]", file);
+			json_end_array(e);
 
 			if (p->func_decl.attr_optional)
 			{
-				fputs(",\"is_optional\":true", file);
+				json_write_prop_bool(e, "is_optional", true);
 			}
-
-			fputs("}", file);
+			json_end_object(e);
 		}
-		fputs("]", file);
+		json_end_array(e);
 		return true;
 	}
 	return false;
 }
 
-static void emit_custom_attrs(FILE *file, Decl *decl, bool *first)
+static void emit_custom_attrs(JsonEmitter *e, Decl *decl)
 {
 	if (!decl->resolved_attributes || !decl->attrs_resolved) return;
 	if (vec_size(decl->attrs_resolved->tags) == 0) return;
 
-	if (!*first) fputs(",", file);
-	*first = false;
-	fputs("\"custom_attrs\":[", file);
+	json_start_array_prop(e, "custom_attrs");
 	for (unsigned i = 0; i < vec_size(decl->attrs_resolved->tags); i++)
 	{
-		if (i > 0) fputs(",", file);
 		Attr *attr = decl->attrs_resolved->tags[i];
-		fputs("{", file);
-		fputs("\"name\":", file);
-		json_write_string(file, attr->name);
+		json_start_object(e);
+		json_write_prop_string(e, "name", attr->name);
 		if (vec_size(attr->exprs) > 0)
 		{
-			fputs(",\"args\":[", file);
+			json_start_array_prop(e, "args");
 			for (unsigned j = 0; j < vec_size(attr->exprs); j++)
 			{
-				if (j > 0) fputs(",", file);
-				Expr *e = attr->exprs[j];
-				if (expr_is_const_string(e))
+				json_comma(e);
+				Expr *ex = attr->exprs[j];
+				if (expr_is_const_string(ex))
 				{
-					json_write_string(file, e->const_expr.bytes.ptr);
+					json_write_string(e->file, ex->const_expr.bytes.ptr);
 				}
 				else
 				{
-					fputs("null", file);
+					fputs("null", e->file);
 				}
 			}
-			fputs("]", file);
+			json_end_array(e);
 		}
-		fputs("}", file);
+		json_end_object(e);
 	}
-	fputs("]", file);
+	json_end_array(e);
 }
 
-static void emit_normal_attrs(FILE *file, Decl *decl, bool *first)
+static void emit_normal_attrs(JsonEmitter *e, Decl *decl)
 {
 	bool has_attrs = false;
 
-#define EMIT_ATTR(flag, name)                 \
-	if (flag)                                 \
-	{                                         \
-		if (has_attrs)                        \
-		{                                     \
-			fputs(",", file);                 \
-		}                                     \
-		else                                  \
-		{                                     \
-			if (!*first) fputs(",", file);    \
-			*first = false;                   \
-			fputs("\"attributes\":[", file);  \
-			has_attrs = true;                 \
-		}                                     \
-		fputs("\"@" name "\"", file);         \
+#define EMIT_ATTR(flag, name)                               \
+	if (flag)                                               \
+	{                                                       \
+		if (!has_attrs)                                     \
+		{                                                   \
+			json_start_array_prop(e, "attributes");         \
+			has_attrs = true;                               \
+		}                                                   \
+		else                                                \
+		{                                                   \
+			fputs(",", e->file);                            \
+		}                                                   \
+		fputs("\"@" name "\"", e->file);                    \
 	}
 
 	EMIT_ATTR(decl->is_export, "export")
@@ -843,7 +848,7 @@ static void emit_normal_attrs(FILE *file, Decl *decl, bool *first)
 		EMIT_ATTR(decl->func_decl.signature.attrs.always_const, "const")
 	}
 
-	if (has_attrs) fputs("]", file);
+	if (has_attrs) json_end_array(e);
 #undef EMIT_ATTR
 }
 
@@ -855,7 +860,7 @@ static Decl *get_contract_decl(DeclId id)
 	return NULL;
 }
 
-static bool emit_doc_comments(FILE *file, Decl *decl, bool *first)
+static bool emit_doc_comments(JsonEmitter *e, Decl *decl)
 {
 	if (!decl) return false;
 
@@ -878,77 +883,55 @@ static bool emit_doc_comments(FILE *file, Decl *decl, bool *first)
 
 	if (!has_docs) return false;
 
-	if (!*first) fputs(",", file);
-	*first = false;
-	fputs("\"docs\":{", file);
-	bool inner_first = true;
+	json_start_object_prop(e, "docs");
 
 	if (deprecated)
 	{
-		fputs("\"deprecated\":", file);
-		json_write_string(file, deprecated);
-		inner_first = false;
+		json_write_prop_string(e, "deprecated", deprecated);
 	}
 
 	if (contract)
 	{
 		if (contract->contracts_decl.comment)
 		{
-			if (!inner_first) fputs(",", file);
-			fputs("\"text\":", file);
-			json_write_string(file, contract->contracts_decl.comment);
-			inner_first = false;
+			json_write_prop_string(e, "text", contract->contracts_decl.comment);
 		}
 
 		if (contract->contracts_decl.return_desc)
 		{
-			if (!inner_first) fputs(",", file);
-			fputs("\"return\":", file);
-			json_write_string(file, contract->contracts_decl.return_desc);
-			inner_first = false;
+			json_write_prop_string(e, "return", contract->contracts_decl.return_desc);
 		}
 
 		if (contract->contracts_decl.pure)
 		{
-			if (!inner_first) fputs(",", file);
-			fputs("\"pure\":true", file);
-			inner_first = false;
+			json_write_prop_bool(e, "pure", true);
 		}
 
 		if (vec_size(contract->contracts_decl.params) > 0)
 		{
-			if (!inner_first) fputs(",", file);
-			fputs("\"params\":[", file);
-			bool first_p = true;
+			json_start_array_prop(e, "params");
 			for (unsigned i = 0; i < vec_size(contract->contracts_decl.params); i++)
 			{
 				ContractParam *p = &contract->contracts_decl.params[i];
 				if (!p || !p->name) continue;
-				if (!first_p) fputs(",", file);
-				first_p = false;
 
-				fputs("{", file);
-				fputs("\"name\":", file);
-				json_write_string(file, p->name);
+				json_start_object(e);
+				json_write_prop_string(e, "name", p->name);
 				const char *mod = get_inout_modifier_name(p->modifier);
-				if (mod) fprintf(file, ",\"modifier\":\"%s\"", mod);
-				if (p->by_ref) fputs(",\"by_ref\":true", file);
-				if (p->description)
-				{
-					fputs(",\"description\":", file);
-					json_write_string(file, p->description);
-				}
-				fputs("}", file);
+				if (mod) json_write_prop_string(e, "modifier", mod);
+				if (p->by_ref) json_write_prop_bool(e, "by_ref", true);
+				if (p->description) json_write_prop_string(e, "description", p->description);
+				json_end_object(e);
 			}
-			fputs("]", file);
+			json_end_array(e);
 		}
 	}
 
-	fputs("}", file);
+	json_end_object(e);
 	return true;
 }
 
-static void emit_attrdef_target_json(FILE *file, Decl *decl, bool *first)
+static void emit_attrdef_target_json(JsonEmitter *e, Decl *decl)
 {
 	Attr **attrs = decl->attr_decl.attrs;
 	if (vec_size(attrs) == 0) return;
@@ -966,18 +949,15 @@ static void emit_attrdef_target_json(FILE *file, Decl *decl, bool *first)
 		if (vec_size(attr->exprs) > 0)
 		{
 			scratch_buffer_append("(");
-			FOREACH_IDX(j, Expr *, e, attr->exprs)
+			FOREACH_IDX(j, Expr *, ex, attr->exprs)
 			{
 				if (j > 0) scratch_buffer_append(", ");
-				if (e) loc_to_scratch(e->loc);
+				if (ex) loc_to_scratch(ex->loc);
 			}
 			scratch_buffer_append(")");
 		}
 	}
-	if (!*first) fputs(",", file);
-	*first = false;
-	fputs("\"target\":", file);
-	json_write_string(file, scratch_buffer_to_string());
+	json_write_prop_string(e, "target", scratch_buffer_to_string());
 }
 
 static const char *get_decl_kind_name(Decl *decl)
@@ -995,26 +975,14 @@ static const char *get_decl_kind_name(Decl *decl)
 	}
 }
 
-static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **generic_params)
+static void emit_decl_json(JsonEmitter *e, Module *module, Decl *decl, const char **generic_params)
 {
-	fputs("{", file);
-	bool first = true;
+	json_start_object(e);
 
-	if (!first) fputs(",", file);
-	first = false;
-	fputs("\"name\":", file);
-	json_write_string(file, decl->name);
-
-	if (!first) fputs(",", file);
-	first = false;
-	fputs("\"kind\":\"", file);
-	fputs(get_decl_kind_name(decl), file);
-	fputs("\"", file);
-
-	if (!first) fputs(",", file);
-	first = false;
-	fputs("\"uid\":", file);
-	write_decl_uid(file, module, decl);
+	json_write_prop_string(e, "name", decl->name);
+	json_write_prop_string(e, "kind", get_decl_kind_name(decl));
+	json_write_prop_key(e, "uid");
+	write_decl_uid(e, module, decl);
 
 	if (decl->loc)
 	{
@@ -1024,17 +992,12 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 			File *f = source_file_by_id(loc_info->file_id);
 			if (f && f->full_path)
 			{
-				if (!first) fputs(",", file);
-				first = false;
-				fputs("\"file\":", file);
 				scratch_buffer_clear();
 				const char *path = f->full_path;
-				// Strip cwd prefix to get a relative path
 				char cwd_buf[PATH_MAX + 1];
 				const char *cwd = getcwd(cwd_buf, sizeof(cwd_buf));
 				if (cwd)
 				{
-					// Normalize backslashes (Windows) to forward slashes
 					for (char *p = cwd_buf; *p; p++) if (*p == '\\') *p = '/';
 					size_t cwd_len = strlen(cwd);
 					if (strncmp(path, cwd, cwd_len) == 0 && path[cwd_len] == '/')
@@ -1043,36 +1006,30 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 					}
 				}
 				scratch_buffer_printf("%s:%u:%u", path, loc_info->row, loc_info->col);
-				json_write_string(file, scratch_buffer_to_string());
+				json_write_prop_string(e, "file", scratch_buffer_to_string());
 			}
 		}
 	}
 	if (decl->visibility != VISIBLE_PUBLIC)
 	{
-		if (!first) fputs(",", file);
-		first = false;
-		fprintf(file, "\"visibility\":\"%s\"", get_visibility_name(decl->visibility));
+		json_write_prop_string(e, "visibility", get_visibility_name(decl->visibility));
 	}
 	if (decl->is_template)
 	{
-		if (!first) fputs(",", file);
-		first = false;
-		fputs("\"is_generic\":true", file);
+		json_write_prop_bool(e, "is_generic", true);
 	}
 	if (generic_params)
 	{
 		unsigned param_count = vec_size(generic_params);
 		if (param_count > 0)
 		{
-			if (!first) fputs(",", file);
-			first = false;
-			fputs("\"generic_parameters\":[", file);
+			json_start_array_prop(e, "generic_parameters");
 			for (unsigned i = 0; i < param_count; i++)
 			{
-				if (i > 0) fputs(",", file);
-				json_write_string(file, generic_params[i]);
+				json_comma(e);
+				json_write_string(e->file, generic_params[i]);
 			}
-			fputs("]", file);
+			json_end_array(e);
 		}
 	}
 	if (decl_has_interface(decl))
@@ -1080,15 +1037,13 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 		unsigned iface_count = vec_size(decl->interfaces);
 		if (iface_count > 0)
 		{
-			if (!first) fputs(",", file);
-			first = false;
-			fputs("\"interfaces\":[", file);
+			json_start_array_prop(e, "interfaces");
 			for (unsigned i = 0; i < iface_count; i++)
 			{
-				if (i > 0) fputs(",", file);
-				print_doc_type(file, module, decl->interfaces[i], false);
+				json_comma(e);
+				print_doc_type(e, module, decl->interfaces[i], false);
 			}
-			fputs("]", file);
+			json_end_array(e);
 		}
 	}
 
@@ -1097,21 +1052,11 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 	{
 		case DECL_FUNC:
 		case DECL_MACRO:
-			emit_return_type_json(file, module, type_infoptrzero(decl->func_decl.signature.rtype), &first);
+			emit_return_type_json(e, module, type_infoptrzero(decl->func_decl.signature.rtype));
 			if (decl->decl_kind == DECL_MACRO)
 			{
-				if (decl->func_decl.signature.is_at_macro)
-				{
-					if (!first) fputs(",", file);
-					first = false;
-					fputs("\"is_at_macro\":true", file);
-				}
-				if (decl->func_decl.signature.is_safemacro)
-				{
-					if (!first) fputs(",", file);
-					first = false;
-					fputs("\"is_safemacro\":true", file);
-				}
+				if (decl->func_decl.signature.is_at_macro)  json_write_prop_bool(e, "is_at_macro", true);
+				if (decl->func_decl.signature.is_safemacro) json_write_prop_bool(e, "is_safemacro", true);
 			}
 			break;
 		case DECL_TYPE_ALIAS:
@@ -1120,7 +1065,7 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 				Decl *fntype = decl->type_alias_decl.decl;
 				if (fntype && fntype->decl_kind == DECL_FNTYPE)
 				{
-					emit_return_type_json(file, module, type_infoptrzero(fntype->fntype_decl.signature.rtype), &first);
+					emit_return_type_json(e, module, type_infoptrzero(fntype->fntype_decl.signature.rtype));
 				}
 				break;
 			}
@@ -1141,45 +1086,32 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 			base = decl->strukt.container_type;
 			goto PRINT_BASE;
 		case DECL_TYPEDEF:
-			if (decl->is_substruct)
-			{
-				if (!first) fputs(",", file);
-				first = false;
-				fputs("\"is_inline\":true", file);
-			}
+			if (decl->is_substruct) json_write_prop_bool(e, "is_inline", true);
 			base = decl->distinct;
 			goto PRINT_BASE;
 		PRINT_BASE:
-			if (!first) fputs(",", file);
-			first = false;
-			fputs("\"base_type\":", file);
-			print_doc_type(file, module, base, false);
+			json_write_prop_key(e, "base_type");
+			print_doc_type(e, module, base, false);
 			break;
 		case DECL_VAR:
 			base = type_infoptrzero(decl->var.type_info);
 			if (base)
 			{
-				if (!first) fputs(",", file);
-				first = false;
-				fputs("\"type\":", file);
-				print_doc_type(file, module, base, false);
+				json_write_prop_key(e, "type");
+				print_doc_type(e, module, base, false);
 			}
 			if (decl->var.kind == VARDECL_CONST)
 			{
-				if (!first) fputs(",", file);
-				first = false;
-				fputs("\"is_const\":true", file);
+				json_write_prop_bool(e, "is_const", true);
 			}
 			if (decl->var.init_expr)
 			{
-				if (!first) fputs(",", file);
-				first = false;
-				fputs("\"value\":", file);
-				write_const_value_json(file, decl->var.init_expr);
+				json_write_prop_key(e, "value");
+				write_const_value_json(e->file, decl->var.init_expr);
 			}
 			break;
 		case DECL_ATTRIBUTE:
-			emit_attrdef_target_json(file, decl, &first);
+			emit_attrdef_target_json(e, decl);
 			break;
 		case DECL_POISONED:
 		case DECL_BODYPARAM:
@@ -1211,24 +1143,19 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 	{
 		if (vec_size(decl->enums.parameters) > 0)
 		{
-			if (!first) fputs(",", file);
-			first = false;
-			fputs("\"associated_values\":[", file);
-			bool first_param = true;
+			json_start_array_prop(e, "associated_values");
 			FOREACH_IDX(i, Decl *, p, decl->enums.parameters)
 			{
-				if (!first_param) fputs(",", file);
-				first_param = false;
-				emit_param_json(file, module, p);
+				if (p) emit_param_json(e, module, p);
 			}
-			fputs("]", file);
+			json_end_array(e);
 		}
 	}
-	emit_doc_members_json(file, module, decl, &first);
-	emit_doc_comments(file, decl, &first);
-	emit_custom_attrs(file, decl, &first);
-	emit_normal_attrs(file, decl, &first);
-	fputs("}", file);
+	emit_doc_members_json(e, module, decl);
+	emit_doc_comments(e, decl);
+	emit_custom_attrs(e, decl);
+	emit_normal_attrs(e, decl);
+	json_end_object(e);
 }
 
 static DocCategory get_category_for_decl(Decl *decl)
@@ -1260,8 +1187,11 @@ static DocCategory get_category_for_decl(Decl *decl)
 	}
 }
 
-static bool category_has_content(Module *module, DocCategory cat)
+typedef void (*DocDeclCallback)(JsonEmitter *e, Module *module, Decl *decl, const char **generic_params, void *userdata);
+
+static bool foreach_doc_decl_in_category(Module *module, DocCategory cat, DocDeclCallback callback, JsonEmitter *e, void *userdata)
 {
+	bool found = false;
 	unsigned unit_count = vec_size(module->units);
 	for (unsigned j = 0; j < unit_count; j++)
 	{
@@ -1276,7 +1206,10 @@ static bool category_has_content(Module *module, DocCategory cat)
 			FOREACH(Decl *, decl, list)
 			{
 				if (decl->is_templated || decl->decl_kind == DECL_GENERIC_INSTANCE) continue;
-				if (get_category_for_decl(decl) == cat) return true;
+				if (get_category_for_decl(decl) != cat) continue;
+				found = true;
+				if (callback) callback(e, module, decl, NULL, userdata);
+				else return true;
 			}
 		}
 
@@ -1291,12 +1224,25 @@ static bool category_has_content(Module *module, DocCategory cat)
 				FOREACH(Decl *, decl, sub_lists[list_idx])
 				{
 					if (decl->is_templated || decl->decl_kind == DECL_GENERIC_INSTANCE) continue;
-					if (get_category_for_decl(decl) == cat) return true;
+					if (get_category_for_decl(decl) != cat) continue;
+					found = true;
+					if (callback) callback(e, module, decl, (const char **)gdecl->generic_decl.parameters, userdata);
+					else return true;
 				}
 			}
 		}
 	}
-	return false;
+	return found;
+}
+
+static bool category_has_content(Module *module, DocCategory cat)
+{
+	return foreach_doc_decl_in_category(module, cat, NULL, NULL, NULL);
+}
+
+static void emit_decl_json_cb(JsonEmitter *e, Module *module, Decl *decl, const char **generic_params, void *userdata)
+{
+	emit_decl_json(e, module, decl, generic_params);
 }
 
 void compiler_docgen(BuildTarget *target)
@@ -1341,11 +1287,13 @@ void compiler_docgen(BuildTarget *target)
 		fprintf(file, "\n\t\tEMBEDDED_JSON_LIST.push({ target: \"%s\", data: ", target_str);
 	}
 
-	fputs("{", file);
-	all_modules = compiler.context.module_list;
-	fputs("\"modules\":{", file);
+	JsonEmitter emitter;
+	json_init(&emitter, file);
 
-	bool first_module = true;
+	json_start_object(&emitter);
+	all_modules = compiler.context.module_list;
+	json_start_object_prop(&emitter, "modules");
+
 	FOREACH(Module *, module, all_modules)
 	{
 		if (target->emit_stdlib == EMIT_STDLIB_OFF &&
@@ -1374,10 +1322,7 @@ void compiler_docgen(BuildTarget *target)
 
 		if (!has_any_content) continue;
 
-		if (!first_module) fputs(",", file);
-		first_module = false;
-
-		fprintf(file, "\"%s\":{", module->name->module);
+		json_start_object_prop(&emitter, module->name->module);
 		Decl *module_generic = NULL;
 		FOREACH(CompilationUnit *, unit, module->units)
 		{
@@ -1389,76 +1334,33 @@ void compiler_docgen(BuildTarget *target)
 		}
 
 		bool is_module_generic = module_generic != NULL;
-		bool mod_first = true;
-		if (!mod_first) fputs(",", file);
-		mod_first = false;
-		fprintf(file, "\"is_generic\":%s", is_module_generic ? "true" : "false");
+		json_write_prop_bool(&emitter, "is_generic", is_module_generic);
 		if (is_module_generic)
 		{
-			fputs(",\"generic_parameters\":[", file);
+			json_start_array_prop(&emitter, "generic_parameters");
 			GenericDecl *g = &module_generic->generic_decl;
 			for (unsigned j = 0; j < vec_size(g->parameters); j++)
 			{
-				if (j > 0) fputs(",", file);
-				json_write_string(file, g->parameters[j]);
+				json_comma(&emitter);
+				json_write_string(emitter.file, g->parameters[j]);
 			}
-			fputs("]", file);
+			json_end_array(&emitter);
 		}
 
-		if (module_doc) emit_doc_comments(file, declptr(module_doc), &mod_first);
+		if (module_doc) emit_doc_comments(&emitter, declptr(module_doc));
 
 		for (int cat = 0; cat < DOC_CAT_COUNT; cat++)
 		{
 			if (!cat_has_content[cat]) continue;
 
-			fputs(",", file);
-			fprintf(file, "\"%s\":[", category_names[cat]);
-
-			bool first_in_cat = true;
-			for (unsigned j = 0; j < unit_count; j++)
-			{
-				CompilationUnit *unit = module->units[j];
-				Decl **lists[3];
-				get_unit_lists(unit, (DocCategory)cat, lists);
-
-				for (int l = 0; l < 3; l++)
-				{
-					Decl **list = lists[l];
-					FOREACH(Decl *, decl, list)
-					{
-						if (decl->is_templated || decl->decl_kind == DECL_GENERIC_INSTANCE) continue;
-						if (!first_in_cat) fputs(",", file);
-						first_in_cat = false;
-						emit_decl_json(file, module, decl, NULL);
-					}
-				}
-
-				unsigned generic_count = vec_size(unit->generic_decls);
-				for (unsigned k = 0; k < generic_count; k++)
-				{
-					Decl *gdecl = unit->generic_decls[k];
-					if (gdecl->decl_kind != DECL_GENERIC) continue;
-					Decl **sub_lists[2] = {gdecl->generic_decl.decls, gdecl->generic_decl.conditional_decls};
-					for (int list_idx = 0; list_idx < 2; list_idx++)
-					{
-						FOREACH(Decl *, decl, sub_lists[list_idx])
-						{
-							if (decl->is_templated || decl->decl_kind == DECL_GENERIC_INSTANCE) continue;
-							if (get_category_for_decl(decl) == cat)
-							{
-								if (!first_in_cat) fputs(",", file);
-								first_in_cat = false;
-								emit_decl_json(file, module, decl, (const char **)gdecl->generic_decl.parameters);
-							}
-						}
-					}
-				}
-			}
-			fputs("]", file);
+			json_start_array_prop(&emitter, category_names[cat]);
+			foreach_doc_decl_in_category(module, (DocCategory)cat, emit_decl_json_cb, &emitter, NULL);
+			json_end_array(&emitter);
 		}
-		fputs("}", file);
+		json_end_object(&emitter);
 	}
-	fputs("}}", file);
+	json_end_object(&emitter);
+	json_end_object(&emitter);
 
 	if (!json_only)
 	{

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -1235,7 +1235,10 @@ void compiler_docgen(BuildTarget *target)
 	bool first_module = true;
 	FOREACH(Module *, module, all_modules)
 	{
-		if (target->emit_stdlib == EMIT_STDLIB_OFF && module_is_stdlib(module)) continue;
+		if (target->emit_stdlib == EMIT_STDLIB_OFF &&
+			(module_is_stdlib(module) ||
+			 (module->name->len == 11 && strcmp(module->name->module, "compiler_rt") == 0) ||
+			 (module->name->len > 13 && memcmp(module->name->module, "compiler_rt::", 13) == 0))) continue;
 
 		DeclId module_doc = 0;
 		unsigned unit_count = vec_size(module->units);

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -1187,9 +1187,7 @@ static DocCategory get_category_for_decl(Decl *decl)
 	}
 }
 
-typedef void (*DocDeclCallback)(JsonEmitter *e, Module *module, Decl *decl, const char **generic_params, void *userdata);
-
-static bool foreach_doc_decl_in_category(Module *module, DocCategory cat, DocDeclCallback callback, JsonEmitter *e, void *userdata)
+static bool emit_category_decls(JsonEmitter *e, Module *module, DocCategory cat)
 {
 	bool found = false;
 	unsigned unit_count = vec_size(module->units);
@@ -1208,7 +1206,7 @@ static bool foreach_doc_decl_in_category(Module *module, DocCategory cat, DocDec
 				if (decl->is_templated || decl->decl_kind == DECL_GENERIC_INSTANCE) continue;
 				if (get_category_for_decl(decl) != cat) continue;
 				found = true;
-				if (callback) callback(e, module, decl, NULL, userdata);
+				if (e) emit_decl_json(e, module, decl, NULL);
 				else return true;
 			}
 		}
@@ -1226,7 +1224,7 @@ static bool foreach_doc_decl_in_category(Module *module, DocCategory cat, DocDec
 					if (decl->is_templated || decl->decl_kind == DECL_GENERIC_INSTANCE) continue;
 					if (get_category_for_decl(decl) != cat) continue;
 					found = true;
-					if (callback) callback(e, module, decl, (const char **)gdecl->generic_decl.parameters, userdata);
+					if (e) emit_decl_json(e, module, decl, (const char **)gdecl->generic_decl.parameters);
 					else return true;
 				}
 			}
@@ -1237,12 +1235,7 @@ static bool foreach_doc_decl_in_category(Module *module, DocCategory cat, DocDec
 
 static bool category_has_content(Module *module, DocCategory cat)
 {
-	return foreach_doc_decl_in_category(module, cat, NULL, NULL, NULL);
-}
-
-static void emit_decl_json_cb(JsonEmitter *e, Module *module, Decl *decl, const char **generic_params, void *userdata)
-{
-	emit_decl_json(e, module, decl, generic_params);
+	return emit_category_decls(NULL, module, cat);
 }
 
 void compiler_docgen(BuildTarget *target)
@@ -1354,7 +1347,7 @@ void compiler_docgen(BuildTarget *target)
 			if (!cat_has_content[cat]) continue;
 
 			json_start_array_prop(&emitter, category_names[cat]);
-			foreach_doc_decl_in_category(module, (DocCategory)cat, emit_decl_json_cb, &emitter, NULL);
+			emit_category_decls(&emitter, module, (DocCategory)cat);
 			json_end_array(&emitter);
 		}
 		json_end_object(&emitter);

--- a/src/compiler/docgen.c
+++ b/src/compiler/docgen.c
@@ -9,13 +9,14 @@ typedef enum
 	DOC_CAT_FUNCTIONS,
 	DOC_CAT_METHODS,
 	DOC_CAT_MACROS,
+	DOC_CAT_ATTRDEFS,
 	DOC_CAT_MACRO_METHODS,
 	DOC_CAT_TYPES,
 	DOC_CAT_VARIABLES,
 	DOC_CAT_COUNT
 } DocCategory;
 
-static const char *category_names[DOC_CAT_COUNT] = {"functions", "methods", "macros", "macro_methods", "types", "variables"};
+static const char *category_names[DOC_CAT_COUNT] = {"functions", "methods", "macros", "attrdefs", "macro_methods", "types", "variables"};
 static Module **all_modules = NULL;
 
 static void write_decl_uid(FILE *file, Module *module, Decl *decl);
@@ -102,6 +103,9 @@ static void get_unit_lists(CompilationUnit *unit, DocCategory cat, Decl ***lists
 			break;
 		case DOC_CAT_MACROS:
 			lists[i++] = unit->macros;
+			break;
+		case DOC_CAT_ATTRDEFS:
+			lists[i++] = unit->attributes;
 			break;
 		case DOC_CAT_MACRO_METHODS:
 			lists[i++] = unit->macro_methods;
@@ -586,6 +590,11 @@ static void emit_doc_members(FILE *file, Module *module, Decl *decl)
 			return;
 		}
 	}
+	if (decl->decl_kind == DECL_ATTRIBUTE)
+	{
+		emit_params_json(file, module, decl->attr_decl.params);
+		return;
+	}
 	fputs("[", file);
 	bool first = true;
 	if (decl->decl_kind == DECL_ENUM || decl->decl_kind == DECL_CONSTDEF)
@@ -781,7 +790,12 @@ static void emit_doc_comments(FILE *file, Decl *decl)
 		return;
 	}
 
-	Decl *contract = (decl->decl_kind == DECL_CONTRACT) ? decl : get_contract_decl(decl->docs);
+	DeclId docs_id = decl->docs;
+	if (!docs_id && decl->decl_kind == DECL_TYPE_ALIAS && decl->type_alias_decl.is_func && decl->type_alias_decl.decl)
+	{
+		docs_id = decl->type_alias_decl.decl->docs;
+	}
+	Decl *contract = (decl->decl_kind == DECL_CONTRACT) ? decl : get_contract_decl(docs_id);
 	const char *deprecated = (decl->resolved_attributes && decl->attrs_resolved) ? decl->attrs_resolved->deprecated : NULL;
 
 	if (!contract && !deprecated)
@@ -855,6 +869,37 @@ static void emit_doc_comments(FILE *file, Decl *decl)
 	}
 
 	fputs("}", file);
+}
+
+static void emit_attrdef_target_json(FILE *file, Decl *decl)
+{
+	Attr **attrs = decl->attr_decl.attrs;
+	if (vec_size(attrs) == 0) return;
+
+	scratch_buffer_clear();
+	FOREACH_IDX(i, Attr *, attr, attrs)
+	{
+		if (!attr) continue;
+		if (i > 0) scratch_buffer_append(" ");
+		if (attr->name)
+		{
+			if (attr->name[0] != '@') scratch_buffer_append("@");
+			scratch_buffer_append(attr->name);
+		}
+		if (vec_size(attr->exprs) > 0)
+		{
+			scratch_buffer_append("(");
+			FOREACH_IDX(j, Expr *, e, attr->exprs)
+			{
+				if (j > 0) scratch_buffer_append(", ");
+				if (e) loc_to_scratch(e->loc);
+			}
+			scratch_buffer_append(")");
+		}
+	}
+	fputs("\"target\":", file);
+	json_write_string(file, scratch_buffer_to_string());
+	fputs(",", file);
 }
 
 static const char *get_decl_kind_name(Decl *decl)
@@ -1017,8 +1062,10 @@ static void emit_decl_json(FILE *file, Module *module, Decl *decl, const char **
 				fputs(",", file);
 			}
 			break;
-		case DECL_POISONED:
 		case DECL_ATTRIBUTE:
+			emit_attrdef_target_json(file, decl);
+			break;
+		case DECL_POISONED:
 		case DECL_BODYPARAM:
 		case DECL_CT_ASSERT:
 		case DECL_CT_ECHO:
@@ -1081,6 +1128,8 @@ static DocCategory get_category_for_decl(Decl *decl)
 		case DECL_MACRO:
 			if (decl->func_decl.type_parent) return DOC_CAT_MACRO_METHODS;
 			return DOC_CAT_MACROS;
+		case DECL_ATTRIBUTE:
+			return DOC_CAT_ATTRDEFS;
 		case DECL_STRUCT:
 		case DECL_UNION:
 		case DECL_ENUM:

--- a/src/compiler/parse_global.c
+++ b/src/compiler/parse_global.c
@@ -2580,6 +2580,8 @@ static inline Decl *parse_attrdef(ParseContext *c)
 	Attr **attributes = NULL;
 	if (!parse_attributes_for_global(c, decl)) return poisoned_decl;
 
+	decl->docs = decl_from_contract_description(&c->contracts);
+
 	// Empty
 	if (try_consume(c, TOKEN_EOS)) return decl;
 


### PR DESCRIPTION
Fixes #3333, #3334, #3408

- Emit `attrdef` declarations and attached doc comments in JSON output.
- Include doc comments on `alias` declarations in JSON output.
- Render contract `@return` documentation in docs.html symbol details.
- Suppress empty `docs`, `members`, and `name` JSON fields. (make it slimmer basically)
- Refactor `docgen.c` JSON emission using JsonEmitter API. This was needed for my sanity.
- and docs.html general cleanup

I've also:
- Excluded `compiler_rt` from `--emit-stdlib=no` on docgen.