### PR TITLE
Fix stale tid in thread::current on POSIX

### DIFF
--- a/lib/std/threads/os/thread_posix.c3
+++ b/lib/std/threads/os/thread_posix.c3
@@ -199,11 +199,11 @@ tlocal NativeThread current_thread @private;
 fn void* callback(void* arg) @private
 {
 	NativeThread* thread = arg;
-	current_thread = *thread;
 	$if ANDROID_LINUX:
 		thread.tid = (Pid_t)@syscall(libc::SYS_GETTID);
 		os::sem_post(&thread.sem);
 	$endif
+	current_thread = *thread;
 	return (void*)(iptr)thread.thread_fn(thread.arg);
 }
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -41,6 +41,7 @@
 - Typedef access resolution preferred inner type field over method. #3457
 - Generic gets instantiated despite being disabled with `@feat` #3459
 - Compiler hangs with generic alias in function. #3470
+- Stale tid in `thread::current` on POSIX. #3472
 
 ## 0.8.3 Change list
 


### PR DESCRIPTION
so thread::current() returns the valid kernel TID inside worker threads

```c3
module main;
import std;

fn int worker(void* arg)
{
	io::printfn("Worker Kernel TID: %d", thread::current().tid);
	return 0;
}

fn void main()
{
	Thread t;
	t.create(&worker, null)!!;
	t.join();
}
```