### PR TITLE
Fix flat_kind using wrong function for recursion

### DIFF
--- a/lib/std/core/types.c3
+++ b/lib/std/core/types.c3
@@ -181,7 +181,7 @@ macro typeid flat_type($Type) @const
 macro TypeKind flat_kind($Type) @const
 {
 	$if $Type::kind == TYPEDEF || $Type::kind == CONSTDEF:
-		return flat_type($Type::inner);
+		return flat_kind($Type::inner);
 	$else
 		return $Type::kind;
 	$endif


### PR DESCRIPTION
flat_kind used flat_type for recursion and produced errors when was used with types of kind TYPEDEF or CONSTDEF, because of different return type