### PR TITLE
feat: Adds `lidt` and `lgdt` instructions to inline assembly for x86 targets 

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -4,7 +4,6 @@
 
 ### Changes / improvements
 - Windows aarch64 is now supported.
-- Add the `lgdt` and `lidt` instructions to x86 inline assembly.
 - Tracking allocator can now accept cross-thread allocations.
 - Filter test backtraces #3368
 - Improved GDB compatibility for macros.
@@ -15,6 +14,7 @@
 - Experimental support for `constset`, `cenum`, `faultconst`, `faultset`, `excuse`, `attrgroup`, `attrmacro`, `distinct`.
 - Defer resolution of typedef alignment and generics, allowing more recursive definitions.
 - Improve error message on multiple <* *> in a row. #2971
+- Add the `lgdt` and `lidt` instructions to x86 inline assembly.
 
 ### Stdlib changes
 - LinkedList and Deque added a `prepend` method.

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -4,6 +4,7 @@
 
 ### Changes / improvements
 - Windows aarch64 is now supported.
+- Add the `lgdt` and `lidt` instructions to x86 inline assembly.
 - Tracking allocator can now accept cross-thread allocations.
 - Filter test backtraces #3368
 - Improved GDB compatibility for macros.

--- a/src/compiler/asm_target.c
+++ b/src/compiler/asm_target.c
@@ -874,6 +874,10 @@ static void init_asm_x86(PlatformTarget* target)
 	// RDSEED
 	reg_instr_clob(target, "rdseed", cc_flag_mask, "w:r16/r32/r64");
 
+	// LGDT, LIDT
+	reg_instr(target, "lgdt", "mem");
+	reg_instr(target, "lidt", "mem");
+
 	target->clobber_name_list = X86ClobberNames;
 	target->extra_clobbers = "~{flags},~{dirflag},~{fspr}";
 	if (target->arch == ARCH_TYPE_X86)


### PR DESCRIPTION
Adds the `lgdt` and `lidt` instructions support to inline assembly for x86 targets