### PR TITLE
Fix constant subscript folding for nested arrays and structs

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -42,6 +42,7 @@
 - Generic gets instantiated despite being disabled with `@feat` #3459
 - Compiler hangs with generic alias in function. #3470
 - Resolution order for generics may cause generic function pointers to not get resolved before use. #3471
+- Fix constant subscript folding for nested arrays and structs.
 
 ## 0.8.3 Change list
 

--- a/src/compiler/expr.c
+++ b/src/compiler/expr.c
@@ -673,12 +673,12 @@ bool expr_rewrite_to_const_initializer_index(Type *list_type, ConstInitializer *
 {
 	ConstInitializer *initializer = initializer_for_index(list, index, from_back);
 	ConstInitType kind = initializer ? initializer->kind : CONST_INIT_ZERO;
+	Type *indexed_type = type_get_indexed_type(list_type);
+	if (!indexed_type) return false;
 	switch (kind)
 	{
 		case CONST_INIT_ZERO:
 		{
-			Type *indexed_type = type_get_indexed_type(list_type);
-			if (!indexed_type) return false;
 			expr_rewrite_to_const_zero(result, indexed_type);
 			return true;
 		}
@@ -686,6 +686,15 @@ bool expr_rewrite_to_const_initializer_index(Type *list_type, ConstInitializer *
 		case CONST_INIT_UNION:
 		case CONST_INIT_ARRAY:
 		case CONST_INIT_ARRAY_FULL:
+			if (type_flatten(indexed_type)->type_kind == TYPE_SLICE)
+			{
+				expr_rewrite_const_slice(result, indexed_type, initializer);
+			}
+			else
+			{
+				expr_rewrite_const_initializer(result, indexed_type, initializer);
+			}
+			return true;
 		case CONST_INIT_ARRAY_VALUE:
 			return false;
 		case CONST_INIT_VALUE:

--- a/test/test_suite/compile_time/ct_subscript_aggregate_init.c3
+++ b/test/test_suite/compile_time/ct_subscript_aggregate_init.c3
@@ -1,0 +1,75 @@
+module test_ct_subscript_aggregate;
+
+struct Point
+{
+    int x;
+    int y;
+}
+
+union TestUnion
+{
+    int a;
+    short b;
+}
+
+struct Nested
+{
+    int[4] arr;
+    bool flag;
+}
+
+fn void test_nested_array() @test
+{
+    int[2][2] $a = { { 10, 20 }, { 30, 40 } };
+    var $b = $a[1];
+    $b[0] = 99;
+    $assert($b[0] == 99);
+    $assert($b[1] == 40);
+    $assert($a[1][0] == 30);
+}
+
+fn void test_struct_array() @test
+{
+    Point[2] $pts = { { 1, 2 }, { 3, 4 } };
+    var $p = $pts[1];
+    $assert($p.x == 3);
+    $assert($p.y == 4);
+}
+
+fn void test_union_array() @test
+{
+    TestUnion[2] $us = { { .a = 100 }, { .a = 200 } };
+    var $u = $us[1];
+    $assert($u.a == 200);
+}
+
+fn void test_nested_struct_array() @test
+{
+    Nested[1] $nodes = { { .arr = { 1, 2, 3, 4 }, .flag = true } };
+    var $sub = $nodes[0].arr;
+    $sub[2] = 42;
+    $assert($sub[0] == 1);
+    $assert($sub[2] == 42);
+    $assert($sub[3] == 4);
+}
+
+fn void test_slice_array() @test
+{
+    int[][2] $slices = { { 1, 2, 3 }, { 4, 5 } };
+    var $s = $slices[1];
+    $assert($s.len == 2);
+    $assert($s[0] == 4);
+    $assert($s[1] == 5);
+}
+
+fn void test_foreach_nested() @test
+{
+    int[2][2] $matrix = { { 1, 2 }, { 3, 4 } };
+    var $sum = 0;
+    $foreach $row : $matrix:
+        $foreach $val : $row:
+            $sum += $val;
+        $endforeach
+    $endforeach
+    $assert($sum == 10);
+}


### PR DESCRIPTION
Indexing compile-time nested arrays/structs failed to fold to a constant, leaving unflattened expressions and triggering compiler asserts.