### PR TITLE
Added path::is_link support

### DIFF
--- a/lib/std/io/os/fileinfo.c3
+++ b/lib/std/io/os/fileinfo.c3
@@ -103,6 +103,23 @@ fn bool native_is_dir(String path)
 	$endif
 }
 
+fn bool native_is_link(String path)
+{
+	$switch:
+		$case env::DARWIN || env::LINUX || env::ANDROID || env::BSD_FAMILY || env::EMSCRIPTEN:
+			@pool()
+			{
+				Stat stat;
+				return libc::lstat(path.zstr_tcopy(), &stat) == 0 && libc_S_ISTYPE(stat.st_mode, libc::S_IFLNK);
+			};
+		$case env::WIN32:
+			Win32_FILE_ATTRIBUTE_DATA data;
+			return @ok(get_win32_file_attributes(path, &data)) && (data.dwFileAttributes & win32::FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+		$default:
+			return false;
+	$endswitch
+}
+
 fn Time_t? native_get_modified_time(String path) => @pool()
 {
 	$switch:

--- a/lib/std/io/path.c3
+++ b/lib/std/io/path.c3
@@ -36,6 +36,7 @@ enum PathEnv : (PathSeparator separator)
 
 fn bool is_dir(Path path) => os::native_is_dir(path);
 fn bool is_file(Path path) => os::native_is_file(path);
+fn bool is_link(Path path) => os::native_is_link(path);
 fn long? file_size(Path path) => os::native_file_size(path);
 fn bool exists(Path path) => os::native_file_or_dir_exists(path);
 fn Path? tcwd() => cwd(tmem) @inline;

--- a/lib/std/libc/os/android.c3
+++ b/lib/std/libc/os/android.c3
@@ -57,6 +57,7 @@ struct Stat @feat(!X86_64)
 }
 
 extern fn CInt stat(ZString path, Stat* stat);
+extern fn CInt lstat(ZString path, Stat* stat);
 
 extern fn CInt get_nprocs();
 extern fn CInt get_nprocs_conf();

--- a/lib/std/libc/os/darwin.c3
+++ b/lib/std/libc/os/darwin.c3
@@ -42,6 +42,7 @@ struct Stat
 }
 
 extern fn int stat(ZString str, Stat* stat) @cname("stat64");
+extern fn int lstat(ZString str, Stat* stat) @cname("lstat64");
 
 extern fn CInt sysctl(CInt *name, CUInt namelen, void *oldp, usz *oldlenp, void *newp, usz newlen);
 

--- a/lib/std/libc/os/emscripten.c3
+++ b/lib/std/libc/os/emscripten.c3
@@ -30,4 +30,5 @@ struct Stat
 }
 
 extern fn CInt stat(ZString path, Stat* stat);
+extern fn CInt lstat(ZString path, Stat* stat);
 extern fn CInt emscripten_num_logical_cores();

--- a/lib/std/libc/os/freebsd.c3
+++ b/lib/std/libc/os/freebsd.c3
@@ -58,6 +58,7 @@ struct Stat @feat(!X86_64)
 }
 
 extern fn CInt stat(ZString path, Stat* stat);
+extern fn CInt lstat(ZString path, Stat* stat);
 
 extern fn CInt get_nprocs();
 extern fn CInt get_nprocs_conf();

--- a/lib/std/libc/os/linux.c3
+++ b/lib/std/libc/os/linux.c3
@@ -57,6 +57,7 @@ struct Stat @feat(!X86_64)
 }
 
 extern fn CInt stat(ZString path, Stat* stat);
+extern fn CInt lstat(ZString path, Stat* stat);
 
 extern fn CInt get_nprocs();
 extern fn CInt get_nprocs_conf();

--- a/lib/std/libc/os/netbsd.c3
+++ b/lib/std/libc/os/netbsd.c3
@@ -33,6 +33,7 @@ struct Stat
 }
 
 extern fn CInt stat(ZString path, Stat* stat) @cname("__stat50");
+extern fn CInt lstat(ZString path, Stat* stat) @cname("__lstat50");
 
 extern fn CInt sysctl(CInt *name, CUInt namelen, void *oldp, usz *oldlenp, void *newp, usz newlen);
 

--- a/lib/std/libc/os/openbsd.c3
+++ b/lib/std/libc/os/openbsd.c3
@@ -55,6 +55,7 @@ struct Stat @feat(!X86_64)
 }
 
 extern fn CInt stat(ZString path, Stat* stat);
+extern fn CInt lstat(ZString path, Stat* stat);
 
 extern fn CInt sysctl(CInt *name, CUInt namelen, void *oldp, usz *oldlenp, void *newp, usz newlen);
 

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -32,6 +32,7 @@
 - Add a `range::slice` macro.
 - Add `log::get_logger`.
 - `RefCounted` now correctly makes a difference between dealloc and free.
+- `Path.is_link` added.
 
 ### Fixes
 - Vmem incorrectly handled reserve page sizes.

--- a/test/unit/stdlib/io/fileinfo.c3
+++ b/test/unit/stdlib/io/fileinfo.c3
@@ -16,6 +16,13 @@ fn void test_native_is_dir() @feat(LINUX, DARWIN, ANDROID)
 	assert(!os::native_is_dir("/dev/null"));
 }
 
+fn void test_is_link() @feat(LINUX)
+{
+	assert(path::is_link((Path)"/proc/self/exe"));
+	assert(!path::is_link((Path)"/"));
+	assert(!path::is_link((Path)"/this/file/does/not/exist"));
+}
+
 
 fn void test_native_is_file() @feat(BSD)
 {


### PR DESCRIPTION
Closes #3448.

- Uses `lstat` on Linux, Android, Darwin, BSD, and Emscripten.
- Uses `FILE_ATTRIBUTE_REPARSE_POINT` on Windows.
- Adds the required platform-specific libc `lstat` bindings.
- Returns `false` for missing paths, consistent with `path::is_file` and `path::is_dir`.
- Detects dangling symbolic links on POSIX platforms.