### PR TITLE
fix: write back the hi-offset GEP in llvm_coerce_expand_hi_offset

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -40,7 +40,6 @@
 - ThreadGroup with function returning `void` was broken.
 - Timed `tcp::connect` always failed with `io::GENERAL_ERROR` instead of the real result.
 - Compile time struct with zeroed union member access causes compiler error #3382.
-- RISC-V structs with mixed FP and integer fields were corrupted when passed or returned by value. #3428
 - Generic methods checked before the generic type is fully registered.
 - Math function `_erff` invoked C `erf` function instead of `erff` function #3391
 - Defining local constants inside a macro causes it to fail to @const fold. #3397
@@ -57,6 +56,7 @@
 - Several uses of InStream didn't properly handle io::EOF.
 - Fixes to memory handling during zip loading.
 - Multireader reading after a final empty read would crash.
+- RISC-V structs with mixed FP and integer fields were corrupted when passed or returned by value. #3428
 
 ## 0.8.2 Change list
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -38,6 +38,7 @@
 - ThreadGroup with function returning `void` was broken.
 - Timed `tcp::connect` always failed with `io::GENERAL_ERROR` instead of the real result.
 - Compile time struct with zeroed union member access causes compiler error #3382.
+- RISC-V structs with mixed FP and integer fields were corrupted when passed or returned by value. #3428
 - Generic methods checked before the generic type is fully registered.
 - Math function `_erff` invoked C `erf` function instead of `erff` function #3391
 - Defining local constants inside a macro causes it to fail to @const fold. #3397

