### PR TITLE
feat: allow xtensa to compile without flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ The compiler is currently verified to compile on Windows, MacOS, Linux, OpenBSD,
 *\* Inline asm is still a work in progress*<br>
 *\* OpenBSD 7.8 is the only tested version*<br>
 *\* OpenBSD has limited stacktrace, needs to be tested further*<br>
-*\* Xtensa support is enabled by compiling with `-DXTENSA_ENABLE`. The [espressif llvm fork](https://github.com/espressif/llvm-project) is recommended for best compatibility*
 
 More platforms will be supported in the future.
 </details>

--- a/src/compiler/target.c
+++ b/src/compiler/target.c
@@ -1954,9 +1954,7 @@ void *llvm_target_machine_create(void)
 	if (!llvm_initialized)
 	{
 		llvm_initialized = true;
-#ifdef XTENSA_ENABLE
 		INITIALIZE_TARGET(Xtensa);
-#endif
 #ifndef AVR_DISABLE
 		INITIALIZE_TARGET(AVR);
 #endif
@@ -2185,13 +2183,6 @@ void target_setup(BuildTarget *build_target)
 	{
 		error_exit("Failed to find Windows def file: '%s' in path.", build_target->win.def);
 	}
-
-#ifndef XTENSA_ENABLE
-	if (build_target->arch_os_target == ELF_XTENSA)
-	{
-		error_exit("Xtensa support is not available with this LLVM version.");
-	}
-#endif
 
 	compiler.platform.target_triple = arch_to_target_triple(build_target->arch_os_target, build_target->linuxpaths.libc);
 	ASSERT(compiler.platform.target_triple);


### PR DESCRIPTION
Enable Xtensa by default in C3C

Makes the existing `elf-xtensa` target available in standard C3C builds by removing the `XTENSA_ENABLE` requirement. Depends on c3lang/llvm-for-c3#5, which adds the Xtensa backend to the LLVM builds.
