### PR TITLE
feat: Add x86 control registers to the inline asm register list

### DIFF
--- a/releasenotes.md
+++ b/releasenotes.md
@@ -27,6 +27,7 @@
 - `--keep-obj` added, to prevent object files from being deleted after building/linking.
 - Slice equality for flat types is now lowered to `memcmp`, avoiding scalar loops. #3491
 - Add `--warn-unusedlocal` and `--warn-unusedparam` to detect unused parameters and locals. #3485
+- Add control registers to x86 inline assembly
 
 ### Stdlib changes
 - `CachedInStream` and `CachedOutStream` added.

--- a/src/compiler/asm/x86.h
+++ b/src/compiler/asm/x86.h
@@ -66,13 +66,11 @@ typedef enum
 	X86_TMM5,
 	X86_TMM6,
 	X86_TMM7,
+	X86_CR0,
 	X86_CR2,
 	X86_CR3,
-	X86_CR4,
-	X86_CR0
+	X86_CR4
 } X86Clobbers;
-
-
 
 static const char *X86ClobberNames[] = {
 		[X86_CC] = "cc",
@@ -139,10 +137,10 @@ static const char *X86ClobberNames[] = {
 		[X86_TMM5] = "tmm5",
 		[X86_TMM6] = "tmm6",
 		[X86_TMM7] = "tmm7",
+		[X86_CR0] = "cr0",
 		[X86_CR2] = "cr2",
 		[X86_CR3] = "cr3",
 		[X86_CR4] = "cr4",
-		[X86_CR0] = "cr0",
 };
 
 static const char *x64_quad_regs[] = { "$rax", "$rbx", "$rcx", "$rdx", "$rsp",
@@ -170,4 +168,4 @@ static const char *x86_ymm_regs[] = { "$ymm0", "$ymm1", "$ymm2", "$ymm3", "$ymm4
 static const char *x86_zmm_regs[] = { "$zmm0", "$zmm1", "$zmm2", "$zmm3", "$zmm4", "$zmm5", "$zmm6", "$zmm7",
 									  "$zmm8", "$zmm9", "$zmm10", "$zmm11", "$zmm12", "$zmm13", "$zmm14", "$zmm15" };
 
-static const char *x86_control_regs[] = {"$cr2", "$cr3", "$cr4", "$cr0" };
+static const char *x86_control_regs[] = {"$cr0", "$cr2", "$cr3", "$cr4"};

--- a/src/compiler/asm/x86.h
+++ b/src/compiler/asm/x86.h
@@ -66,6 +66,10 @@ typedef enum
 	X86_TMM5,
 	X86_TMM6,
 	X86_TMM7,
+	X86_CR2,
+	X86_CR3,
+	X86_CR4,
+	X86_CR0
 } X86Clobbers;
 
 
@@ -135,6 +139,10 @@ static const char *X86ClobberNames[] = {
 		[X86_TMM5] = "tmm5",
 		[X86_TMM6] = "tmm6",
 		[X86_TMM7] = "tmm7",
+		[X86_CR2] = "cr2",
+		[X86_CR3] = "cr3",
+		[X86_CR4] = "cr4",
+		[X86_CR0] = "cr0",
 };
 
 static const char *x64_quad_regs[] = { "$rax", "$rbx", "$rcx", "$rdx", "$rsp",
@@ -161,3 +169,5 @@ static const char *x86_ymm_regs[] = { "$ymm0", "$ymm1", "$ymm2", "$ymm3", "$ymm4
 
 static const char *x86_zmm_regs[] = { "$zmm0", "$zmm1", "$zmm2", "$zmm3", "$zmm4", "$zmm5", "$zmm6", "$zmm7",
 									  "$zmm8", "$zmm9", "$zmm10", "$zmm11", "$zmm12", "$zmm13", "$zmm14", "$zmm15" };
+
+static const char *x86_control_regs[] = {"$cr2", "$cr3", "$cr4", "$cr0" };

--- a/src/compiler/asm_target.c
+++ b/src/compiler/asm_target.c
@@ -880,6 +880,8 @@ static void init_asm_x86(PlatformTarget* target)
 
 	target->clobber_name_list = X86ClobberNames;
 	target->extra_clobbers = "~{flags},~{dirflag},~{fspr}";
+
+
 	if (target->arch == ARCH_TYPE_X86)
 	{
 		reg_register_list(target, x86_long_regs, 8, ASM_REG_INT, ARG_BITS_32, X86_RAX);
@@ -887,6 +889,7 @@ static void init_asm_x86(PlatformTarget* target)
 		reg_register_list(target, x86_low_byte_regs, 8, ASM_REG_INT, ARG_BITS_8, X86_RAX);
 		reg_register_list(target, x86_float_regs, 8, ASM_REG_FLOAT, ARG_BITS_80, X86_ST0);
 		reg_register_list(target, x86_xmm_regs, 8, ASM_REF_FVEC, ARG_BITS_128, X86_MM0);
+		reg_register_list(target, x86_control_regs, 3 , ASM_REG_INT, ARG_BITS_32, X86_CR2);
 	}
 	else
 	{
@@ -898,7 +901,10 @@ static void init_asm_x86(PlatformTarget* target)
 		reg_register_list(target, x86_xmm_regs, 16, ASM_REF_FVEC, ARG_BITS_128, X86_XMM0);
 		reg_register_list(target, x86_ymm_regs, 16, ASM_REF_FVEC, ARG_BITS_256, X86_XMM0);
 		reg_register_list(target, x86_zmm_regs, 16, ASM_REF_FVEC, ARG_BITS_512, X86_XMM0);
+		reg_register_list(target, x86_control_regs, 3, ASM_REG_INT, ARG_BITS_64, X86_CR2);
 	}
+
+	reg_register(target, x86_control_regs[3], ASM_REG_INT, ARG_BITS_32, X86_CR0);
 }
 
 bool asm_is_supported(ArchType arch)

--- a/src/compiler/asm_target.c
+++ b/src/compiler/asm_target.c
@@ -889,7 +889,7 @@ static void init_asm_x86(PlatformTarget* target)
 		reg_register_list(target, x86_low_byte_regs, 8, ASM_REG_INT, ARG_BITS_8, X86_RAX);
 		reg_register_list(target, x86_float_regs, 8, ASM_REG_FLOAT, ARG_BITS_80, X86_ST0);
 		reg_register_list(target, x86_xmm_regs, 8, ASM_REF_FVEC, ARG_BITS_128, X86_MM0);
-		reg_register_list(target, x86_control_regs, 3 , ASM_REG_INT, ARG_BITS_32, X86_CR2);
+		reg_register_list(target, x86_control_regs, 4 , ASM_REG_INT, ARG_BITS_32, X86_CR0);
 	}
 	else
 	{
@@ -901,10 +901,9 @@ static void init_asm_x86(PlatformTarget* target)
 		reg_register_list(target, x86_xmm_regs, 16, ASM_REF_FVEC, ARG_BITS_128, X86_XMM0);
 		reg_register_list(target, x86_ymm_regs, 16, ASM_REF_FVEC, ARG_BITS_256, X86_XMM0);
 		reg_register_list(target, x86_zmm_regs, 16, ASM_REF_FVEC, ARG_BITS_512, X86_XMM0);
-		reg_register_list(target, x86_control_regs, 3, ASM_REG_INT, ARG_BITS_64, X86_CR2);
+		reg_register_list(target, x86_control_regs, 4, ASM_REG_INT, ARG_BITS_64, X86_CR0);
 	}
 
-	reg_register(target, x86_control_regs[3], ASM_REG_INT, ARG_BITS_32, X86_CR0);
 }
 
 bool asm_is_supported(ArchType arch)

--- a/test/test_suite/asm/asm_cr_regs_x64.c3t
+++ b/test/test_suite/asm/asm_cr_regs_x64.c3t
@@ -1,0 +1,18 @@
+// #target: linux-x64
+
+module test;
+
+fn void main(String[] args)
+{
+	asm
+	{
+		movq $rax, $cr0;
+		movq $rax, $cr2;
+		movq $rax, $cr3;
+		movq $rax, $cr4;
+	};
+}
+
+/* #expect: test.ll
+
+"movq %cr0, %rax\0Amovq %cr2, %rax\0Amovq %cr3, %rax\0Amovq %cr4, %rax\0A", "~{rax},~{flags},~{dirflag},~{fspr}"


### PR DESCRIPTION
We add x86 control registers to the register list so we can use them with inline asm

`CR0` is 32bit on both x86 and x86_64, that's why I registered it seperately.

