### PR TITLE
docgen: format method receivers using &self/self shorthand

### DIFF
--- a/resources/docs.html
+++ b/resources/docs.html
@@ -2196,19 +2196,24 @@
 					const bodyParams = renderParams(m.params);
 					return `<span class="c3-keyword">@body</span>(${bodyParams})`;
 				}
+				// Shorthand reference receiver: &self, &mutex, etc.
+				if (m.is_ref) {
+					let res = `<span class="c3-variable">&${m.name}</span>`;
+					if (m.attributes) res += ` <span class="c3-attribute">${m.attributes.join(' ')}</span>`;
+					return res;
+				}
+				// Shorthand by-value receiver: self
 				if (m.name === 'self') {
-					if (m.type) {
-						const selfType = renderTypeName(m.type);
-						return `${selfType} <span class="c3-variable">${m.is_ref ? '&' : ''}self</span>`;
-					}
-					return `<span class="c3-variable">${m.is_ref ? '&' : ''}self</span>`;
+					let res = `<span class="c3-variable">self</span>`;
+					if (m.attributes) res += ` <span class="c3-attribute">${m.attributes.join(' ')}</span>`;
+					return res;
 				}
 				const isUntypedVararg = m.is_vararg && m.type && m.type.name === 'any...';
 				if (isUntypedVararg) {
 					return `<span class="c3-variable">${m.name || ''}...</span>`;
 				}
 				const type = m.type ? renderTypeName(m.type) : '';
-				const name = m.name ? `<span class="c3-variable">${m.is_ref ? '&' : ''}${m.name}</span>` : '';
+				const name = m.name ? `<span class="c3-variable">${m.name}</span>` : '';
 				let res = type ? (name ? `${type} ${name}` : type) : name;
 				if (m.attributes) res += ` <span class="c3-attribute">${m.attributes.join(' ')}</span>`;
 				if (m.default_value) res += ` = <span class="c3-variable">${m.default_value}</span>`;


### PR DESCRIPTION
Omit redundant type names for reference and by-value method receivers, avoiding invalid signatures like `Type* &name`.

Before:
<img width="468" height="387" alt="image" src="https://github.com/user-attachments/assets/b18a2815-320e-45b8-aa5b-cca3225c5224" />

After:
<img width="494" height="378" alt="image" src="https://github.com/user-attachments/assets/9bcba8be-cdf4-42a3-bf82-9c971e5d77f1" />