--- a/src/compiler/llvm_codegen_expr.c
+++ b/src/compiler/llvm_codegen_expr.c
@@ -442,11 +442,11 @@ LLVMTypeRef llvm_coerce_expand_hi_offset(GenContext *c, LLVMValueRef *addr, ABIA
 	if (info->coerce_expand.packed)
 	{
 		*align = type_min_alignment(*align, *align + info->coerce_expand.offset_hi);
-		llvm_emit_const_ptradd_inbounds_raw(c, *addr, info->coerce_expand.offset_hi);
+		*addr = llvm_emit_const_ptradd_inbounds_raw(c, *addr, info->coerce_expand.offset_hi);
 		return type2;
 	}
 	*align = type_min_alignment(*align, *align + llvm_store_size(c, type2) * info->coerce_expand.offset_hi);
-	llvm_emit_const_ptradd_inbounds_raw(c, *addr, type_size(info->coerce_expand.hi) * info->coerce_expand.offset_hi);
+	*addr = llvm_emit_const_ptradd_inbounds_raw(c, *addr, type_size(info->coerce_expand.hi) * info->coerce_expand.offset_hi);
 	return type2;
 }
 /**

--- a/test/test_suite/abi/riscv32-ilp32d-abi.c3t
+++ b/test/test_suite/abi/riscv32-ilp32d-abi.c3t
@@ -203,7 +203,7 @@ entry:
   %a = alloca %Double_double_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i32 8
-  store double %1, ptr %a, align 8
+  store double %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -214,7 +214,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.1, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 8
-  %1 = load double, ptr %literal, align 8
+  %1 = load double, ptr %ptradd, align 8
   %2 = insertvalue { double, double } undef, double %0, 0
   %3 = insertvalue { double, double } %2, double %1, 1
   ret { double, double } %3
@@ -226,7 +226,7 @@ entry:
   %a = alloca %Double_float_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i32 8
-  store float %1, ptr %a, align 8
+  store float %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -237,7 +237,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.2, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 8
-  %1 = load float, ptr %literal, align 8
+  %1 = load float, ptr %ptradd, align 8
   %2 = insertvalue { double, float } undef, double %0, 0
   %3 = insertvalue { double, float } %2, float %1, 1
   ret { double, float } %3
@@ -255,7 +255,7 @@ entry:
   %a = alloca %Double_int8_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i32 8
-  store i8 %1, ptr %a, align 8
+  store i8 %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -266,7 +266,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.3, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 8
-  %1 = load i8, ptr %literal, align 8
+  %1 = load i8, ptr %ptradd, align 8
   %2 = insertvalue { double, i8 } undef, double %0, 0
   %3 = insertvalue { double, i8 } %2, i8 %1, 1
   ret { double, i8 } %3
@@ -278,7 +278,7 @@ entry:
   %a = alloca %Double_uint8_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i32 8
-  store i8 %1, ptr %a, align 8
+  store i8 %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -289,7 +289,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.4, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 8
-  %1 = load i8, ptr %literal, align 8
+  %1 = load i8, ptr %ptradd, align 8
   %2 = insertvalue { double, i8 } undef, double %0, 0
   %3 = insertvalue { double, i8 } %2, i8 %1, 1
   ret { double, i8 } %3
@@ -301,7 +301,7 @@ entry:
   %a = alloca %Double_int32_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i32 8
-  store i32 %1, ptr %a, align 8
+  store i32 %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -312,7 +312,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.5, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 8
-  %1 = load i32, ptr %literal, align 8
+  %1 = load i32, ptr %ptradd, align 8
   %2 = insertvalue { double, i32 } undef, double %0, 0
   %3 = insertvalue { double, i32 } %2, i32 %1, 1
   ret { double, i32 } %3
@@ -368,7 +368,7 @@ entry:
   %a = alloca %Doublearr2_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i32 8
-  store double %1, ptr %a, align 8
+  store double %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -379,7 +379,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.8, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 8
-  %1 = load double, ptr %literal, align 8
+  %1 = load double, ptr %ptradd, align 8
   %2 = insertvalue { double, double } undef, double %0, 0
   %3 = insertvalue { double, double } %2, double %1, 1
   ret { double, double } %3
@@ -391,7 +391,7 @@ entry:
   %a = alloca %Doublearr2_tricky1_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i32 8
-  store double %1, ptr %a, align 8
+  store double %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -402,7 +402,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.9, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 8
-  %1 = load double, ptr %literal, align 8
+  %1 = load double, ptr %ptradd, align 8
   %2 = insertvalue { double, double } undef, double %0, 0
   %3 = insertvalue { double, double } %2, double %1, 1
   ret { double, double } %3
@@ -477,11 +477,11 @@ entry:
   %literal = alloca %Double_int32_s, align 8
   store double %7, ptr %h, align 8
   %ptradd = getelementptr inbounds i8, ptr %h, i32 8
-  store i32 %8, ptr %h, align 8
+  store i32 %8, ptr %ptradd, align 8
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.14, i32 16, i1 false)
   %9 = load double, ptr %literal, align 8
   %ptradd1 = getelementptr inbounds i8, ptr %literal, i32 8
-  %10 = load i32, ptr %literal, align 8
+  %10 = load i32, ptr %ptradd1, align 8
   %11 = insertvalue { double, i32 } undef, double %9, 0
   %12 = insertvalue { double, i32 } %11, i32 %10, 1
   ret { double, i32 } %12
@@ -494,11 +494,11 @@ entry:
   %literal = alloca %Double_double_s, align 8
   store double %7, ptr %h, align 8
   %ptradd = getelementptr inbounds i8, ptr %h, i32 8
-  store i32 %8, ptr %h, align 8
+  store i32 %8, ptr %ptradd, align 8
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.15, i32 16, i1 false)
   %9 = load double, ptr %literal, align 8
   %ptradd1 = getelementptr inbounds i8, ptr %literal, i32 8
-  %10 = load double, ptr %literal, align 8
+  %10 = load double, ptr %ptradd1, align 8
   %11 = insertvalue { double, double } undef, double %9, 0
   %12 = insertvalue { double, double } %11, double %10, 1
   ret { double, double } %12

--- a/test/test_suite/abi/riscv32-ilp32f-ilp32d-abi-2.c3t
+++ b/test/test_suite/abi/riscv32-ilp32f-ilp32d-abi-2.c3t
@@ -178,7 +178,7 @@ entry:
   %a = alloca %Float_float_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i32 4
-  store float %1, ptr %a, align 4
+  store float %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -188,7 +188,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.1, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 4
-  %1 = load float, ptr %literal, align 4
+  %1 = load float, ptr %ptradd, align 4
   %2 = insertvalue { float, float } undef, float %0, 0
   %3 = insertvalue { float, float } %2, float %1, 1
   ret { float, float } %3
@@ -208,7 +208,7 @@ entry:
   %a = alloca %Float_int8_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i32 4
-  store i8 %1, ptr %a, align 4
+  store i8 %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -219,7 +219,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.2, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 4
-  %1 = load i8, ptr %literal, align 4
+  %1 = load i8, ptr %ptradd, align 4
   %2 = insertvalue { float, i8 } undef, float %0, 0
   %3 = insertvalue { float, i8 } %2, i8 %1, 1
   ret { float, i8 } %3
@@ -231,7 +231,7 @@ entry:
   %a = alloca %Float_uint8_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i32 4
-  store i8 %1, ptr %a, align 4
+  store i8 %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -242,7 +242,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.3, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 4
-  %1 = load i8, ptr %literal, align 4
+  %1 = load i8, ptr %ptradd, align 4
   %2 = insertvalue { float, i8 } undef, float %0, 0
   %3 = insertvalue { float, i8 } %2, i8 %1, 1
   ret { float, i8 } %3
@@ -254,7 +254,7 @@ entry:
   %a = alloca %Float_int32_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i32 4
-  store i32 %1, ptr %a, align 4
+  store i32 %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -265,7 +265,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.4, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 4
-  %1 = load i32, ptr %literal, align 4
+  %1 = load i32, ptr %ptradd, align 4
   %2 = insertvalue { float, i32 } undef, float %0, 0
   %3 = insertvalue { float, i32 } %2, i32 %1, 1
   ret { float, i32 } %3
@@ -325,7 +325,7 @@ entry:
   %a = alloca %Floatarr2_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i32 4
-  store float %1, ptr %a, align 4
+  store float %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -336,7 +336,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.7, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 4
-  %1 = load float, ptr %literal, align 4
+  %1 = load float, ptr %ptradd, align 4
   %2 = insertvalue { float, float } undef, float %0, 0
   %3 = insertvalue { float, float } %2, float %1, 1
   ret { float, float } %3
@@ -348,7 +348,7 @@ entry:
   %a = alloca %Floatarr2_tricky1_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i32 4
-  store float %1, ptr %a, align 4
+  store float %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -359,7 +359,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.8, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i32 4
-  %1 = load float, ptr %literal, align 4
+  %1 = load float, ptr %ptradd, align 4
   %2 = insertvalue { float, float } undef, float %0, 0
   %3 = insertvalue { float, float } %2, float %1, 1
   ret { float, float } %3

--- a/test/test_suite/abi/riscv64-lp64d-abi.c3t
+++ b/test/test_suite/abi/riscv64-lp64d-abi.c3t
@@ -181,7 +181,7 @@ entry:
   %a = alloca %Double_double_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i64 8
-  store double %1, ptr %a, align 8
+  store double %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -192,7 +192,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.1, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 8
-  %1 = load double, ptr %literal, align 8
+  %1 = load double, ptr %ptradd, align 8
   %2 = insertvalue { double, double } undef, double %0, 0
   %3 = insertvalue { double, double } %2, double %1, 1
   ret { double, double } %3
@@ -204,7 +204,7 @@ entry:
   %a = alloca %Double_float_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i64 8
-  store float %1, ptr %a, align 8
+  store float %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -215,7 +215,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.2, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 8
-  %1 = load float, ptr %literal, align 8
+  %1 = load float, ptr %ptradd, align 8
   %2 = insertvalue { double, float } undef, double %0, 0
   %3 = insertvalue { double, float } %2, float %1, 1
   ret { double, float } %3
@@ -235,7 +235,7 @@ entry:
   %a = alloca %Double_int8_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i64 8
-  store i8 %1, ptr %a, align 8
+  store i8 %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -246,7 +246,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.3, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 8
-  %1 = load i8, ptr %literal, align 8
+  %1 = load i8, ptr %ptradd, align 8
   %2 = insertvalue { double, i8 } undef, double %0, 0
   %3 = insertvalue { double, i8 } %2, i8 %1, 1
   ret { double, i8 } %3
@@ -258,7 +258,7 @@ entry:
   %a = alloca %Double_uint8_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i64 8
-  store i8 %1, ptr %a, align 8
+  store i8 %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -269,7 +269,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.4, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 8
-  %1 = load i8, ptr %literal, align 8
+  %1 = load i8, ptr %ptradd, align 8
   %2 = insertvalue { double, i8 } undef, double %0, 0
   %3 = insertvalue { double, i8 } %2, i8 %1, 1
   ret { double, i8 } %3
@@ -281,7 +281,7 @@ entry:
   %a = alloca %Double_int32_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i64 8
-  store i32 %1, ptr %a, align 8
+  store i32 %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -292,7 +292,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.5, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 8
-  %1 = load i32, ptr %literal, align 8
+  %1 = load i32, ptr %ptradd, align 8
   %2 = insertvalue { double, i32 } undef, double %0, 0
   %3 = insertvalue { double, i32 } %2, i32 %1, 1
   ret { double, i32 } %3
@@ -304,7 +304,7 @@ entry:
   %a = alloca %Double_int64_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i64 8
-  store i64 %1, ptr %a, align 8
+  store i64 %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -315,7 +315,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.6, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 8
-  %1 = load i64, ptr %literal, align 8
+  %1 = load i64, ptr %ptradd, align 8
   %2 = insertvalue { double, i64 } undef, double %0, 0
   %3 = insertvalue { double, i64 } %2, i64 %1, 1
   ret { double, i64 } %3
@@ -360,7 +360,7 @@ entry:
   %a = alloca %Doublearr2_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i64 8
-  store double %1, ptr %a, align 8
+  store double %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -371,7 +371,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.8, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 8
-  %1 = load double, ptr %literal, align 8
+  %1 = load double, ptr %ptradd, align 8
   %2 = insertvalue { double, double } undef, double %0, 0
   %3 = insertvalue { double, double } %2, double %1, 1
   ret { double, double } %3
@@ -383,7 +383,7 @@ entry:
   %a = alloca %Doublearr2_tricky1_s, align 8
   store double %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i64 8
-  store double %1, ptr %a, align 8
+  store double %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -394,7 +394,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.9, i32 16, i1 false)
   %0 = load double, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 8
-  %1 = load double, ptr %literal, align 8
+  %1 = load double, ptr %ptradd, align 8
   %2 = insertvalue { double, double } undef, double %0, 0
   %3 = insertvalue { double, double } %2, double %1, 1
   ret { double, double } %3

--- a/test/test_suite/abi/riscv64-lp64f-lp64d-abi-2.c3t
+++ b/test/test_suite/abi/riscv64-lp64f-lp64d-abi-2.c3t
@@ -159,7 +159,7 @@ entry:
   %a = alloca %Float_float_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i64 4
-  store float %1, ptr %a, align 4
+  store float %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -170,7 +170,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.1, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 4
-  %1 = load float, ptr %literal, align 4
+  %1 = load float, ptr %ptradd, align 4
   %2 = insertvalue { float, float } undef, float %0, 0
   %3 = insertvalue { float, float } %2, float %1, 1
   ret { float, float } %3
@@ -190,7 +190,7 @@ entry:
   %a = alloca %Float_int8_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i64 4
-  store i8 %1, ptr %a, align 4
+  store i8 %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -201,7 +201,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.2, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 4
-  %1 = load i8, ptr %literal, align 4
+  %1 = load i8, ptr %ptradd, align 4
   %2 = insertvalue { float, i8 } undef, float %0, 0
   %3 = insertvalue { float, i8 } %2, i8 %1, 1
   ret { float, i8 } %3
@@ -213,7 +213,7 @@ entry:
   %a = alloca %Float_uint8_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i64 4
-  store i8 %1, ptr %a, align 4
+  store i8 %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -224,7 +224,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.3, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 4
-  %1 = load i8, ptr %literal, align 4
+  %1 = load i8, ptr %ptradd, align 4
   %2 = insertvalue { float, i8 } undef, float %0, 0
   %3 = insertvalue { float, i8 } %2, i8 %1, 1
   ret { float, i8 } %3
@@ -236,7 +236,7 @@ entry:
   %a = alloca %Float_int32_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i64 4
-  store i32 %1, ptr %a, align 4
+  store i32 %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -247,7 +247,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.4, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 4
-  %1 = load i32, ptr %literal, align 4
+  %1 = load i32, ptr %ptradd, align 4
   %2 = insertvalue { float, i32 } undef, float %0, 0
   %3 = insertvalue { float, i32 } %2, i32 %1, 1
   ret { float, i32 } %3
@@ -259,7 +259,7 @@ entry:
   %a = alloca %Float_int64_s, align 8
   store float %0, ptr %a, align 8
   %ptradd = getelementptr inbounds i8, ptr %a, i64 8
-  store i64 %1, ptr %a, align 8
+  store i64 %1, ptr %ptradd, align 8
   ret void
 }
 
@@ -270,7 +270,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 8 %literal, ptr align 8 @.__const.5, i32 16, i1 false)
   %0 = load float, ptr %literal, align 8
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 8
-  %1 = load i64, ptr %literal, align 8
+  %1 = load i64, ptr %ptradd, align 8
   %2 = insertvalue { float, i64 } undef, float %0, 0
   %3 = insertvalue { float, i64 } %2, i64 %1, 1
   ret { float, i64 } %3
@@ -315,7 +315,7 @@ entry:
   %a = alloca %Floatarr2_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i64 4
-  store float %1, ptr %a, align 4
+  store float %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -326,7 +326,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.7, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 4
-  %1 = load float, ptr %literal, align 4
+  %1 = load float, ptr %ptradd, align 4
   %2 = insertvalue { float, float } undef, float %0, 0
   %3 = insertvalue { float, float } %2, float %1, 1
   ret { float, float } %3
@@ -338,7 +338,7 @@ entry:
   %a = alloca %Floatarr2_tricky1_s, align 4
   store float %0, ptr %a, align 4
   %ptradd = getelementptr inbounds i8, ptr %a, i64 4
-  store float %1, ptr %a, align 4
+  store float %1, ptr %ptradd, align 4
   ret void
 }
 
@@ -349,7 +349,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i32(ptr align 4 %literal, ptr align 4 @.__const.8, i32 8, i1 false)
   %0 = load float, ptr %literal, align 4
   %ptradd = getelementptr inbounds i8, ptr %literal, i64 4
-  %1 = load float, ptr %literal, align 4
+  %1 = load float, ptr %ptradd, align 4
   %2 = insertvalue { float, float } undef, float %0, 0
   %3 = insertvalue { float, float } %2, float %1, 1
   ret { float, float } %3


### PR DESCRIPTION
# PR: fix riscv64 ABI corruption of FP+int structs passed/returned by value

Fixes #3428.

## Problem

`llvm_coerce_expand_hi_offset` computes the address of the `hi` member of an
`ABI_ARG_EXPAND_COERCE` pair but drops the GEP result, so `*addr` keeps
pointing at `lo`. All four call sites then place/read the `hi` value at
offset 0. On RISC-V this corrupts any `{float, int}`-style struct passed or
returned by value (the integer member arrives as 0).

## Fix

```diff
 	if (info->coerce_expand.packed)
 	{
 		*align = type_min_alignment(*align, *align + info->coerce_expand.offset_hi);
-		llvm_emit_const_ptradd_inbounds_raw(c, *addr, info->coerce_expand.offset_hi);
+		*addr = llvm_emit_const_ptradd_inbounds_raw(c, *addr, info->coerce_expand.offset_hi);
 		return type2;
 	}
 	*align = type_min_alignment(*align, *align + llvm_store_size(c, type2) * info->coerce_expand.offset_hi);
-	llvm_emit_const_ptradd_inbounds_raw(c, *addr, type_size(info->coerce_expand.hi) * info->coerce_expand.offset_hi);
+	*addr = llvm_emit_const_ptradd_inbounds_raw(c, *addr, type_size(info->coerce_expand.hi) * info->coerce_expand.offset_hi);
 	return type2;
```

## Verification

- Minimal repro (`pair_abi.c3`) fails on riscv64 before the fix
  (`make_pair().i = 0`) and passes after (`ok`), verified under qemu-riscv64.
- The same repro passes on x86-64 before and after (no regression).
- clang-compiled C equivalent passes on riscv64, confirming the issue is in
  c3c's codegen, not LLVM.
- Full rvinfer (an inference runtime exercising this ABI path with
  quantization structs) now produces correct results on riscv64.

## Scope

Only `c_abi_riscv.c` uses `abi_arg_new_expand_coerce_pair`, so this affects
RISC-V targets only.
