### PR TITLE
Cleans up several oversized functions across `std::hash` (SHA-256, Streebog, BLAKE3) and `std::compression` (ZIP, Deflate):

### DIFF
--- a/lib/std/compression/deflate.c3
+++ b/lib/std/compression/deflate.c3
@@ -518,43 +518,8 @@ fn void? Deflater.scan_matches(&self, bool final)
 	self.match_pos = (uint)pos;
 }
 
-fn void? Deflater.emit_block(&self, bool final)=> @pool()
+fn void _rle_encode_tree_lengths(char[] all_lens, List{Token}* tree_tokens, uint[] tree_freqs) @local
 {
-	if (self.token_count == 0 && !final) return;
-
-	self.lit_freqs[256] = 1;
-	self.tokens[self.token_count++] = { 256, 0 };
-
-	// Build dynamic Huffman trees from frequency tables
-	Huffman lit_huff, dist_huff;
-	lit_huff.build_from_freqs(self.lit_freqs[..], 15);
-
-	uint d_sum = 0;
-	foreach (f : self.dist_freqs) d_sum += f;
-	if (d_sum == 0) self.dist_freqs[0] = 1;
-	dist_huff.build_from_freqs(self.dist_freqs[..], 15);
-
-	self.bwriter.write_bits(final ? 1 : 0, 1);
-	self.bwriter.write_bits(2, 2); // BTYPE=2 (Dynamic Huffman)
-
-	char[] lit_lens = lit_huff.get_lengths(285);
-	char[] dist_lens = dist_huff.get_lengths(29);
-
-	sz hlit_cnt = 286;
-	while (hlit_cnt > 257 && lit_lens[hlit_cnt - 1] == 0) hlit_cnt--;
-	sz hdist_cnt = 30;
-	while (hdist_cnt > 1 && dist_lens[hdist_cnt - 1] == 0) hdist_cnt--;
-
-	self.bwriter.write_bits((uint)hlit_cnt - 257u, 5);
-	self.bwriter.write_bits((uint)hdist_cnt - 1u, 5);
-
-	// RLE-encode the combined code lengths
-	List{Token} tree_tokens; tree_tokens.tinit();
-	uint[] tree_freqs = mem::temp_array(uint, 19);
-	char[] all_lens = mem::temp_array(char, hlit_cnt + hdist_cnt);
-	all_lens[:hlit_cnt] = lit_lens[:hlit_cnt];
-	all_lens[hlit_cnt:hdist_cnt] = dist_lens[:hdist_cnt];
-
 	for (long i = 0; i < all_lens.len;)
 	{
 		char len = all_lens[i];
@@ -598,6 +563,104 @@ fn void? Deflater.emit_block(&self, bool final)=> @pool()
 			i++;
 		}
 	}
+}
+
+fn void _encode_match_len(uint b_len, uint* code, int* extra_bits, uint* extra) @local
+{
+	switch (b_len)
+	{
+		case 3..10:   *code = 257u + b_len - 3u; *extra_bits = 0; *extra = 0;
+		case 11..18:  *code = 265u + (b_len - 11u) / 2; *extra_bits = 1; *extra = (b_len - 11u) % 2;
+		case 19..34:  *code = 269u + (b_len - 19u) / 4; *extra_bits = 2; *extra = (b_len - 19u) % 4;
+		case 35..66:  *code = 273u + (b_len - 35u) / 8; *extra_bits = 3; *extra = (b_len - 35u) % 8;
+		case 67..130: *code = 277u + (b_len - 67u) / 16; *extra_bits = 4; *extra = (b_len - 67u) % 16;
+		case 131..257:*code = 281u + (b_len - 131u) / 32; *extra_bits = 5; *extra = (b_len - 131u) % 32;
+		default:      *code = 285u; *extra_bits = 0; *extra = 0;
+	}
+}
+
+fn void _encode_match_dist(uint b_dist, uint* code, int* extra_bits, uint* extra) @local
+{
+	switch (b_dist)
+	{
+		case 1..4:     *code = b_dist - 1u; *extra_bits = 0; *extra = 0;
+		case 5..8:     *code = 4u + (b_dist - 5u) / 2u; *extra_bits = 1; *extra = (b_dist - 5u) % 2;
+		case 9..16:    *code = 6u + (b_dist - 9u) / 4u; *extra_bits = 2; *extra = (b_dist - 9u) % 4;
+		case 17..32:   *code = 8u + (b_dist - 17u) / 8u; *extra_bits = 3; *extra = (b_dist - 17u) % 8;
+		case 33..64:   *code = 10u + (b_dist - 33u) / 16u; *extra_bits = 4; *extra = (b_dist - 33u) % 16;
+		case 65..128:  *code = 12u + (b_dist - 65u) / 32u; *extra_bits = 5; *extra = (b_dist - 65u) % 32;
+		case 129..256: *code = 14u + (b_dist - 129u) / 64u; *extra_bits = 6; *extra = (b_dist - 129u) % 64;
+		case 257..512: *code = 16u + (b_dist - 257u) / 128u; *extra_bits = 7; *extra = (b_dist - 257u) % 128;
+		case 513..1024: *code = 18u + (b_dist - 513u) / 256; *extra_bits = 8; *extra = (b_dist - 513u) % 256;
+		case 1025..2048: *code = 20u + (b_dist - 1025u) / 512; *extra_bits = 9; *extra = (b_dist - 1025u) % 512;
+		case 2049..4096: *code = 22u + (b_dist - 2049u) / 1024; *extra_bits = 10; *extra = (b_dist - 2049u) % 1024;
+		case 4097..8192: *code = 24u + (b_dist - 4097u) / 2048; *extra_bits = 11; *extra = (b_dist - 4097u) % 2048;
+		case 8193..16384: *code = 26u + (b_dist - 8193u) / 4096; *extra_bits = 12; *extra = (b_dist - 8193u) % 4096;
+		default:          *code = 28u + (b_dist - 16385u) / 8192; *extra_bits = 13; *extra = (b_dist - 16385u) % 8192;
+	}
+}
+
+fn void _write_compressed_tokens(Deflater* self, Code* lit_codes, Code* dist_codes) @local
+{
+	foreach (t : self.tokens[:self.token_count])
+	{
+		if (t.dist == 0)
+		{
+			self.bwriter.write_huffman(lit_codes[t.val].code, lit_codes[t.val].len);
+		}
+		else
+		{
+			uint len_code; int len_extra_bits; uint len_extra;
+			_encode_match_len(t.val, &len_code, &len_extra_bits, &len_extra);
+			self.bwriter.write_huffman(lit_codes[len_code].code, lit_codes[len_code].len);
+			if (len_extra_bits > 0) self.bwriter.write_bits(len_extra, len_extra_bits);
+
+			uint dist_c; int dist_extra_b; uint dist_ex;
+			_encode_match_dist(t.dist, &dist_c, &dist_extra_b, &dist_ex);
+			self.bwriter.write_huffman(dist_codes[dist_c].code, dist_codes[dist_c].len);
+			if (dist_extra_b > 0) self.bwriter.write_bits(dist_ex, dist_extra_b);
+		}
+	}
+}
+
+fn void? Deflater.emit_block(&self, bool final)=> @pool()
+{
+	if (self.token_count == 0 && !final) return;
+
+	self.lit_freqs[256] = 1;
+	self.tokens[self.token_count++] = { 256, 0 };
+
+	// Build dynamic Huffman trees from frequency tables
+	Huffman lit_huff, dist_huff;
+	lit_huff.build_from_freqs(self.lit_freqs[..], 15);
+
+	uint d_sum = 0;
+	foreach (f : self.dist_freqs) d_sum += f;
+	if (d_sum == 0) self.dist_freqs[0] = 1;
+	dist_huff.build_from_freqs(self.dist_freqs[..], 15);
+
+	self.bwriter.write_bits(final ? 1 : 0, 1);
+	self.bwriter.write_bits(2, 2); // BTYPE=2 (Dynamic Huffman)
+
+	char[] lit_lens = lit_huff.get_lengths(285);
+	char[] dist_lens = dist_huff.get_lengths(29);
+
+	sz hlit_cnt = 286;
+	while (hlit_cnt > 257 && lit_lens[hlit_cnt - 1] == 0) hlit_cnt--;
+	sz hdist_cnt = 30;
+	while (hdist_cnt > 1 && dist_lens[hdist_cnt - 1] == 0) hdist_cnt--;
+
+	self.bwriter.write_bits((uint)hlit_cnt - 257u, 5);
+	self.bwriter.write_bits((uint)hdist_cnt - 1u, 5);
+
+	// RLE-encode the combined code lengths
+	List{Token} tree_tokens; tree_tokens.tinit();
+	uint[] tree_freqs = mem::temp_array(uint, 19);
+	char[] all_lens = mem::temp_array(char, hlit_cnt + hdist_cnt);
+	all_lens[:hlit_cnt] = lit_lens[:hlit_cnt];
+	all_lens[hlit_cnt:hdist_cnt] = dist_lens[:hdist_cnt];
+
+	_rle_encode_tree_lengths(all_lens, &tree_tokens, tree_freqs);
 
 	// Build the code length Huffman tree
 	Huffman tree_huff;
@@ -629,51 +692,7 @@ fn void? Deflater.emit_block(&self, bool final)=> @pool()
 	gen_canonical_codes(&dist_codes, dist_lens[:hdist_cnt]);
 
 	// Write the actual compressed data tokens
-	foreach (t : self.tokens[:self.token_count])
-	{
-		if (t.dist == 0)
-		{
-			self.bwriter.write_huffman(lit_codes[t.val].code, lit_codes[t.val].len);
-		}
-		else
-		{
-			uint b_len = t.val; uint b_dist = t.dist;
-			uint len_code; int len_extra_bits = 0; uint len_extra = 0;
-			switch (b_len)
-			{
-				case 3..10:   len_code = 257u + b_len - 3u;
-				case 11..18:  len_code = 265u + (b_len - 11u) / 2; len_extra_bits = 1; len_extra = (b_len - 11u) % 2;
-				case 19..34:  len_code = 269u + (b_len - 19u) / 4; len_extra_bits = 2; len_extra = (b_len - 19u) % 4;
-				case 35..66:  len_code = 273u + (b_len - 35u) / 8; len_extra_bits = 3; len_extra = (b_len - 35u) % 8;
-				case 67..130: len_code = 277u + (b_len - 67u) / 16; len_extra_bits = 4; len_extra = (b_len - 67u) % 16;
-				case 131..257:len_code = 281u + (b_len - 131u) / 32; len_extra_bits = 5; len_extra = (b_len - 131u) % 32;
-				default:      len_code = 285u;
-			}
-			self.bwriter.write_huffman(lit_codes[len_code].code, lit_codes[len_code].len);
-			if (len_extra_bits > 0) self.bwriter.write_bits(len_extra, len_extra_bits);
-
-			uint dist_c; int dist_extra_b = 0; uint dist_ex = 0;
-			switch (b_dist)
-			{
-				case 1..4:     dist_c = b_dist - 1u;
-				case 5..8:     dist_c = 4u + (b_dist - 5u) / 2u; dist_extra_b = 1; dist_ex = (b_dist - 5u) % 2;
-				case 9..16:    dist_c = 6u + (b_dist - 9u) / 4u; dist_extra_b = 2; dist_ex = (b_dist - 9u) % 4;
-				case 17..32:   dist_c = 8u + (b_dist - 17u) / 8u; dist_extra_b = 3; dist_ex = (b_dist - 17u) % 8;
-				case 33..64:   dist_c = 10u + (b_dist - 33u) / 16u; dist_extra_b = 4; dist_ex = (b_dist - 33u) % 16;
-				case 65..128:  dist_c = 12u + (b_dist - 65u) / 32u; dist_extra_b = 5; dist_ex = (b_dist - 65u) % 32;
-				case 129..256: dist_c = 14u + (b_dist - 129u) / 64u; dist_extra_b = 6; dist_ex = (b_dist - 129u) % 64;
-				case 257..512: dist_c = 16u + (b_dist - 257u) / 128u; dist_extra_b = 7; dist_ex = (b_dist - 257u) % 128;
-				case 513..1024: dist_c = 18u + (b_dist - 513u) / 256; dist_extra_b = 8; dist_ex = (b_dist - 513u) % 256;
-				case 1025..2048: dist_c = 20u + (b_dist - 1025u) / 512; dist_extra_b = 9; dist_ex = (b_dist - 1025u) % 512;
-				case 2049..4096: dist_c = 22u + (b_dist - 2049u) / 1024; dist_extra_b = 10; dist_ex = (b_dist - 2049u) % 1024;
-				case 4097..8192: dist_c = 24u + (b_dist - 4097u) / 2048; dist_extra_b = 11; dist_ex = (b_dist - 4097u) % 2048;
-				case 8193..16384: dist_c = 26u + (b_dist - 8193u) / 4096; dist_extra_b = 12; dist_ex = (b_dist - 8193u) % 4096;
-				default:          dist_c = 28u + (b_dist - 16385u) / 8192; dist_extra_b = 13; dist_ex = (b_dist - 16385u) % 8192;
-			}
-			self.bwriter.write_huffman(dist_codes[dist_c].code, dist_codes[dist_c].len);
-			if (dist_extra_b > 0) self.bwriter.write_bits(dist_ex, dist_extra_b);
-		}
-	}
+	_write_compressed_tokens(self, &lit_codes, &dist_codes);
 
 	if (final)
 	{
@@ -996,86 +1015,10 @@ struct IndexMap @private
 }
 fn bool IndexMap.less(&self, IndexMap other) => self.freq < other.freq;
 
-fn char[] pkg_merge(Allocator allocator, uint[] freqs, int max_bits) @private => @pool()
+fn void _pkg_merge_backtrack(ulong[] is_merged, uint[] hist, sz max_elements, sz num_relevant, ulong mask) @local
 {
-	List {IndexMap} map; map.tinit();
-	sz n = 0;
-	foreach (i, freq : freqs) { if (freq == 0) continue; map.push({i, freq}); n++; }
-	if (n == 0) return {};
-	sort::quicksort(map.array_view());
-	if (n == 1)
-	{
-		char[] blen = alloc::new_array(allocator, char, freqs.len);
-		blen[map[0].index] = 1;
-		return blen;
-	}
-	sz max_elements = 2 * n;
-	uint[] hist = mem::temp_array(uint, max_elements);
-	foreach (i, m : map) hist[i] = m.freq;
-	uint[] current = mem::temp_array(uint, max_elements);
-	uint[] previous = mem::temp_array(uint, max_elements);
-	ulong[] is_merged = mem::temp_array(ulong, max_elements);
-	previous[:n] = hist[:n];
-	sz num_previous = n;
-	is_merged[:max_elements] = 0;
-	sz num_relevant = 2 * n - 2;
-	ulong mask = 1;
-
-	for (int bits = max_bits - 1; bits > 0; bits--)
-	{
-		num_previous &= (sz)~1;
-		current[0] = hist[0];
-		current[1] = hist[1];
-		uint sum = current[0] + current[1];
-		sz num_current = 2; sz num_hist = 2; sz num_merged = 0;
-
-		while (true)
-		{
-			if (num_hist < n && hist[num_hist] <= sum)
-			{
-				if (num_current < max_elements)
-				{
-					current[num_current++] = hist[num_hist++];
-					continue;
-				} else { break; }
-			}
-			if (num_current < max_elements)
-			{
-				is_merged[num_current] |= mask;
-				current[num_current] = sum;
-				num_current++;
-				num_merged++;
-			}
-			else
-			{
-				break;
-			}
-
-			if (num_merged * 2 >= num_previous) break;
-			sum = previous[num_merged * 2] + previous[num_merged * 2 + 1];
-		}
-		while (num_hist < n && num_current < max_elements)
-		{
-			current[num_current++] = hist[num_hist++];
-		}
-		mask <<= 1;
-		if (num_previous >= num_relevant)
-		{
-			bool keep_going = false;
-			for (sz i = num_relevant; i > 1; i--)
-			{
-				if (previous[i - 1] != current[i - 1])
-				{
-					keep_going = true;
-					break;
-				}
-			}
-			if (!keep_going) break;
-		}
-		@swap(previous, current); num_previous = num_current;
-	}
-
-	mask >>= 1; hist[..] = 0;
+	mask >>= 1;
+	hist[..] = 0;
 	sz num_analyze = num_relevant;
 	while (mask != 0)
 	{
@@ -1095,8 +1038,97 @@ fn char[] pkg_merge(Allocator allocator, uint[] freqs, int max_bits) @private =>
 		mask >>= 1;
 	}
 	for (sz i = 0; i < num_analyze; i++) hist[i]++;
+}
+
+fn sz _pkg_merge_round(uint[] hist, sz n, uint[] current, uint[] previous, sz num_previous, ulong[] is_merged, ulong mask, sz max_elements) @local
+{
+	num_previous &= (sz)~1;
+	current[0] = hist[0];
+	current[1] = hist[1];
+	uint sum = current[0] + current[1];
+	sz num_current = 2; sz num_hist = 2; sz num_merged = 0;
+
+	while (true)
+	{
+		if (num_hist < n && hist[num_hist] <= sum)
+		{
+			if (num_current < max_elements)
+			{
+				current[num_current++] = hist[num_hist++];
+				continue;
+			} else { break; }
+		}
+		if (num_current < max_elements)
+		{
+			is_merged[num_current] |= mask;
+			current[num_current] = sum;
+			num_current++;
+			num_merged++;
+		}
+		else
+		{
+			break;
+		}
+
+		if (num_merged * 2 >= num_previous) break;
+		sum = previous[num_merged * 2] + previous[num_merged * 2 + 1];
+	}
+	while (num_hist < n && num_current < max_elements)
+	{
+		current[num_current++] = hist[num_hist++];
+	}
+	return num_current;
+}
+
+fn char[] pkg_merge(Allocator allocator, uint[] freqs, int max_bits) @private => @pool()
+{
+	IndexMap[] map = mem::temp_array(IndexMap, freqs.len);
+	sz n = 0;
+	foreach (i, freq : freqs) { if (freq != 0) map[n++] = {i, freq}; }
+	if (n == 0) return {};
+	IndexMap[] sorted_map = map[:n];
+	sort::quicksort(sorted_map);
+	if (n == 1)
+	{
+		char[] blen = alloc::new_array(allocator, char, freqs.len);
+		blen[sorted_map[0].index] = 1;
+		return blen;
+	}
+	sz max_elements = 2 * n;
+	uint[] hist = mem::temp_array(uint, max_elements);
+	foreach (i, m : sorted_map) hist[i] = m.freq;
+	uint[] current = mem::temp_array(uint, max_elements);
+	uint[] previous = mem::temp_array(uint, max_elements);
+	ulong[] is_merged = mem::temp_array(ulong, max_elements);
+	previous[:n] = hist[:n];
+	sz num_previous = n;
+	is_merged[:max_elements] = 0;
+	sz num_relevant = 2 * n - 2;
+	ulong mask = 1;
+
+	for (int bits = max_bits - 1; bits > 0; bits--)
+	{
+		sz num_current = _pkg_merge_round(hist, n, current, previous, num_previous, is_merged, mask, max_elements);
+		mask <<= 1;
+		if (num_previous >= num_relevant)
+		{
+			bool keep_going = false;
+			for (sz i = num_relevant; i > 1; i--)
+			{
+				if (previous[i - 1] != current[i - 1])
+				{
+					keep_going = true;
+					break;
+				}
+			}
+			if (!keep_going) break;
+		}
+		@swap(previous, current); num_previous = num_current;
+	}
+
+	_pkg_merge_backtrack(is_merged, hist, max_elements, num_relevant, mask);
 	char[] blen = alloc::new_array(allocator, char, freqs.len);
-	foreach (i, m : map) blen[m.index] = (char)hist[i];
+	foreach (i, m : sorted_map) blen[m.index] = (char)hist[i];
 	return blen;
 }
 

--- a/lib/std/compression/deflate.c3
+++ b/lib/std/compression/deflate.c3
@@ -203,6 +203,8 @@ fn sz Inflater.copy_unused_input(&self, char[] dest)
 	return self.reader.copy_unused_input(dest);
 }
 
+fn void Inflater.write_byte(&self, char c) @inline { self.window[(sz)(self.pos & 0xFFFF)] = c; self.pos++; }
+
 fn char[]? decompress(Allocator allocator, char[] input) => @pool()
 {
 	if (!input.len) return alloc::new_array(allocator, char, 0);
@@ -516,111 +518,6 @@ fn void? Deflater.scan_matches(&self, bool final)
 	self.hash = hash;
 	self.strstart = strstart;
 	self.match_pos = (uint)pos;
-}
-
-fn void _rle_encode_tree_lengths(char[] all_lens, List{Token}* tree_tokens, uint[] tree_freqs) @local
-{
-	for (long i = 0; i < all_lens.len;)
-	{
-		char len = all_lens[i];
-		long count = 1;
-		while (i + count < all_lens.len && all_lens[i + count] == len) count++;
-
-		if (len == 0)
-		{
-			while (count >= 11)
-			{
-				uint c = (uint)math::min(count, (long)138);
-				tree_tokens.push({ 18, (ushort)(c - 11u) });
-				tree_freqs[18]++;
-				i += c; count -= c;
-			}
-			while (count >= 3)
-			{
-				uint c = (uint)math::min(count, (long)10);
-				tree_tokens.push({ 17, (ushort)(c - 3u) });
-				tree_freqs[17]++;
-				i += c; count -= c;
-			}
-		}
-		else if (count >= 4)
-		{
-			tree_tokens.push({ (ushort)len, 0 });
-			tree_freqs[(uint)len]++;
-			i++; count--;
-			while (count >= 3)
-			{
-				uint c = (uint)math::min(count, (long)6);
-				tree_tokens.push({ 16, (ushort)(c - 3u) });
-				tree_freqs[16]++;
-				i += c; count -= c;
-			}
-		}
-		while (count--)
-		{
-			tree_tokens.push({ (ushort)len, 0 });
-			tree_freqs[(uint)len]++;
-			i++;
-		}
-	}
-}
-
-fn void _encode_match_len(uint b_len, uint* code, int* extra_bits, uint* extra) @local
-{
-	switch (b_len)
-	{
-		case 3..10:   *code = 257u + b_len - 3u; *extra_bits = 0; *extra = 0;
-		case 11..18:  *code = 265u + (b_len - 11u) / 2; *extra_bits = 1; *extra = (b_len - 11u) % 2;
-		case 19..34:  *code = 269u + (b_len - 19u) / 4; *extra_bits = 2; *extra = (b_len - 19u) % 4;
-		case 35..66:  *code = 273u + (b_len - 35u) / 8; *extra_bits = 3; *extra = (b_len - 35u) % 8;
-		case 67..130: *code = 277u + (b_len - 67u) / 16; *extra_bits = 4; *extra = (b_len - 67u) % 16;
-		case 131..257:*code = 281u + (b_len - 131u) / 32; *extra_bits = 5; *extra = (b_len - 131u) % 32;
-		default:      *code = 285u; *extra_bits = 0; *extra = 0;
-	}
-}
-
-fn void _encode_match_dist(uint b_dist, uint* code, int* extra_bits, uint* extra) @local
-{
-	switch (b_dist)
-	{
-		case 1..4:     *code = b_dist - 1u; *extra_bits = 0; *extra = 0;
-		case 5..8:     *code = 4u + (b_dist - 5u) / 2u; *extra_bits = 1; *extra = (b_dist - 5u) % 2;
-		case 9..16:    *code = 6u + (b_dist - 9u) / 4u; *extra_bits = 2; *extra = (b_dist - 9u) % 4;
-		case 17..32:   *code = 8u + (b_dist - 17u) / 8u; *extra_bits = 3; *extra = (b_dist - 17u) % 8;
-		case 33..64:   *code = 10u + (b_dist - 33u) / 16u; *extra_bits = 4; *extra = (b_dist - 33u) % 16;
-		case 65..128:  *code = 12u + (b_dist - 65u) / 32u; *extra_bits = 5; *extra = (b_dist - 65u) % 32;
-		case 129..256: *code = 14u + (b_dist - 129u) / 64u; *extra_bits = 6; *extra = (b_dist - 129u) % 64;
-		case 257..512: *code = 16u + (b_dist - 257u) / 128u; *extra_bits = 7; *extra = (b_dist - 257u) % 128;
-		case 513..1024: *code = 18u + (b_dist - 513u) / 256; *extra_bits = 8; *extra = (b_dist - 513u) % 256;
-		case 1025..2048: *code = 20u + (b_dist - 1025u) / 512; *extra_bits = 9; *extra = (b_dist - 1025u) % 512;
-		case 2049..4096: *code = 22u + (b_dist - 2049u) / 1024; *extra_bits = 10; *extra = (b_dist - 2049u) % 1024;
-		case 4097..8192: *code = 24u + (b_dist - 4097u) / 2048; *extra_bits = 11; *extra = (b_dist - 4097u) % 2048;
-		case 8193..16384: *code = 26u + (b_dist - 8193u) / 4096; *extra_bits = 12; *extra = (b_dist - 8193u) % 4096;
-		default:          *code = 28u + (b_dist - 16385u) / 8192; *extra_bits = 13; *extra = (b_dist - 16385u) % 8192;
-	}
-}
-
-fn void _write_compressed_tokens(Deflater* self, Code* lit_codes, Code* dist_codes) @local
-{
-	foreach (t : self.tokens[:self.token_count])
-	{
-		if (t.dist == 0)
-		{
-			self.bwriter.write_huffman(lit_codes[t.val].code, lit_codes[t.val].len);
-		}
-		else
-		{
-			uint len_code; int len_extra_bits; uint len_extra;
-			_encode_match_len(t.val, &len_code, &len_extra_bits, &len_extra);
-			self.bwriter.write_huffman(lit_codes[len_code].code, lit_codes[len_code].len);
-			if (len_extra_bits > 0) self.bwriter.write_bits(len_extra, len_extra_bits);
-
-			uint dist_c; int dist_extra_b; uint dist_ex;
-			_encode_match_dist(t.dist, &dist_c, &dist_extra_b, &dist_ex);
-			self.bwriter.write_huffman(dist_codes[dist_c].code, dist_codes[dist_c].len);
-			if (dist_extra_b > 0) self.bwriter.write_bits(dist_ex, dist_extra_b);
-		}
-	}
 }
 
 fn void? Deflater.emit_block(&self, bool final)=> @pool()
@@ -1355,10 +1252,114 @@ fn void? Inflater.step(&self)
 	return;
 }
 
-fn void Inflater.write_byte(&self, char c) @inline { self.window[(sz)(self.pos & 0xFFFF)] = c; self.pos++; }
 
 const ushort[31] LENGTH_BASE @private = { 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258, 0, 0 };
 const char[31] LENGTH_EXTRA @private = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0, 0, 0 };
 const ushort[32] DIST_BASE @private = { 1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193, 257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145, 8193, 12289, 16385, 24577, 0, 0 };
 const char[32] DIST_EXTRA @private = { 0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 0, 0 };
 const uint[19] ORDER @private = { 16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15 };
+
+fn void _encode_match_len(uint b_len, uint* code, int* extra_bits, uint* extra) @local
+{
+	switch (b_len)
+	{
+		case 3..10:   *code = 257u + b_len - 3u; *extra_bits = 0; *extra = 0;
+		case 11..18:  *code = 265u + (b_len - 11u) / 2; *extra_bits = 1; *extra = (b_len - 11u) % 2;
+		case 19..34:  *code = 269u + (b_len - 19u) / 4; *extra_bits = 2; *extra = (b_len - 19u) % 4;
+		case 35..66:  *code = 273u + (b_len - 35u) / 8; *extra_bits = 3; *extra = (b_len - 35u) % 8;
+		case 67..130: *code = 277u + (b_len - 67u) / 16; *extra_bits = 4; *extra = (b_len - 67u) % 16;
+		case 131..257:*code = 281u + (b_len - 131u) / 32; *extra_bits = 5; *extra = (b_len - 131u) % 32;
+		default:      *code = 285u; *extra_bits = 0; *extra = 0;
+	}
+}
+
+fn void _encode_match_dist(uint b_dist, uint* code, int* extra_bits, uint* extra) @local
+{
+	switch (b_dist)
+	{
+		case 1..4:     *code = b_dist - 1u; *extra_bits = 0; *extra = 0;
+		case 5..8:     *code = 4u + (b_dist - 5u) / 2u; *extra_bits = 1; *extra = (b_dist - 5u) % 2;
+		case 9..16:    *code = 6u + (b_dist - 9u) / 4u; *extra_bits = 2; *extra = (b_dist - 9u) % 4;
+		case 17..32:   *code = 8u + (b_dist - 17u) / 8u; *extra_bits = 3; *extra = (b_dist - 17u) % 8;
+		case 33..64:   *code = 10u + (b_dist - 33u) / 16u; *extra_bits = 4; *extra = (b_dist - 33u) % 16;
+		case 65..128:  *code = 12u + (b_dist - 65u) / 32u; *extra_bits = 5; *extra = (b_dist - 65u) % 32;
+		case 129..256: *code = 14u + (b_dist - 129u) / 64u; *extra_bits = 6; *extra = (b_dist - 129u) % 64;
+		case 257..512: *code = 16u + (b_dist - 257u) / 128u; *extra_bits = 7; *extra = (b_dist - 257u) % 128;
+		case 513..1024: *code = 18u + (b_dist - 513u) / 256; *extra_bits = 8; *extra = (b_dist - 513u) % 256;
+		case 1025..2048: *code = 20u + (b_dist - 1025u) / 512; *extra_bits = 9; *extra = (b_dist - 1025u) % 512;
+		case 2049..4096: *code = 22u + (b_dist - 2049u) / 1024; *extra_bits = 10; *extra = (b_dist - 2049u) % 1024;
+		case 4097..8192: *code = 24u + (b_dist - 4097u) / 2048; *extra_bits = 11; *extra = (b_dist - 4097u) % 2048;
+		case 8193..16384: *code = 26u + (b_dist - 8193u) / 4096; *extra_bits = 12; *extra = (b_dist - 8193u) % 4096;
+		default:          *code = 28u + (b_dist - 16385u) / 8192; *extra_bits = 13; *extra = (b_dist - 16385u) % 8192;
+	}
+}
+
+fn void _write_compressed_tokens(Deflater* self, Code* lit_codes, Code* dist_codes) @local
+{
+	foreach (t : self.tokens[:self.token_count])
+	{
+		if (t.dist == 0)
+		{
+			self.bwriter.write_huffman(lit_codes[t.val].code, lit_codes[t.val].len);
+		}
+		else
+		{
+			uint len_code; int len_extra_bits; uint len_extra;
+			_encode_match_len(t.val, &len_code, &len_extra_bits, &len_extra);
+			self.bwriter.write_huffman(lit_codes[len_code].code, lit_codes[len_code].len);
+			if (len_extra_bits > 0) self.bwriter.write_bits(len_extra, len_extra_bits);
+
+			uint dist_c; int dist_extra_b; uint dist_ex;
+			_encode_match_dist(t.dist, &dist_c, &dist_extra_b, &dist_ex);
+			self.bwriter.write_huffman(dist_codes[dist_c].code, dist_codes[dist_c].len);
+			if (dist_extra_b > 0) self.bwriter.write_bits(dist_ex, dist_extra_b);
+		}
+	}
+}
+
+fn void _rle_encode_tree_lengths(char[] all_lens, List{Token}* tree_tokens, uint[] tree_freqs) @local
+{
+	for (long i = 0; i < all_lens.len;)
+	{
+		char len = all_lens[i];
+		long count = 1;
+		while (i + count < all_lens.len && all_lens[i + count] == len) count++;
+
+		if (len == 0)
+		{
+			while (count >= 11)
+			{
+				uint c = (uint)math::min(count, (long)138);
+				tree_tokens.push({ 18, (ushort)(c - 11u) });
+				tree_freqs[18]++;
+				i += c; count -= c;
+			}
+			while (count >= 3)
+			{
+				uint c = (uint)math::min(count, (long)10);
+				tree_tokens.push({ 17, (ushort)(c - 3u) });
+				tree_freqs[17]++;
+				i += c; count -= c;
+			}
+		}
+		else if (count >= 4)
+		{
+			tree_tokens.push({ (ushort)len, 0 });
+			tree_freqs[(uint)len]++;
+			i++; count--;
+			while (count >= 3)
+			{
+				uint c = (uint)math::min(count, (long)6);
+				tree_tokens.push({ 16, (ushort)(c - 3u) });
+				tree_freqs[16]++;
+				i += c; count -= c;
+			}
+		}
+		while (count--)
+		{
+			tree_tokens.push({ (ushort)len, 0 });
+			tree_freqs[(uint)len]++;
+			i++;
+		}
+	}
+}

--- a/lib/std/compression/zip.c3
+++ b/lib/std/compression/zip.c3
@@ -65,6 +65,168 @@ constset ZipMethod : UShortLE
 	AEX = {99},
 }
 
+fn bool? _find_eocd(File* f, long file_size, ZipEOCD* eocd) @local
+{
+	long search_start = file_size > ZipEOCD::size + 65535LL ? file_size - (ZipEOCD::size + 65535LL) : 0;
+	for (long pos = file_size - ZipEOCD::size; pos >= search_start; pos--)
+	{
+		if (pos > sz::max) return io::OVERFLOW~;
+		f.seek(pos)!;
+		UIntLE sig;
+		if (io::read_any(f, &sig)! != 4) break;
+
+		if (sig.val == ZIP_EOCD_SIG)
+		{
+			f.seek(pos)!;
+			if (io::read_any(f, eocd)! == ZipEOCD::size)
+			{
+				long expected_end = pos + ZipEOCD::size + eocd.comment_len.val;
+				if (expected_end == file_size)
+				{
+					return true;
+				}
+			}
+		}
+		if (pos == 0) break;
+	}
+	return false;
+}
+
+fn sz? _read_zip64_cd(File* f, long file_size, sz default_entries) @local
+{
+	sz locator_pos = (sz)file_size - ZipEOCD::size - Zip64Locator::size;
+	if (locator_pos < 0) return default_entries;
+
+	f.seek(locator_pos)!;
+	Zip64Locator locator;
+	if (try n = io::read_buffer_to_end(f, ((char*)&locator)[:Zip64Locator::size]).len
+		&& n == Zip64Locator::size && locator.signature.val == ZIP64_LOCATOR_SIG)
+	{
+		if (locator.offset_eocd.val > sz::max) return io::OVERFLOW~;
+		f.seek(locator.offset_eocd.val)!;
+		Zip64EOCD eocd64;
+		io::read_any(f, &eocd64)!;
+		if (eocd64.signature.val == ZIP64_EOCD_SIG)
+		{
+			if (eocd64.offset_cd.val > sz::max) return io::OVERFLOW~;
+			f.seek(eocd64.offset_cd.val)!!;
+			return (sz)eocd64.count_total.val;
+		}
+	}
+	return default_entries;
+}
+
+fn String? _decode_filename(Allocator allocator, char[] raw_name, bool is_utf8) @local
+{
+	if (is_utf8 || is_valid_utf8(raw_name))
+	{
+		return (String)raw_name;
+	}
+	String name = (String)codepage::decode(allocator, raw_name, CP437)!!;
+	alloc::free(allocator, raw_name.ptr);
+	return name;
+}
+
+fn void? _parse_zip64_extra(char[] extra_field, ZipCDH* cdh, long* uncompressed_size, long* compressed_size, long* offset) @local
+{
+	ByteReader reader = { .bytes = extra_field };
+	while (reader.available()! >= 4)
+	{
+		ushort id = io::read_le_ushort(&reader)!;
+		ushort size = io::read_le_ushort(&reader)!;
+
+		if (id == ZIP64_EXTRA_ID)
+		{
+			int remaining = size;
+			if (cdh.uncompressed_size.val == 0xFFFFFFFF && remaining >= 8)
+			{
+				*uncompressed_size = io::read_le_long(&reader)!;
+				remaining -= 8;
+			}
+			if (cdh.compressed_size.val == 0xFFFFFFFF && remaining >= 8)
+			{
+				*compressed_size = io::read_le_long(&reader)!;
+				remaining -= 8;
+			}
+			if (cdh.relative_offset.val == 0xFFFFFFFF && remaining >= 8)
+			{
+				*offset = io::read_le_long(&reader)!;
+				remaining -= 8;
+			}
+			break;
+		}
+		reader.seek(size, FROM_CURSOR)!;
+	}
+}
+
+fn bool _is_directory_entry(String name, ushort version_made_by, uint external_attr) @local
+{
+	if (name.ends_with("/") || name.ends_with("\\")) return true;
+	ushort host_system = version_made_by >> 8;
+	if (host_system == 0 || host_system == 10) // MS-DOS or NTFS
+	{
+		if ((external_attr & 0x10) != 0) return true;
+	}
+	else if (host_system == 3) // Unix
+	{
+		if (((external_attr >> 16) & 0x4000) != 0) return true;
+	}
+	return false;
+}
+
+fn bool? _parse_zip_cd_entry(File* f, Allocator allocator, ZipEntry* entry) @local
+{
+	ZipCDH cdh;
+	if (io::read_any(f, &cdh)! != ZipCDH::size) return false;
+	if (cdh.signature.val != ZIP_CDH_SIG) return false;
+
+	char[] raw_name = alloc::alloc_array(allocator, char, cdh.filename_len.val);
+	defer catch alloc::free(allocator, raw_name);
+	if (raw_name.len && io::read_buffer(f, raw_name)! != (sz)cdh.filename_len.val)
+	{
+		alloc::free(allocator, raw_name);
+		return false;
+	}
+
+	String name = _decode_filename(allocator, raw_name, (cdh.flags.val & 0x0800) != 0)!;
+	raw_name = {};
+	defer catch alloc::free(allocator, name);
+
+	char[] extra_field;
+	if (cdh.extra_field_len.val > 0)
+	{
+		extra_field = alloc::alloc_array(allocator, char, cdh.extra_field_len.val);
+		defer catch alloc::free(allocator, extra_field);
+		io::read_all(f, extra_field)!;
+	}
+	defer alloc::free(allocator, extra_field);
+
+	f.seek(cdh.comment_len.val, FROM_CURSOR)!;
+
+	long uncompressed_size = cdh.uncompressed_size.val;
+	long compressed_size = cdh.compressed_size.val;
+	long offset = cdh.relative_offset.val;
+
+	if (cdh.uncompressed_size.val == 0xFFFFFFFF || cdh.compressed_size.val == 0xFFFFFFFF || cdh.relative_offset.val == 0xFFFFFFFF)
+	{
+		_parse_zip64_extra(extra_field, &cdh, &uncompressed_size, &compressed_size, &offset)!;
+	}
+
+	*entry = {
+		.name = name,
+		.uncompressed_size = uncompressed_size,
+		.compressed_size = compressed_size,
+		.crc32 = cdh.crc32.val,
+		.offset = offset,
+		.method = cdh.method,
+		.last_mod_time = cdh.last_mod_time.val,
+		.last_mod_date = cdh.last_mod_date.val,
+		.is_directory = _is_directory_entry(name, cdh.version_made_by.val, cdh.external_attr.val),
+		.is_encrypted = (cdh.flags.val & 1) != 0
+	};
+	return true;
+}
+
 <*
  Opens a ZIP archive.
  @param allocator : `The allocator to use.`
@@ -93,38 +255,10 @@ fn ZipArchive? open(Allocator allocator, String path, String mode = "r")
 	defer catch (void)f.close();
 
 	long file_size = f.size()!!;
-
 	if (file_size < ZipEOCD::size) return CORRUPTED_DATA~;
 
-	long search_start = file_size > ZipEOCD::size + 65535LL ? file_size - (ZipEOCD::size + 65535LL) : 0;
-
 	ZipEOCD eocd;
-	bool found = false;
-
-	for (long pos = file_size - ZipEOCD::size; pos >= search_start; pos--)
-	{
-		if (pos > sz::max) return io::OVERFLOW~;
-		f.seek(pos)!;
-		UIntLE sig;
-		if (io::read_any(&f, &sig)! != 4) break;
-
-		if (sig.val == ZIP_EOCD_SIG)
-		{
-			f.seek(pos)!;
-			if (io::read_any(&f, &eocd)! == ZipEOCD::size)
-			{
-				long expected_end = pos + ZipEOCD::size + eocd.comment_len.val;
-				if (expected_end == file_size)
-				{
-					found = true;
-					break;
-				}
-			}
-		}
-		if (pos == 0) break;
-	}
-
-	if (!found) return CORRUPTED_DATA~;
+	if (!_find_eocd(&f, file_size, &eocd)!) return CORRUPTED_DATA~;
 
 	ZipArchive archive;
 	archive.allocator = allocator;
@@ -150,134 +284,16 @@ fn ZipArchive? open(Allocator allocator, String path, String mode = "r")
 
 	sz num_entries = eocd.num_entries.val;
 
-
 	// ZIP64 check
 	if (eocd.num_entries.val == 0xFFFF || eocd.cd_offset.val == 0xFFFFFFFF)
 	{
-		sz locator_pos = (sz)file_size - ZipEOCD::size - Zip64Locator::size;
-		if (locator_pos >= 0)
-		{
-			archive.file.seek(locator_pos)!;
-			Zip64Locator locator;
-			if (try n = io::read_buffer_to_end(archive.file, ((char*)&locator)[:Zip64Locator::size]).len
-				&& n == Zip64Locator::size && locator.signature.val == ZIP64_LOCATOR_SIG)
-			{
-				if (locator.offset_eocd.val > sz::max) return io::OVERFLOW~;
-				archive.file.seek(locator.offset_eocd.val)!;
-				Zip64EOCD eocd64;
-				io::read_any(archive.file, &eocd64)!;
-				if (eocd64.signature.val == ZIP64_EOCD_SIG)
-				{
-					if (eocd64.offset_cd.val > sz::max) return io::OVERFLOW~;
-					archive.file.seek(eocd64.offset_cd.val)!!;
-					num_entries = (sz)eocd64.count_total.val;
-				}
-			}
-		}
+		num_entries = _read_zip64_cd(archive.file, file_size, num_entries)!;
 	}
 
 	for (sz i = 0; i < num_entries; i++)
 	{
-		ZipCDH cdh;
-		if (io::read_any(archive.file, &cdh)! != ZipCDH::size) break;
-		if (cdh.signature.val != ZIP_CDH_SIG) break;
-
-		char[] raw_name = alloc::alloc_array(allocator, char, cdh.filename_len.val);
-		defer catch alloc::free(allocator, raw_name);
-		if (raw_name.len && io::read_buffer(archive.file, raw_name)! != (sz)cdh.filename_len.val)
-		{
-			alloc::free(allocator, raw_name);
-			break;
-		}
-
-		String name;
-		bool is_utf8 = (cdh.flags.val & 0x0800) != 0;
-		if (is_utf8 || is_valid_utf8(raw_name))
-		{
-			name = (String)raw_name;
-		}
-		else
-		{
-			name = (String)codepage::decode(allocator, raw_name, CP437)!!;
-			alloc::free(allocator, raw_name.ptr);
-		}
-		raw_name = {};
-		defer catch alloc::free(allocator, name);
-
-		char[] extra_field;
-		if (cdh.extra_field_len.val > 0)
-		{
-			extra_field = alloc::alloc_array(allocator, char, cdh.extra_field_len.val);
-			defer catch alloc::free(allocator, extra_field);
-			io::read_all(archive.file, extra_field)!;
-		}
-
-		defer alloc::free(allocator, extra_field);
-		archive.file.seek(cdh.comment_len.val, FROM_CURSOR)!;
-
-		long uncompressed_size = cdh.uncompressed_size.val;
-		long compressed_size = cdh.compressed_size.val;
-		long offset = cdh.relative_offset.val;
-
-		if (cdh.uncompressed_size.val == 0xFFFFFFFF || cdh.compressed_size.val == 0xFFFFFFFF || cdh.relative_offset.val == 0xFFFFFFFF)
-		{
-			ByteReader reader = { .bytes = extra_field };
-			while (reader.available()! >= 4)
-			{
-				ushort id = io::read_le_ushort(&reader)!;
-				ushort size = io::read_le_ushort(&reader)!;
-
-				if (id == ZIP64_EXTRA_ID)
-				{
-					int remaining = size;
-					if (cdh.uncompressed_size.val == 0xFFFFFFFF && remaining >= 8)
-					{
-						uncompressed_size = io::read_le_long(&reader)!;
-						remaining -= 8;
-					}
-					if (cdh.compressed_size.val == 0xFFFFFFFF && remaining >= 8)
-					{
-						compressed_size = io::read_le_long(&reader)!;
-						remaining -= 8;
-					}
-					if (cdh.relative_offset.val == 0xFFFFFFFF && remaining >= 8)
-					{
-						offset = io::read_le_long(&reader)!;
-						remaining -= 8;
-					}
-					break;
-				}
-				reader.seek(size, FROM_CURSOR)!;
-			}
-		}
-
-		bool is_directory = name.ends_with("/") || name.ends_with("\\");
-		if (!is_directory)
-		{
-			ushort host_system = cdh.version_made_by.val >> 8;
-			if (host_system == 0 || host_system == 10) // MS-DOS or NTFS
-			{
-				if ((cdh.external_attr.val & 0x10) != 0) is_directory = true;
-			}
-			else if (host_system == 3) // Unix
-			{
-				if (((cdh.external_attr.val >> 16) & 0x4000) != 0) is_directory = true;
-			}
-		}
-
-		ZipEntry entry = {
-			.name = name,
-			.uncompressed_size = uncompressed_size,
-			.compressed_size = compressed_size,
-			.crc32 = cdh.crc32.val,
-			.offset = offset,
-			.method = cdh.method,
-			.last_mod_time = cdh.last_mod_time.val,
-			.last_mod_date = cdh.last_mod_date.val,
-			.is_directory = is_directory,
-			.is_encrypted = (cdh.flags.val & 1) != 0
-		};
-
+		ZipEntry entry;
+		if (!_parse_zip_cd_entry(archive.file, allocator, &entry)!) break;
 		archive.entries.push(entry);
 	}
 
@@ -328,16 +344,7 @@ fn ZipArchive? recover(Allocator allocator, String path)
 			break;
 		}
 
-		String name;
-		if ((lfh.flags.val & 0x0800) != 0 || is_valid_utf8(raw_name))
-		{
-			name = (String)raw_name;
-		}
-		else
-		{
-			name = (String)codepage::decode(allocator, raw_name, CP437)!!;
-			alloc::free(allocator, raw_name.ptr);
-		}
+		String name = _decode_filename(allocator, raw_name, (lfh.flags.val & 0x0800) != 0)!;
 
 		archive.file.seek(lfh.extra_field_len.val, FROM_CURSOR)!!;
 
@@ -362,6 +369,127 @@ fn ZipArchive? recover(Allocator allocator, String path)
 
 	if (archive.entries.len() == 0) return CORRUPTED_DATA~;
 	return archive;
+}
+
+fn void? _write_cd_entry(File* f, Allocator allocator, ZipEntry* entry, long* cd_size) @local
+{
+	ZipCDH cdh = {
+		.signature.val = ZIP_CDH_SIG,
+		.version_made_by.val = 45, // 4.5 for ZIP64
+		.version_needed.val = 45,
+		.method = entry.method,
+		.last_mod_time.val = entry.last_mod_time,
+		.last_mod_date.val = entry.last_mod_date,
+		.crc32.val = entry.crc32,
+		.filename_len.val = (ushort)entry.name.len,
+	};
+
+	bool is_zip64 = entry.uncompressed_size >= 0xFFFFFFFF || entry.compressed_size >= 0xFFFFFFFF || entry.offset >= 0xFFFFFFFF;
+
+	char[] extra_data;
+	if (is_zip64)
+	{
+		cdh.compressed_size.val = 0xFFFFFFFF;
+		cdh.uncompressed_size.val = 0xFFFFFFFF;
+		cdh.relative_offset.val = 0xFFFFFFFF;
+
+		// Header(4) + Uncomp(8) + Comp(8) + Offset(8)
+		ushort extra_size = 28;
+		extra_data = alloc::alloc_array(allocator, char, extra_size);
+		bitorder::write(ZIP64_EXTRA_ID, extra_data[:2], UShortLE);
+		bitorder::write((ushort)(extra_size - 4), extra_data[2:2], UShortLE);
+		bitorder::write(entry.uncompressed_size, extra_data[4:8], LongLE);
+		bitorder::write(entry.compressed_size, extra_data[12:8], LongLE);
+		bitorder::write(entry.offset, extra_data[20:8], LongLE);
+
+		cdh.extra_field_len.val = extra_size;
+	}
+	else
+	{
+		cdh.compressed_size.val = (uint)entry.compressed_size;
+		cdh.uncompressed_size.val = (uint)entry.uncompressed_size;
+		cdh.relative_offset.val = (uint)entry.offset;
+	}
+
+	// Set external attributes (MS-DOS compatibility).
+	// 0x10 is the DOS directory attribute.
+	cdh.external_attr.val = (uint)(entry.is_directory ? 0x10 : 0);
+
+	io::write_any(f, &cdh)!;
+	f.write(entry.name)!;
+	if (is_zip64)
+	{
+		f.write(extra_data)!;
+		alloc::free(allocator, extra_data);
+	}
+
+	long entry_record_size = (long)ZipCDH::size + entry.name.len + cdh.extra_field_len.val;
+	if (*cd_size + entry_record_size <= 0) return io::OVERFLOW~;
+	*cd_size += entry_record_size;
+}
+
+fn void? _write_eocd_records(File* f, Allocator allocator, sz num_entries, long cd_size, long cd_offset, String comment) @local
+{
+	bool cd_zip64 = num_entries >= 0xFFFF || cd_size >= 0xFFFFFFFF || cd_offset >= 0xFFFFFFFF;
+
+	if (cd_zip64)
+	{
+		long eocd64_offset = f.cursor()!;
+
+		Zip64EOCD eocd64 = {
+			.signature.val = ZIP64_EOCD_SIG,
+			.size.val = (ulong)(Zip64EOCD::size - 12),
+			.version_made.val = 45,
+			.version_needed.val = 45,
+			.count_this_disk.val = num_entries,
+			.count_total.val = num_entries,
+			.size_cd.val = cd_size,
+			.offset_cd.val = cd_offset,
+		};
+
+		io::write_any(f, &eocd64)!;
+
+		Zip64Locator locator = {
+			.signature.val = ZIP64_LOCATOR_SIG,
+			.disk_start.val = 0,
+			.offset_eocd.val = eocd64_offset,
+			.total_disks.val = 1,
+		};
+
+		io::write_any(f, &locator)!;
+	}
+
+	char[] encoded_comment;
+	if (comment.len > 0)
+	{
+		char[]? res = codepage::encode(allocator, comment, CodePage.CP437);
+		if (try res)
+		{
+			encoded_comment = res;
+			if (encoded_comment.len > 0xFFFF)
+			{
+				alloc::free(allocator, encoded_comment.ptr);
+				return INVALID_ARGUMENT~;
+			}
+		}
+	}
+	defer if (encoded_comment.ptr) alloc::free(allocator, encoded_comment);
+
+	ZipEOCD eocd = {
+		.signature.val = ZIP_EOCD_SIG,
+		.num_entries_this_disk.val = (ushort)(num_entries >= 0xFFFF ? 0xFFFF : (ushort)num_entries),
+		.num_entries.val = (ushort)(num_entries >= 0xFFFF ? 0xFFFF : (ushort)num_entries),
+		.cd_size.val = (uint)(cd_size >= 0xFFFFFFFF ? 0xFFFFFFFF : (uint)cd_size),
+		.cd_offset.val = (uint)(cd_offset >= 0xFFFFFFFF ? 0xFFFFFFFF : (uint)cd_offset),
+		.comment_len.val = (ushort)encoded_comment.len,
+	};
+
+	io::write_any(f, &eocd)!;
+
+	if (encoded_comment.len > 0)
+	{
+		f.write(encoded_comment)!;
+	}
 }
 
 <*
@@ -391,122 +519,10 @@ fn void? ZipArchive.close(&self)
 
 		for (sz i = 0; i < self.entries.len(); i++)
 		{
-			ZipEntry* entry = self.entries.get_ref(i);
-			ZipCDH cdh = {
-				.signature.val = ZIP_CDH_SIG,
-				.version_made_by.val = 45, // 4.5 for ZIP64
-				.version_needed.val = 45,
-				.method = entry.method,
-				.last_mod_time.val = entry.last_mod_time,
-				.last_mod_date.val = entry.last_mod_date,
-				.crc32.val = entry.crc32,
-				.filename_len.val = (ushort)entry.name.len,
-			};
-
-			bool is_zip64 = entry.uncompressed_size >= 0xFFFFFFFF || entry.compressed_size >= 0xFFFFFFFF || entry.offset >= 0xFFFFFFFF;
-
-			char[] extra_data;
-			if (is_zip64)
-			{
-				cdh.compressed_size.val = 0xFFFFFFFF;
-				cdh.uncompressed_size.val = 0xFFFFFFFF;
-				cdh.relative_offset.val = 0xFFFFFFFF;
-
-				// Header(4) + Uncomp(8) + Comp(8) + Offset(8)
-				ushort extra_size = 28;
-				extra_data = alloc::alloc_array(self.allocator, char, extra_size);
-				bitorder::write(ZIP64_EXTRA_ID, extra_data[:2], UShortLE);
-				bitorder::write((ushort)(extra_size - 4), extra_data[2:2], UShortLE);
-				bitorder::write(entry.uncompressed_size, extra_data[4:8], LongLE);
-				bitorder::write(entry.compressed_size, extra_data[12:8], LongLE);
-				bitorder::write(entry.offset, extra_data[20:8], LongLE);
-
-				cdh.extra_field_len.val = extra_size;
-			}
-			else
-			{
-				cdh.compressed_size.val = (uint)entry.compressed_size;
-				cdh.uncompressed_size.val = (uint)entry.uncompressed_size;
-				cdh.relative_offset.val = (uint)entry.offset;
-			}
-
-			// Set external attributes (MS-DOS compatibility).
-			// 0x10 is the DOS directory attribute.
-			cdh.external_attr.val = (uint)(entry.is_directory ? 0x10 : 0);
-
-			io::write_any(self.file, &cdh)!;
-			self.file.write(entry.name)!;
-			if (is_zip64)
-			{
-				self.file.write(extra_data)!;
-				alloc::free(self.allocator, extra_data);
-			}
-
-			long entry_record_size = (long)ZipCDH::size + entry.name.len + cdh.extra_field_len.val;
-			if (cd_size + entry_record_size <= 0) return io::OVERFLOW~;
-			cd_size += entry_record_size;
+			_write_cd_entry(self.file, self.allocator, self.entries.get_ref(i), &cd_size)!;
 		}
 
-		bool cd_zip64 = self.entries.len() >= 0xFFFF || cd_size >= 0xFFFFFFFF || cd_offset >= 0xFFFFFFFF;
-
-		if (cd_zip64)
-		{
-			long eocd64_offset = self.file.cursor()!;
-
-			Zip64EOCD eocd64 = {
-				.signature.val = ZIP64_EOCD_SIG,
-				.size.val = (ulong)(Zip64EOCD::size - 12),
-				.version_made.val = 45,
-				.version_needed.val = 45,
-				.count_this_disk.val = self.entries.len(),
-				.count_total.val = self.entries.len(),
-				.size_cd.val = cd_size,
-				.offset_cd.val = cd_offset,
-			};
-
-			io::write_any(self.file, &eocd64)!;
-
-			Zip64Locator locator = {
-				.signature.val = ZIP64_LOCATOR_SIG,
-				.disk_start.val = 0,
-				.offset_eocd.val = eocd64_offset,
-				.total_disks.val = 1,
-			};
-
-			io::write_any(self.file, &locator)!;
-		}
-
-		char[] encoded_comment;
-		if (self.comment.len > 0)
-		{
-			char[]? res = codepage::encode(self.allocator, self.comment, CodePage.CP437);
-			if (try res)
-			{
-				encoded_comment = res;
-				if (encoded_comment.len > 0xFFFF)
-				{
-					alloc::free(self.allocator, encoded_comment.ptr);
-					return INVALID_ARGUMENT~;
-				}
-			}
-		}
-		defer if (encoded_comment.ptr) alloc::free(self.allocator, encoded_comment);
-
-		ZipEOCD eocd = {
-			.signature.val = ZIP_EOCD_SIG,
-			.num_entries_this_disk.val = (ushort)(self.entries.len() >= 0xFFFF ? 0xFFFF : (ushort)self.entries.len()),
-			.num_entries.val = (ushort)(self.entries.len() >= 0xFFFF ? 0xFFFF : (ushort)self.entries.len()),
-			.cd_size.val = (uint)(cd_size >= 0xFFFFFFFF ? 0xFFFFFFFF : (uint)cd_size),
-			.cd_offset.val = (uint)(cd_offset >= 0xFFFFFFFF ? 0xFFFFFFFF : (uint)cd_offset),
-			.comment_len.val = (ushort)encoded_comment.len,
-		};
-
-		io::write_any(self.file, &eocd)!;
-
-		if (encoded_comment.len > 0)
-		{
-			self.file.write(encoded_comment)!;
-		}
+		_write_eocd_records(self.file, self.allocator, self.entries.len(), cd_size, cd_offset, self.comment)!;
 	}
 }
 
@@ -738,6 +754,89 @@ fn void? ZipEntryReader.seek(&self, long offset, SeekOrigin seek = FROM_START) @
 	self.adapter.pos = new_pos;
 }
 
+fn void? _init_aex_reader(File* f, ZipEntry* entry, ZipLFH* lfh, String password, ZipEntryReader* reader) @local
+{
+	if (entry.method != AEX) return ENCRYPTED_FILE~;
+	if (!password.len) return PASSWORD_NEEDED~;
+
+	char aex_strength;
+	ushort aex_method;
+	ushort aex_version;
+
+	f.seek(lfh.filename_len.val, FROM_CURSOR)!;
+	long end = f.cursor()! + lfh.extra_field_len.val;
+	while (f.cursor()! < end)
+	{
+		ushort id = io::read_le_ushort(f)!;
+		ushort size = io::read_le_ushort(f)!;
+
+		if (id == AEX_EXTRA_ID)
+		{
+			aex_version = io::read_le_ushort(f)!;
+			io::read_le_ushort(f)!;
+			aex_strength = f.read_byte()!;
+			aex_method = io::read_le_ushort(f)!;
+			continue;
+		}
+		f.seek(size, FROM_CURSOR)!;
+	}
+	if (!aex_version) return CORRUPTED_DATA~;
+
+	AesType aes_type;
+	sz key_len;
+	switch (aex_strength)
+	{
+		case 1: key_len = 16; aes_type = AES128;
+		case 2: key_len = 24; aes_type = AES192;
+		case 3: key_len = 32; aes_type = AES256;
+		default: return CORRUPTED_DATA~;
+	}
+	sz salt_len = key_len / 2;
+
+	@pool()
+	{
+		char[] buf = mem::temp_array(char, salt_len + 2);
+		buf = io::read_buffer_to_end(f, buf)!;
+
+		if (buf.len < salt_len + 2) return CORRUPTED_DATA~;
+
+		char[] salt        = buf[0:salt_len];
+		char[] pv_stored   = buf[salt_len:2];
+
+		sz cipher_len = (sz)entry.compressed_size - salt_len - 2 - 10;
+		if (cipher_len < 0) return CORRUPTED_DATA~;
+
+		char[] cipher = mem::temp_array(char, cipher_len);
+		cipher = io::read_buffer_to_end(f, cipher)!;
+		if (cipher.len != cipher_len) return CORRUPTED_DATA~;
+
+		char[] hmac_stored = mem::temp_array(char, 10);
+		hmac_stored = io::read_buffer_to_end(f, hmac_stored)!;
+		if (hmac_stored.len != 10) return CORRUPTED_DATA~;
+
+		sz dk_len = key_len * 2 + 2;
+		char[] dk = mem::temp_array(char, dk_len);
+		sha1::pbkdf2(password, salt, 1000, dk);
+
+		char[] aes_key = dk[0:key_len];
+		char[] mac_key = dk[key_len:key_len];
+		char[] pv_derived = dk[key_len*2:2];
+
+		if (pv_stored != pv_derived) return PASSWORD_MISMATCH~;
+
+		char[*] hmac_calc = sha1::hmac(mac_key, cipher);
+		if (hmac_stored[:10] != hmac_calc[:10]) return CORRUPTED_DATA~;
+
+		char[16] iv = { [0] = 1 };
+		reader.adapter.aes.init(aes_type, aes_key, iv[..], CTR_LE);
+	};
+
+	reader.adapter.aex = aex_version;
+	reader.adapter.start_offset += (long)salt_len + 2;
+	reader.adapter.size = entry.compressed_size - salt_len - 2 - 10;
+	reader.method = (ZipMethod)aex_method;
+}
+
 <*
  Opens a reader for an entry.
  @param filename : `The name of the file to read.`
@@ -774,85 +873,7 @@ fn ZipEntryReader? ZipArchive.open_reader(&self, String filename, String passwor
 	// AE-X decryption.
 	if (entry.is_encrypted)
 	{
-		if (entry.method != AEX) return ENCRYPTED_FILE~;
-		if (!password.len) return PASSWORD_NEEDED~;
-
-		char aex_strength;
-		ushort aex_method;
-		ushort aex_version;
-
-		self.file.seek(lfh.filename_len.val, FROM_CURSOR)!;
-		long end = self.file.cursor()! + lfh.extra_field_len.val;
-		while (self.file.cursor()! < end)
-		{
-			ushort id = io::read_le_ushort(self.file)!;
-			ushort size = io::read_le_ushort(self.file)!;
-
-			if (id == AEX_EXTRA_ID)
-			{
-				aex_version = io::read_le_ushort(self.file)!;
-				io::read_le_ushort(self.file)!;
-				aex_strength = self.file.read_byte()!;
-				aex_method = io::read_le_ushort(self.file)!;
-				continue;
-			}
-			self.file.seek(size, FROM_CURSOR)!;
-		}
-		if (!aex_version) return CORRUPTED_DATA~;
-
-		AesType aes_type;
-		sz key_len;
-		switch (aex_strength)
-		{
-			case 1: key_len = 16; aes_type = AES128;
-			case 2: key_len = 24; aes_type = AES192;
-			case 3: key_len = 32; aes_type = AES256;
-			default: return CORRUPTED_DATA~;
-		}
-		sz salt_len = key_len / 2;
-
-		@pool()
-		{
-			char[] buf = mem::temp_array(char, salt_len + 2);
-			buf = io::read_buffer_to_end(self.file, buf)!;
-
-			if (buf.len < salt_len + 2) return CORRUPTED_DATA~;
-
-			char[] salt        = buf[0:salt_len];
-			char[] pv_stored   = buf[salt_len:2];
-
-			sz cipher_len = (sz)entry.compressed_size - salt_len - 2 - 10;
-			if (cipher_len < 0) return CORRUPTED_DATA~;
-
-			char[] cipher = mem::temp_array(char, cipher_len);
-			cipher = io::read_buffer_to_end(self.file, cipher)!;
-			if (cipher.len != cipher_len) return CORRUPTED_DATA~;
-
-			char[] hmac_stored = mem::temp_array(char, 10);
-			hmac_stored = io::read_buffer_to_end(self.file, hmac_stored)!;
-			if (hmac_stored.len != 10) return CORRUPTED_DATA~;
-
-			sz dk_len = key_len * 2 + 2;
-			char[] dk = mem::temp_array(char, dk_len);
-			sha1::pbkdf2(password, salt, 1000, dk);
-
-			char[] aes_key = dk[0:key_len];
-			char[] mac_key = dk[key_len:key_len];
-			char[] pv_derived = dk[key_len*2:2];
-
-			if (pv_stored != pv_derived) return PASSWORD_MISMATCH~;
-
-			char[*] hmac_calc = sha1::hmac(mac_key, cipher);
-			if (hmac_stored[:10] != hmac_calc[:10]) return CORRUPTED_DATA~;
-
-			char[16] iv = { [0] = 1 };
-			reader.adapter.aes.init(aes_type, aes_key, iv[..], CTR_LE);
-		};
-
-		reader.adapter.aex = aex_version;
-		reader.adapter.start_offset += (long)salt_len + 2;
-		reader.adapter.size = entry.compressed_size - salt_len - 2 - 10;
-		reader.method = (ZipMethod)aex_method;
+		_init_aex_reader(self.file, &entry, &lfh, password, &reader)!;
 	}
 
 	return reader;

--- a/lib/std/compression/zip.c3
+++ b/lib/std/compression/zip.c3
@@ -65,168 +65,6 @@ constset ZipMethod : UShortLE
 	AEX = {99},
 }
 
-fn bool? _find_eocd(File* f, long file_size, ZipEOCD* eocd) @local
-{
-	long search_start = file_size > ZipEOCD::size + 65535LL ? file_size - (ZipEOCD::size + 65535LL) : 0;
-	for (long pos = file_size - ZipEOCD::size; pos >= search_start; pos--)
-	{
-		if (pos > sz::max) return io::OVERFLOW~;
-		f.seek(pos)!;
-		UIntLE sig;
-		if (io::read_any(f, &sig)! != 4) break;
-
-		if (sig.val == ZIP_EOCD_SIG)
-		{
-			f.seek(pos)!;
-			if (io::read_any(f, eocd)! == ZipEOCD::size)
-			{
-				long expected_end = pos + ZipEOCD::size + eocd.comment_len.val;
-				if (expected_end == file_size)
-				{
-					return true;
-				}
-			}
-		}
-		if (pos == 0) break;
-	}
-	return false;
-}
-
-fn sz? _read_zip64_cd(File* f, long file_size, sz default_entries) @local
-{
-	sz locator_pos = (sz)file_size - ZipEOCD::size - Zip64Locator::size;
-	if (locator_pos < 0) return default_entries;
-
-	f.seek(locator_pos)!;
-	Zip64Locator locator;
-	if (try n = io::read_buffer_to_end(f, ((char*)&locator)[:Zip64Locator::size]).len
-		&& n == Zip64Locator::size && locator.signature.val == ZIP64_LOCATOR_SIG)
-	{
-		if (locator.offset_eocd.val > sz::max) return io::OVERFLOW~;
-		f.seek(locator.offset_eocd.val)!;
-		Zip64EOCD eocd64;
-		io::read_any(f, &eocd64)!;
-		if (eocd64.signature.val == ZIP64_EOCD_SIG)
-		{
-			if (eocd64.offset_cd.val > sz::max) return io::OVERFLOW~;
-			f.seek(eocd64.offset_cd.val)!!;
-			return (sz)eocd64.count_total.val;
-		}
-	}
-	return default_entries;
-}
-
-fn String? _decode_filename(Allocator allocator, char[] raw_name, bool is_utf8) @local
-{
-	if (is_utf8 || is_valid_utf8(raw_name))
-	{
-		return (String)raw_name;
-	}
-	String name = (String)codepage::decode(allocator, raw_name, CP437)!!;
-	alloc::free(allocator, raw_name.ptr);
-	return name;
-}
-
-fn void? _parse_zip64_extra(char[] extra_field, ZipCDH* cdh, long* uncompressed_size, long* compressed_size, long* offset) @local
-{
-	ByteReader reader = { .bytes = extra_field };
-	while (reader.available()! >= 4)
-	{
-		ushort id = io::read_le_ushort(&reader)!;
-		ushort size = io::read_le_ushort(&reader)!;
-
-		if (id == ZIP64_EXTRA_ID)
-		{
-			int remaining = size;
-			if (cdh.uncompressed_size.val == 0xFFFFFFFF && remaining >= 8)
-			{
-				*uncompressed_size = io::read_le_long(&reader)!;
-				remaining -= 8;
-			}
-			if (cdh.compressed_size.val == 0xFFFFFFFF && remaining >= 8)
-			{
-				*compressed_size = io::read_le_long(&reader)!;
-				remaining -= 8;
-			}
-			if (cdh.relative_offset.val == 0xFFFFFFFF && remaining >= 8)
-			{
-				*offset = io::read_le_long(&reader)!;
-				remaining -= 8;
-			}
-			break;
-		}
-		reader.seek(size, FROM_CURSOR)!;
-	}
-}
-
-fn bool _is_directory_entry(String name, ushort version_made_by, uint external_attr) @local
-{
-	if (name.ends_with("/") || name.ends_with("\\")) return true;
-	ushort host_system = version_made_by >> 8;
-	if (host_system == 0 || host_system == 10) // MS-DOS or NTFS
-	{
-		if ((external_attr & 0x10) != 0) return true;
-	}
-	else if (host_system == 3) // Unix
-	{
-		if (((external_attr >> 16) & 0x4000) != 0) return true;
-	}
-	return false;
-}
-
-fn bool? _parse_zip_cd_entry(File* f, Allocator allocator, ZipEntry* entry) @local
-{
-	ZipCDH cdh;
-	if (io::read_any(f, &cdh)! != ZipCDH::size) return false;
-	if (cdh.signature.val != ZIP_CDH_SIG) return false;
-
-	char[] raw_name = alloc::alloc_array(allocator, char, cdh.filename_len.val);
-	defer catch alloc::free(allocator, raw_name);
-	if (raw_name.len && io::read_buffer(f, raw_name)! != (sz)cdh.filename_len.val)
-	{
-		alloc::free(allocator, raw_name);
-		return false;
-	}
-
-	String name = _decode_filename(allocator, raw_name, (cdh.flags.val & 0x0800) != 0)!;
-	raw_name = {};
-	defer catch alloc::free(allocator, name);
-
-	char[] extra_field;
-	if (cdh.extra_field_len.val > 0)
-	{
-		extra_field = alloc::alloc_array(allocator, char, cdh.extra_field_len.val);
-		defer catch alloc::free(allocator, extra_field);
-		io::read_all(f, extra_field)!;
-	}
-	defer alloc::free(allocator, extra_field);
-
-	f.seek(cdh.comment_len.val, FROM_CURSOR)!;
-
-	long uncompressed_size = cdh.uncompressed_size.val;
-	long compressed_size = cdh.compressed_size.val;
-	long offset = cdh.relative_offset.val;
-
-	if (cdh.uncompressed_size.val == 0xFFFFFFFF || cdh.compressed_size.val == 0xFFFFFFFF || cdh.relative_offset.val == 0xFFFFFFFF)
-	{
-		_parse_zip64_extra(extra_field, &cdh, &uncompressed_size, &compressed_size, &offset)!;
-	}
-
-	*entry = {
-		.name = name,
-		.uncompressed_size = uncompressed_size,
-		.compressed_size = compressed_size,
-		.crc32 = cdh.crc32.val,
-		.offset = offset,
-		.method = cdh.method,
-		.last_mod_time = cdh.last_mod_time.val,
-		.last_mod_date = cdh.last_mod_date.val,
-		.is_directory = _is_directory_entry(name, cdh.version_made_by.val, cdh.external_attr.val),
-		.is_encrypted = (cdh.flags.val & 1) != 0
-	};
-	return true;
-}
-
 <*
  Opens a ZIP archive.
  @param allocator : `The allocator to use.`
@@ -369,127 +207,6 @@ fn ZipArchive? recover(Allocator allocator, String path)
 
 	if (archive.entries.len() == 0) return CORRUPTED_DATA~;
 	return archive;
-}
-
-fn void? _write_cd_entry(File* f, Allocator allocator, ZipEntry* entry, long* cd_size) @local
-{
-	ZipCDH cdh = {
-		.signature.val = ZIP_CDH_SIG,
-		.version_made_by.val = 45, // 4.5 for ZIP64
-		.version_needed.val = 45,
-		.method = entry.method,
-		.last_mod_time.val = entry.last_mod_time,
-		.last_mod_date.val = entry.last_mod_date,
-		.crc32.val = entry.crc32,
-		.filename_len.val = (ushort)entry.name.len,
-	};
-
-	bool is_zip64 = entry.uncompressed_size >= 0xFFFFFFFF || entry.compressed_size >= 0xFFFFFFFF || entry.offset >= 0xFFFFFFFF;
-
-	char[] extra_data;
-	if (is_zip64)
-	{
-		cdh.compressed_size.val = 0xFFFFFFFF;
-		cdh.uncompressed_size.val = 0xFFFFFFFF;
-		cdh.relative_offset.val = 0xFFFFFFFF;
-
-		// Header(4) + Uncomp(8) + Comp(8) + Offset(8)
-		ushort extra_size = 28;
-		extra_data = alloc::alloc_array(allocator, char, extra_size);
-		bitorder::write(ZIP64_EXTRA_ID, extra_data[:2], UShortLE);
-		bitorder::write((ushort)(extra_size - 4), extra_data[2:2], UShortLE);
-		bitorder::write(entry.uncompressed_size, extra_data[4:8], LongLE);
-		bitorder::write(entry.compressed_size, extra_data[12:8], LongLE);
-		bitorder::write(entry.offset, extra_data[20:8], LongLE);
-
-		cdh.extra_field_len.val = extra_size;
-	}
-	else
-	{
-		cdh.compressed_size.val = (uint)entry.compressed_size;
-		cdh.uncompressed_size.val = (uint)entry.uncompressed_size;
-		cdh.relative_offset.val = (uint)entry.offset;
-	}
-
-	// Set external attributes (MS-DOS compatibility).
-	// 0x10 is the DOS directory attribute.
-	cdh.external_attr.val = (uint)(entry.is_directory ? 0x10 : 0);
-
-	io::write_any(f, &cdh)!;
-	f.write(entry.name)!;
-	if (is_zip64)
-	{
-		f.write(extra_data)!;
-		alloc::free(allocator, extra_data);
-	}
-
-	long entry_record_size = (long)ZipCDH::size + entry.name.len + cdh.extra_field_len.val;
-	if (*cd_size + entry_record_size <= 0) return io::OVERFLOW~;
-	*cd_size += entry_record_size;
-}
-
-fn void? _write_eocd_records(File* f, Allocator allocator, sz num_entries, long cd_size, long cd_offset, String comment) @local
-{
-	bool cd_zip64 = num_entries >= 0xFFFF || cd_size >= 0xFFFFFFFF || cd_offset >= 0xFFFFFFFF;
-
-	if (cd_zip64)
-	{
-		long eocd64_offset = f.cursor()!;
-
-		Zip64EOCD eocd64 = {
-			.signature.val = ZIP64_EOCD_SIG,
-			.size.val = (ulong)(Zip64EOCD::size - 12),
-			.version_made.val = 45,
-			.version_needed.val = 45,
-			.count_this_disk.val = num_entries,
-			.count_total.val = num_entries,
-			.size_cd.val = cd_size,
-			.offset_cd.val = cd_offset,
-		};
-
-		io::write_any(f, &eocd64)!;
-
-		Zip64Locator locator = {
-			.signature.val = ZIP64_LOCATOR_SIG,
-			.disk_start.val = 0,
-			.offset_eocd.val = eocd64_offset,
-			.total_disks.val = 1,
-		};
-
-		io::write_any(f, &locator)!;
-	}
-
-	char[] encoded_comment;
-	if (comment.len > 0)
-	{
-		char[]? res = codepage::encode(allocator, comment, CodePage.CP437);
-		if (try res)
-		{
-			encoded_comment = res;
-			if (encoded_comment.len > 0xFFFF)
-			{
-				alloc::free(allocator, encoded_comment.ptr);
-				return INVALID_ARGUMENT~;
-			}
-		}
-	}
-	defer if (encoded_comment.ptr) alloc::free(allocator, encoded_comment);
-
-	ZipEOCD eocd = {
-		.signature.val = ZIP_EOCD_SIG,
-		.num_entries_this_disk.val = (ushort)(num_entries >= 0xFFFF ? 0xFFFF : (ushort)num_entries),
-		.num_entries.val = (ushort)(num_entries >= 0xFFFF ? 0xFFFF : (ushort)num_entries),
-		.cd_size.val = (uint)(cd_size >= 0xFFFFFFFF ? 0xFFFFFFFF : (uint)cd_size),
-		.cd_offset.val = (uint)(cd_offset >= 0xFFFFFFFF ? 0xFFFFFFFF : (uint)cd_offset),
-		.comment_len.val = (ushort)encoded_comment.len,
-	};
-
-	io::write_any(f, &eocd)!;
-
-	if (encoded_comment.len > 0)
-	{
-		f.write(encoded_comment)!;
-	}
 }
 
 <*
@@ -752,89 +469,6 @@ fn void? ZipEntryReader.seek(&self, long offset, SeekOrigin seek = FROM_START) @
 	if (new_pos > self.size) new_pos = self.size;
 	self.pos = new_pos;
 	self.adapter.pos = new_pos;
-}
-
-fn void? _init_aex_reader(File* f, ZipEntry* entry, ZipLFH* lfh, String password, ZipEntryReader* reader) @local
-{
-	if (entry.method != AEX) return ENCRYPTED_FILE~;
-	if (!password.len) return PASSWORD_NEEDED~;
-
-	char aex_strength;
-	ushort aex_method;
-	ushort aex_version;
-
-	f.seek(lfh.filename_len.val, FROM_CURSOR)!;
-	long end = f.cursor()! + lfh.extra_field_len.val;
-	while (f.cursor()! < end)
-	{
-		ushort id = io::read_le_ushort(f)!;
-		ushort size = io::read_le_ushort(f)!;
-
-		if (id == AEX_EXTRA_ID)
-		{
-			aex_version = io::read_le_ushort(f)!;
-			io::read_le_ushort(f)!;
-			aex_strength = f.read_byte()!;
-			aex_method = io::read_le_ushort(f)!;
-			continue;
-		}
-		f.seek(size, FROM_CURSOR)!;
-	}
-	if (!aex_version) return CORRUPTED_DATA~;
-
-	AesType aes_type;
-	sz key_len;
-	switch (aex_strength)
-	{
-		case 1: key_len = 16; aes_type = AES128;
-		case 2: key_len = 24; aes_type = AES192;
-		case 3: key_len = 32; aes_type = AES256;
-		default: return CORRUPTED_DATA~;
-	}
-	sz salt_len = key_len / 2;
-
-	@pool()
-	{
-		char[] buf = mem::temp_array(char, salt_len + 2);
-		buf = io::read_buffer_to_end(f, buf)!;
-
-		if (buf.len < salt_len + 2) return CORRUPTED_DATA~;
-
-		char[] salt        = buf[0:salt_len];
-		char[] pv_stored   = buf[salt_len:2];
-
-		sz cipher_len = (sz)entry.compressed_size - salt_len - 2 - 10;
-		if (cipher_len < 0) return CORRUPTED_DATA~;
-
-		char[] cipher = mem::temp_array(char, cipher_len);
-		cipher = io::read_buffer_to_end(f, cipher)!;
-		if (cipher.len != cipher_len) return CORRUPTED_DATA~;
-
-		char[] hmac_stored = mem::temp_array(char, 10);
-		hmac_stored = io::read_buffer_to_end(f, hmac_stored)!;
-		if (hmac_stored.len != 10) return CORRUPTED_DATA~;
-
-		sz dk_len = key_len * 2 + 2;
-		char[] dk = mem::temp_array(char, dk_len);
-		sha1::pbkdf2(password, salt, 1000, dk);
-
-		char[] aes_key = dk[0:key_len];
-		char[] mac_key = dk[key_len:key_len];
-		char[] pv_derived = dk[key_len*2:2];
-
-		if (pv_stored != pv_derived) return PASSWORD_MISMATCH~;
-
-		char[*] hmac_calc = sha1::hmac(mac_key, cipher);
-		if (hmac_stored[:10] != hmac_calc[:10]) return CORRUPTED_DATA~;
-
-		char[16] iv = { [0] = 1 };
-		reader.adapter.aes.init(aes_type, aes_key, iv[..], CTR_LE);
-	};
-
-	reader.adapter.aex = aex_version;
-	reader.adapter.start_offset += (long)salt_len + 2;
-	reader.adapter.size = entry.compressed_size - salt_len - 2 - 10;
-	reader.method = (ZipMethod)aex_method;
 }
 
 <*
@@ -1240,4 +874,369 @@ fn bool is_valid_utf8(char[] bytes) @private
 		}
 	}
 	return true;
+}
+
+fn bool? _find_eocd(File* f, long file_size, ZipEOCD* eocd) @local
+{
+	long search_start = file_size > ZipEOCD::size + 65535LL ? file_size - (ZipEOCD::size + 65535LL) : 0;
+	for (long pos = file_size - ZipEOCD::size; pos >= search_start; pos--)
+	{
+		if (pos > sz::max) return io::OVERFLOW~;
+		f.seek(pos)!;
+		UIntLE sig;
+		if (io::read_any(f, &sig)! != 4) break;
+
+		if (sig.val == ZIP_EOCD_SIG)
+		{
+			f.seek(pos)!;
+			if (io::read_any(f, eocd)! == ZipEOCD::size)
+			{
+				long expected_end = pos + ZipEOCD::size + eocd.comment_len.val;
+				if (expected_end == file_size)
+				{
+					return true;
+				}
+			}
+		}
+		if (pos == 0) break;
+	}
+	return false;
+}
+
+fn sz? _read_zip64_cd(File* f, long file_size, sz default_entries) @local
+{
+	sz locator_pos = (sz)file_size - ZipEOCD::size - Zip64Locator::size;
+	if (locator_pos < 0) return default_entries;
+
+	f.seek(locator_pos)!;
+	Zip64Locator locator;
+	if (try n = io::read_buffer_to_end(f, ((char*)&locator)[:Zip64Locator::size]).len
+	&& n == Zip64Locator::size && locator.signature.val == ZIP64_LOCATOR_SIG)
+	{
+		if (locator.offset_eocd.val > sz::max) return io::OVERFLOW~;
+		f.seek(locator.offset_eocd.val)!;
+		Zip64EOCD eocd64;
+		io::read_any(f, &eocd64)!;
+		if (eocd64.signature.val == ZIP64_EOCD_SIG)
+		{
+			if (eocd64.offset_cd.val > sz::max) return io::OVERFLOW~;
+			f.seek(eocd64.offset_cd.val)!!;
+			return (sz)eocd64.count_total.val;
+		}
+	}
+	return default_entries;
+}
+
+fn String? _decode_filename(Allocator allocator, char[] raw_name, bool is_utf8) @local
+{
+	if (is_utf8 || is_valid_utf8(raw_name))
+	{
+		return (String)raw_name;
+	}
+	String name = (String)codepage::decode(allocator, raw_name, CP437)!!;
+	alloc::free(allocator, raw_name.ptr);
+	return name;
+}
+
+fn void? _parse_zip64_extra(char[] extra_field, ZipCDH* cdh, long* uncompressed_size, long* compressed_size, long* offset) @local
+{
+	ByteReader reader = { .bytes = extra_field };
+	while (reader.available()! >= 4)
+	{
+		ushort id = io::read_le_ushort(&reader)!;
+		ushort size = io::read_le_ushort(&reader)!;
+
+		if (id == ZIP64_EXTRA_ID)
+		{
+			int remaining = size;
+			if (cdh.uncompressed_size.val == 0xFFFFFFFF && remaining >= 8)
+			{
+				*uncompressed_size = io::read_le_long(&reader)!;
+				remaining -= 8;
+			}
+			if (cdh.compressed_size.val == 0xFFFFFFFF && remaining >= 8)
+			{
+				*compressed_size = io::read_le_long(&reader)!;
+				remaining -= 8;
+			}
+			if (cdh.relative_offset.val == 0xFFFFFFFF && remaining >= 8)
+			{
+				*offset = io::read_le_long(&reader)!;
+				remaining -= 8;
+			}
+			break;
+		}
+		reader.seek(size, FROM_CURSOR)!;
+	}
+}
+
+fn bool _is_directory_entry(String name, ushort version_made_by, uint external_attr) @local
+{
+	if (name.ends_with("/") || name.ends_with("\\")) return true;
+	ushort host_system = version_made_by >> 8;
+	if (host_system == 0 || host_system == 10) // MS-DOS or NTFS
+	{
+		if ((external_attr & 0x10) != 0) return true;
+	}
+	else if (host_system == 3) // Unix
+	{
+		if (((external_attr >> 16) & 0x4000) != 0) return true;
+	}
+	return false;
+}
+
+fn bool? _parse_zip_cd_entry(File* f, Allocator allocator, ZipEntry* entry) @local
+{
+	ZipCDH cdh;
+	if (io::read_any(f, &cdh)! != ZipCDH::size) return false;
+	if (cdh.signature.val != ZIP_CDH_SIG) return false;
+
+	char[] raw_name = alloc::alloc_array(allocator, char, cdh.filename_len.val);
+	defer catch alloc::free(allocator, raw_name);
+	if (raw_name.len && io::read_buffer(f, raw_name)! != (sz)cdh.filename_len.val)
+	{
+		alloc::free(allocator, raw_name);
+		return false;
+	}
+
+	String name = _decode_filename(allocator, raw_name, (cdh.flags.val & 0x0800) != 0)!;
+	raw_name = {};
+	defer catch alloc::free(allocator, name);
+
+	char[] extra_field;
+	if (cdh.extra_field_len.val > 0)
+	{
+		extra_field = alloc::alloc_array(allocator, char, cdh.extra_field_len.val);
+		defer catch alloc::free(allocator, extra_field);
+		io::read_all(f, extra_field)!;
+	}
+	defer alloc::free(allocator, extra_field);
+
+	f.seek(cdh.comment_len.val, FROM_CURSOR)!;
+
+	long uncompressed_size = cdh.uncompressed_size.val;
+	long compressed_size = cdh.compressed_size.val;
+	long offset = cdh.relative_offset.val;
+
+	if (cdh.uncompressed_size.val == 0xFFFFFFFF || cdh.compressed_size.val == 0xFFFFFFFF || cdh.relative_offset.val == 0xFFFFFFFF)
+	{
+		_parse_zip64_extra(extra_field, &cdh, &uncompressed_size, &compressed_size, &offset)!;
+	}
+
+	*entry = {
+		.name = name,
+		.uncompressed_size = uncompressed_size,
+		.compressed_size = compressed_size,
+		.crc32 = cdh.crc32.val,
+		.offset = offset,
+		.method = cdh.method,
+		.last_mod_time = cdh.last_mod_time.val,
+		.last_mod_date = cdh.last_mod_date.val,
+		.is_directory = _is_directory_entry(name, cdh.version_made_by.val, cdh.external_attr.val),
+		.is_encrypted = (cdh.flags.val & 1) != 0
+	};
+	return true;
+}
+
+fn void? _write_cd_entry(File* f, Allocator allocator, ZipEntry* entry, long* cd_size) @local
+{
+	ZipCDH cdh = {
+		.signature.val = ZIP_CDH_SIG,
+		.version_made_by.val = 45, // 4.5 for ZIP64
+		.version_needed.val = 45,
+		.method = entry.method,
+		.last_mod_time.val = entry.last_mod_time,
+		.last_mod_date.val = entry.last_mod_date,
+		.crc32.val = entry.crc32,
+		.filename_len.val = (ushort)entry.name.len,
+	};
+
+	bool is_zip64 = entry.uncompressed_size >= 0xFFFFFFFF || entry.compressed_size >= 0xFFFFFFFF || entry.offset >= 0xFFFFFFFF;
+
+	char[] extra_data;
+	if (is_zip64)
+	{
+		cdh.compressed_size.val = 0xFFFFFFFF;
+		cdh.uncompressed_size.val = 0xFFFFFFFF;
+		cdh.relative_offset.val = 0xFFFFFFFF;
+
+		// Header(4) + Uncomp(8) + Comp(8) + Offset(8)
+		ushort extra_size = 28;
+		extra_data = alloc::alloc_array(allocator, char, extra_size);
+		bitorder::write(ZIP64_EXTRA_ID, extra_data[:2], UShortLE);
+		bitorder::write((ushort)(extra_size - 4), extra_data[2:2], UShortLE);
+		bitorder::write(entry.uncompressed_size, extra_data[4:8], LongLE);
+		bitorder::write(entry.compressed_size, extra_data[12:8], LongLE);
+		bitorder::write(entry.offset, extra_data[20:8], LongLE);
+
+		cdh.extra_field_len.val = extra_size;
+	}
+	else
+	{
+		cdh.compressed_size.val = (uint)entry.compressed_size;
+		cdh.uncompressed_size.val = (uint)entry.uncompressed_size;
+		cdh.relative_offset.val = (uint)entry.offset;
+	}
+
+	// Set external attributes (MS-DOS compatibility).
+	// 0x10 is the DOS directory attribute.
+	cdh.external_attr.val = (uint)(entry.is_directory ? 0x10 : 0);
+
+	io::write_any(f, &cdh)!;
+	f.write(entry.name)!;
+	if (is_zip64)
+	{
+		f.write(extra_data)!;
+		alloc::free(allocator, extra_data);
+	}
+
+	long entry_record_size = (long)ZipCDH::size + entry.name.len + cdh.extra_field_len.val;
+	if (*cd_size + entry_record_size <= 0) return io::OVERFLOW~;
+	*cd_size += entry_record_size;
+}
+
+fn void? _write_eocd_records(File* f, Allocator allocator, sz num_entries, long cd_size, long cd_offset, String comment) @local
+{
+	bool cd_zip64 = num_entries >= 0xFFFF || cd_size >= 0xFFFFFFFF || cd_offset >= 0xFFFFFFFF;
+
+	if (cd_zip64)
+	{
+		long eocd64_offset = f.cursor()!;
+
+		Zip64EOCD eocd64 = {
+			.signature.val = ZIP64_EOCD_SIG,
+			.size.val = (ulong)(Zip64EOCD::size - 12),
+			.version_made.val = 45,
+			.version_needed.val = 45,
+			.count_this_disk.val = num_entries,
+			.count_total.val = num_entries,
+			.size_cd.val = cd_size,
+			.offset_cd.val = cd_offset,
+		};
+
+		io::write_any(f, &eocd64)!;
+
+		Zip64Locator locator = {
+			.signature.val = ZIP64_LOCATOR_SIG,
+			.disk_start.val = 0,
+			.offset_eocd.val = eocd64_offset,
+			.total_disks.val = 1,
+		};
+
+		io::write_any(f, &locator)!;
+	}
+
+	char[] encoded_comment;
+	if (comment.len > 0)
+	{
+		char[]? res = codepage::encode(allocator, comment, CodePage.CP437);
+		if (try res)
+		{
+			encoded_comment = res;
+			if (encoded_comment.len > 0xFFFF)
+			{
+				alloc::free(allocator, encoded_comment.ptr);
+				return INVALID_ARGUMENT~;
+			}
+		}
+	}
+	defer if (encoded_comment.ptr) alloc::free(allocator, encoded_comment);
+
+	ZipEOCD eocd = {
+		.signature.val = ZIP_EOCD_SIG,
+		.num_entries_this_disk.val = (ushort)(num_entries >= 0xFFFF ? 0xFFFF : (ushort)num_entries),
+		.num_entries.val = (ushort)(num_entries >= 0xFFFF ? 0xFFFF : (ushort)num_entries),
+		.cd_size.val = (uint)(cd_size >= 0xFFFFFFFF ? 0xFFFFFFFF : (uint)cd_size),
+		.cd_offset.val = (uint)(cd_offset >= 0xFFFFFFFF ? 0xFFFFFFFF : (uint)cd_offset),
+		.comment_len.val = (ushort)encoded_comment.len,
+	};
+
+	io::write_any(f, &eocd)!;
+
+	if (encoded_comment.len > 0)
+	{
+		f.write(encoded_comment)!;
+	}
+}
+fn void? _init_aex_reader(File* f, ZipEntry* entry, ZipLFH* lfh, String password, ZipEntryReader* reader) @local
+{
+	if (entry.method != AEX) return ENCRYPTED_FILE~;
+	if (!password.len) return PASSWORD_NEEDED~;
+
+	char aex_strength;
+	ushort aex_method;
+	ushort aex_version;
+
+	f.seek(lfh.filename_len.val, FROM_CURSOR)!;
+	long end = f.cursor()! + lfh.extra_field_len.val;
+	while (f.cursor()! < end)
+	{
+		ushort id = io::read_le_ushort(f)!;
+		ushort size = io::read_le_ushort(f)!;
+
+		if (id == AEX_EXTRA_ID)
+		{
+			aex_version = io::read_le_ushort(f)!;
+			io::read_le_ushort(f)!;
+			aex_strength = f.read_byte()!;
+			aex_method = io::read_le_ushort(f)!;
+			continue;
+		}
+		f.seek(size, FROM_CURSOR)!;
+	}
+	if (!aex_version) return CORRUPTED_DATA~;
+
+	AesType aes_type;
+	sz key_len;
+	switch (aex_strength)
+	{
+		case 1: key_len = 16; aes_type = AES128;
+		case 2: key_len = 24; aes_type = AES192;
+		case 3: key_len = 32; aes_type = AES256;
+		default: return CORRUPTED_DATA~;
+	}
+	sz salt_len = key_len / 2;
+
+	@pool()
+	{
+		char[] buf = mem::temp_array(char, salt_len + 2);
+		buf = io::read_buffer_to_end(f, buf)!;
+
+		if (buf.len < salt_len + 2) return CORRUPTED_DATA~;
+
+		char[] salt        = buf[0:salt_len];
+		char[] pv_stored   = buf[salt_len:2];
+
+		sz cipher_len = (sz)entry.compressed_size - salt_len - 2 - 10;
+		if (cipher_len < 0) return CORRUPTED_DATA~;
+
+		char[] cipher = mem::temp_array(char, cipher_len);
+		cipher = io::read_buffer_to_end(f, cipher)!;
+		if (cipher.len != cipher_len) return CORRUPTED_DATA~;
+
+		char[] hmac_stored = mem::temp_array(char, 10);
+		hmac_stored = io::read_buffer_to_end(f, hmac_stored)!;
+		if (hmac_stored.len != 10) return CORRUPTED_DATA~;
+
+		sz dk_len = key_len * 2 + 2;
+		char[] dk = mem::temp_array(char, dk_len);
+		sha1::pbkdf2(password, salt, 1000, dk);
+
+		char[] aes_key = dk[0:key_len];
+		char[] mac_key = dk[key_len:key_len];
+		char[] pv_derived = dk[key_len*2:2];
+
+		if (pv_stored != pv_derived) return PASSWORD_MISMATCH~;
+
+		char[*] hmac_calc = sha1::hmac(mac_key, cipher);
+		if (hmac_stored[:10] != hmac_calc[:10]) return CORRUPTED_DATA~;
+
+		char[16] iv = { [0] = 1 };
+		reader.adapter.aes.init(aes_type, aes_key, iv[..], CTR_LE);
+	};
+
+	reader.adapter.aex = aex_version;
+	reader.adapter.start_offset += (long)salt_len + 2;
+	reader.adapter.size = entry.compressed_size - salt_len - 2 - 10;
+	reader.method = (ZipMethod)aex_method;
 }

--- a/lib/std/hash/blake3.c3
+++ b/lib/std/hash/blake3.c3
@@ -455,7 +455,7 @@ fn void Blake3ChunkState.update(&self, char[] input)
 		input = input[take..];
 		if (input.len)
 		{
-			compress_in_place(self.cv[..], self.buf[..], BLOCK_SIZE, self.chunk_counter, self.flags | self.maybe_start_flag());
+			compress_in_place(&self.cv, &self.buf, BLOCK_SIZE, self.chunk_counter, self.flags | self.maybe_start_flag());
 			self.blocks_compressed++;
 			self.buf_len = 0;
 			self.buf[..] = {};
@@ -463,7 +463,7 @@ fn void Blake3ChunkState.update(&self, char[] input)
 	}
 	for (; input.len > BLOCK_SIZE; self.blocks_compressed++, input = input[BLOCK_SIZE..])
 	{
-		compress_in_place(self.cv[..], input[:BLOCK_SIZE], BLOCK_SIZE, self.chunk_counter, self.flags | self.maybe_start_flag());
+		compress_in_place(&self.cv, input.ptr, BLOCK_SIZE, self.chunk_counter, self.flags | self.maybe_start_flag());
 	}
 	self.fill_buf(input);
 }
@@ -513,7 +513,7 @@ macro void Blake3Output.chaining_value(&self, char* cv)
 {
 	uint[KEY_SIZE_WORDS] cv_words;
 	cv_words[..] = self.input_cv[..];
-	compress_in_place(cv_words[..], self.block, self.block_len, self.counter, self.flags);
+	compress_in_place(&cv_words, &self.block, self.block_len, self.counter, self.flags);
 	cv[:KEY_SIZE] = @as_char_view(cv_words)[:KEY_SIZE];
 }
 
@@ -533,7 +533,7 @@ fn void Blake3Output.root_bytes(&self, sz seek, char[] into)
 
 	if (offset_within_block)
 	{
-		compress_xof(self.input_cv[..], self.block, self.block_len, output_block_counter, self.flags | Blake3Flags.ROOT, wide_buf[..]);
+		compress_xof(&self.input_cv, &self.block, self.block_len, output_block_counter, self.flags | Blake3Flags.ROOT, &wide_buf);
 		long avail = BLOCK_SIZE - offset_within_block;
 		sz bytes = (sz)min((long)into.len, avail);
 		into[:bytes] = wide_buf[offset_within_block:bytes];
@@ -542,13 +542,13 @@ fn void Blake3Output.root_bytes(&self, sz seek, char[] into)
 	}
 	if (into.len / BLOCK_SIZE)
 	{
-		@xof_many(self.input_cv[..], self.block, self.block_len, output_block_counter, self.flags | Blake3Flags.ROOT, into, into.len / BLOCK_SIZE);
+		@xof_many(&self.input_cv, &self.block, self.block_len, output_block_counter, self.flags | Blake3Flags.ROOT, into, into.len / BLOCK_SIZE);
 	}
 	output_block_counter += into.len / 64;
 	into = into[(sz)(into.len & -64ll) ..];
 	if (into.len)
 	{
-		compress_xof(self.input_cv[..], self.block, self.block_len, output_block_counter, self.flags | Blake3Flags.ROOT, wide_buf[..]);
+		compress_xof(&self.input_cv, &self.block, self.block_len, output_block_counter, self.flags | Blake3Flags.ROOT, &wide_buf);
 		into[..] = wide_buf[:into.len];
 	}
 }
@@ -584,7 +584,7 @@ macro @g(#state, a, b, c, d, x, y) @local
 	#state[b] = (#state[b] ^ #state[c]).rotr(7);
 }
 
-macro @round(uint[] state, uint* msg, sz round) @local
+macro @round(uint* state, uint* msg, sz round) @local
 {
 	char* schedule = &MESSAGE_SCHEDULE[round];
 	@g(state, 0, 4,  8, 12, msg[schedule[0] ], msg[schedule[1] ]);
@@ -597,12 +597,12 @@ macro @round(uint[] state, uint* msg, sz round) @local
 	@g(state, 3, 4,  9, 14, msg[schedule[14]], msg[schedule[15]]);
 }
 
-fn void compress_pre(uint[] state, uint[] cv, char[BLOCK_SIZE] block, sz block_len, long counter, char flags) @local @noinline
+fn void compress_pre(uint* state, uint* cv, char* block, sz block_len, long counter, char flags) @local @noinline
 {
 	uint[16] block_words @noinit;
 	foreach (i, &b : block_words) *b = mem::load((uint*)&block[i * 4], 1);
-	state[0:8] = cv[0:8];
-	state[8:4] = IV[0:4];
+	mem::copy(state, cv, 8 * uint::size);
+	mem::copy(&state[8], &IV, 4 * uint::size);
 	state[12] = (uint)counter;
 	state[13] = (uint)((ulong)counter >> 32);
 	state[14] = (uint)block_len;
@@ -610,28 +610,28 @@ fn void compress_pre(uint[] state, uint[] cv, char[BLOCK_SIZE] block, sz block_l
 
 	for (int i = 0; i < 7; i++)
 	{
-		@round(state, &block_words[0], (sz)i);
+		@round(state, &block_words, (sz)i);
 	}
 }
 
-macro compress_in_place(uint[] cv, char[BLOCK_SIZE] block, sz block_len, long counter, char flags) @local
+fn void compress_in_place(uint* cv, char* block, sz block_len, long counter, char flags) @local @noinline
 {
 	uint[16] state @noinit;
-	compress_pre(state[..], cv, block, block_len, counter, flags);
+	compress_pre(&state, cv, block, block_len, counter, flags);
 	for (sz i = 0; i < 8; i++) cv[i] = state[i] ^ state[i + 8];
 }
 
-macro compress_xof(uint[] cv, char[BLOCK_SIZE] block, sz block_len, long counter, char flags, char[] out) @local
+fn void compress_xof(uint* cv, char* block, sz block_len, long counter, char flags, char* out) @local @noinline
 {
 	uint[16] state @noinit;
-	compress_pre(state[..], cv, block, block_len, counter, flags);
-	$for sz $i = 0; $i < 8; $i++: mem::store((uint*)&out[4 * $i], state[$i] ^ state[$i + 8], 1); $endfor
-	$for sz $i = 0; $i < 8; $i++: mem::store((uint*)&out[4 * (8 + $i)], state[$i + 8] ^ cv[$i], 1); $endfor
+	compress_pre(&state, cv, block, block_len, counter, flags);
+	for (sz i = 0; i < 8; i++) mem::store((uint*)&out[4 * i], state[i] ^ state[i + 8], 1);
+	for (sz i = 0; i < 8; i++) mem::store((uint*)&out[4 * (8 + i)], state[i + 8] ^ cv[i], 1);
 }
 
-macro @xof_many(uint[] cv, char[BLOCK_SIZE] block, sz block_len, long counter, char flags, char[] out, sz out_blocks) @local
+macro @xof_many(uint* cv, char* block, sz block_len, long counter, char flags, char[] out, sz out_blocks) @local
 {
-	for (sz i = 0; i < out_blocks; i++, out = out[BLOCK_SIZE..]) compress_xof(cv, block, block_len, counter + i, flags, out);
+	for (sz i = 0; i < out_blocks; i++, out = out[BLOCK_SIZE..]) compress_xof(cv, block, block_len, counter + i, flags, out.ptr);
 }
 
 macro hash_one(char* input, sz blocks, uint[] key, long counter, char flags, char flags_start, char flags_end, char[] out) @local
@@ -642,7 +642,7 @@ macro hash_one(char* input, sz blocks, uint[] key, long counter, char flags, cha
 	for (; blocks > 0; input += BLOCK_SIZE, blocks--, block_flags = flags)
 	{
 		if (blocks == 1) block_flags |= flags_end;
-		compress_in_place(cv[..], input[:BLOCK_SIZE], BLOCK_SIZE, counter, block_flags);
+		compress_in_place(&cv, input, BLOCK_SIZE, counter, block_flags);
 	}
 	foreach (i, c : cv) mem::store((uint*)&out[i * 4], c, 1);
 }

--- a/lib/std/hash/blake3.c3
+++ b/lib/std/hash/blake3.c3
@@ -483,7 +483,7 @@ fn Blake3Output Blake3ChunkState.output(&self) @inline
  @param counter
  @param flags
 *>
-fn Blake3Output make_output(uint[] key, char* in_block, sz block_len, long counter, char flags) @local @noinline
+fn Blake3Output make_output(uint[] key, char* in_block, sz block_len, long counter, char flags) @local
 {
 	Blake3Output o;
 	o.input_cv[..] = key[..];
@@ -597,7 +597,7 @@ macro @round(uint* state, uint* msg, sz round) @local
 	@g(state, 3, 4,  9, 14, msg[schedule[14]], msg[schedule[15]]);
 }
 
-fn void compress_pre(uint* state, uint* cv, char* block, sz block_len, long counter, char flags) @local @noinline
+fn void compress_pre(uint* state, uint* cv, char* block, sz block_len, long counter, char flags) @local
 {
 	uint[16] block_words @noinit;
 	foreach (i, &b : block_words) *b = mem::load((uint*)&block[i * 4], 1);
@@ -614,14 +614,14 @@ fn void compress_pre(uint* state, uint* cv, char* block, sz block_len, long coun
 	}
 }
 
-fn void compress_in_place(uint* cv, char* block, sz block_len, long counter, char flags) @local @noinline
+fn void compress_in_place(uint* cv, char* block, sz block_len, long counter, char flags) @local
 {
 	uint[16] state @noinit;
 	compress_pre(&state, cv, block, block_len, counter, flags);
 	for (sz i = 0; i < 8; i++) cv[i] = state[i] ^ state[i + 8];
 }
 
-fn void compress_xof(uint* cv, char* block, sz block_len, long counter, char flags, char* out) @local @noinline
+fn void compress_xof(uint* cv, char* block, sz block_len, long counter, char flags, char* out) @local
 {
 	uint[16] state @noinit;
 	compress_pre(&state, cv, block, block_len, counter, flags);
@@ -657,7 +657,7 @@ macro hash_many(char*[] inputs, sz num_inputs, sz blocks, uint[] key, long count
 }
 
 
-fn void compress_subtree_to_parent_node(char[] input, uint[] key, long chunk_counter, char flags, char[] out, bool use_tbb) @local @noinline
+fn void compress_subtree_to_parent_node(char[] input, uint[] key, long chunk_counter, char flags, char[] out, bool use_tbb) @local
 {
 	char[MAX_SIMD_DEGREE_OR_2 * OUT_SIZE] cv_array;
 
@@ -672,7 +672,7 @@ fn void compress_subtree_to_parent_node(char[] input, uint[] key, long chunk_cou
 	out[..] = cv_array[:2 * OUT_SIZE];
 }
 
-fn sz compress_subtree_wide(char[] input, uint[] key, long chunk_counter, char flags, char* out, bool use_tbb) @local @noinline
+fn sz compress_subtree_wide(char[] input, uint[] key, long chunk_counter, char flags, char* out, bool use_tbb) @local
 {
 	if (input.len <= (sz)@simd_degree() * CHUNK_SIZE) return compress_chunks_parallel(input, key, chunk_counter, flags, out);
 
@@ -698,7 +698,7 @@ fn sz compress_subtree_wide(char[] input, uint[] key, long chunk_counter, char f
 	return compress_parents_parallel(cv_array[..], left_n + right_n, key, flags, out);
 }
 
-fn sz compress_parents_parallel(char[] child_chaining_values, sz num_chaining_values, uint[] key, char flags, char* out) @local @noinline
+fn sz compress_parents_parallel(char[] child_chaining_values, sz num_chaining_values, uint[] key, char flags, char* out) @local
 {
 	char*[MAX_SIMD_DEGREE_OR_2] parents_array;
 	sz parents_array_len = 0;
@@ -719,7 +719,7 @@ fn sz compress_parents_parallel(char[] child_chaining_values, sz num_chaining_va
 	return parents_array_len;
 }
 
-fn sz compress_chunks_parallel(char[] input, uint[] key, long chunk_counter, char flags, char* out) @local @noinline
+fn sz compress_chunks_parallel(char[] input, uint[] key, long chunk_counter, char flags, char* out) @local
 {
 	char*[MAX_SIMD_DEGREE] chunks_array;
 	sz input_position = 0;

--- a/lib/std/hash/gost/streebog.c3
+++ b/lib/std/hash/gost/streebog.c3
@@ -69,13 +69,13 @@ macro @lpsx(#a, #b, #result) @local
 	}
 }
 
-macro @g_n(#n, #h, #m) @local
+fn void _g_n(ulong* n, ulong* h, ulong* m) @local @noinline
 {
 	ulong[8] k_i;
 	ulong[8] state;
 
-	@lpsx(#h, #n, k_i);
-	@lpsx(k_i, #m, state);
+	@lpsx(n, h, k_i);
+	@lpsx(k_i, m, state);
 	// Do not unroll this loop - produces far too much code at compile-time.
 	for (sz i = 0; i < 11; i++)
 	{
@@ -84,16 +84,15 @@ macro @g_n(#n, #h, #m) @local
 	}
 	@lpsx(k_i, ITERATION_CONSTANTS[11], k_i);
 	@xor_512(k_i, state, state);
-	@xor_512(state, #h, state);
-	@xor_512(state, #m, #h);
+	@xor_512(state, h, state);
+	@xor_512(state, m, h);
 }
 
-
-macro @_streebog_stage2(Streebog* self, #m) @local
+fn void _streebog_stage2(Streebog* self, ulong* m) @local @noinline
 {
-	@g_n(self.n, self.h, #m);
+	_g_n(&self.n, &self.h, m);
 	@add_512(self.n, STAGE2_512);
-	@add_512(self.s, #m);
+	@add_512(self.s, m);
 }
 
 macro void Streebog.init(&self, StreebogLength $hash_size)
@@ -117,7 +116,7 @@ fn void Streebog.update(&self, char[] data)
 		self.index += size;
 		if (size < rest) return;
 
-		@_streebog_stage2(self, self.message);
+		_streebog_stage2(self, &self.message);
 		data = data[rest..];
 		self.index = 0;
 	}
@@ -126,12 +125,12 @@ fn void Streebog.update(&self, char[] data)
 	{
 		if (aligned)
 		{
-			@_streebog_stage2(self, (ulong*)data.ptr);
+			_streebog_stage2(self, (ulong*)data.ptr);
 		}
 		else
 		{
 			@as_char_view(self.message)[:BLOCK_SIZE] = data[:BLOCK_SIZE];
-			@_streebog_stage2(self, self.message);
+			_streebog_stage2(self, &self.message);
 		}
 	}
 	if (data.len)
@@ -164,9 +163,9 @@ fn void streebog_final_private(Streebog* self) @local
 	self.message[index++] ^= 1ul << shift;
 	if (index < 8) self.message[index..] = {};
 
-	@g_n(self.n, self.h, self.message);
+	_g_n(&self.n, &self.h, &self.message);
 	@add_512(self.n, unprocessed_bits_count);
 	@add_512(self.s, self.message);
-	@g_n(ZERO_512, self.h, self.n);
-	@g_n(ZERO_512, self.h, self.s);
+	_g_n(&ZERO_512, &self.h, &self.n);
+	_g_n(&ZERO_512, &self.h, &self.s);
 }

--- a/lib/std/hash/gost/streebog.c3
+++ b/lib/std/hash/gost/streebog.c3
@@ -69,32 +69,6 @@ macro @lpsx(#a, #b, #result) @local
 	}
 }
 
-fn void _g_n(ulong* n, ulong* h, ulong* m) @local @noinline
-{
-	ulong[8] k_i;
-	ulong[8] state;
-
-	@lpsx(n, h, k_i);
-	@lpsx(k_i, m, state);
-	// Do not unroll this loop - produces far too much code at compile-time.
-	for (sz i = 0; i < 11; i++)
-	{
-		@lpsx(k_i, ITERATION_CONSTANTS[i], k_i);
-		@lpsx(k_i, state, state);
-	}
-	@lpsx(k_i, ITERATION_CONSTANTS[11], k_i);
-	@xor_512(k_i, state, state);
-	@xor_512(state, h, state);
-	@xor_512(state, m, h);
-}
-
-fn void _streebog_stage2(Streebog* self, ulong* m) @local @noinline
-{
-	_g_n(&self.n, &self.h, m);
-	@add_512(self.n, STAGE2_512);
-	@add_512(self.s, m);
-}
-
 macro void Streebog.init(&self, StreebogLength $hash_size)
 {
 	mem::zero_volatile(@as_char_view(*self)); // explicitly initialize the entire state to 0
@@ -146,13 +120,13 @@ fn void Streebog.update(&self, char[] data)
 macro char[*] Streebog.final(&self, StreebogLength $hash_size)
 {
 	char[$hash_size] result;
-	streebog_final_private(self);
+	_streebog_final_private(self);
 	defer mem::zero_volatile(@as_char_view(*self)); // implicitly clear the structure when finalized
 	result[..] = @as_char_view(self.h)[(BLOCK_SIZE - $hash_size)..];
 	return result;
 }
 
-fn void streebog_final_private(Streebog* self) @local
+fn void _streebog_final_private(Streebog* self) @local
 {
 	ulong[8] unprocessed_bits_count;
 	sz index = self.index >> 3;
@@ -168,4 +142,30 @@ fn void streebog_final_private(Streebog* self) @local
 	@add_512(self.s, self.message);
 	_g_n(&ZERO_512, &self.h, &self.n);
 	_g_n(&ZERO_512, &self.h, &self.s);
+}
+
+fn void _g_n(ulong* n, ulong* h, ulong* m) @local
+{
+	ulong[8] k_i;
+	ulong[8] state;
+
+	@lpsx(n, h, k_i);
+	@lpsx(k_i, m, state);
+	// Do not unroll this loop - produces far too much code at compile-time.
+	for (sz i = 0; i < 11; i++)
+	{
+		@lpsx(k_i, ITERATION_CONSTANTS[i], k_i);
+		@lpsx(k_i, state, state);
+	}
+	@lpsx(k_i, ITERATION_CONSTANTS[11], k_i);
+	@xor_512(k_i, state, state);
+	@xor_512(state, h, state);
+	@xor_512(state, m, h);
+}
+
+fn void _streebog_stage2(Streebog* self, ulong* m) @local
+{
+	_g_n(&self.n, &self.h, m);
+	@add_512(self.n, STAGE2_512);
+	@add_512(self.s, m);
 }

--- a/lib/std/hash/sha256.c3
+++ b/lib/std/hash/sha256.c3
@@ -73,13 +73,10 @@ fn void Sha256.update(&self, char[] data)
 
 	// When the data pointer is aligned, we can disregard unaligned loading in the `transform` macro.
 	//   We do this here from the outer call to reduce the expense of checking alignment on every single block.
-	if (0 == (sz)data.ptr % sz::size)
+	bool aligned = ((sz)data.ptr % sz::size) == 0;
+	for (; data.len >= BLOCK_SIZE; data = data[BLOCK_SIZE..])
 	{
-		for (; data.len >= BLOCK_SIZE; data = data[BLOCK_SIZE..]) _transform(self, (uint*)data.ptr);
-	}
-	else
-	{
-		for (; data.len >= BLOCK_SIZE; data = data[BLOCK_SIZE..]) _transform_unaligned(self, (uint*)data.ptr);
+		_transform(self, (uint*)data.ptr, aligned);
 	}
 
 	// Leftover data just gets stored away for the next update or final.
@@ -119,12 +116,8 @@ fn char[HASH_SIZE] Sha256.final(&self)
 	return hash;
 }
 
-// These wrappers are necessary to significantly reduce code generation from macro expansions.
-//   Note that transformations on `self.buffer` (when incoming == null) should always be aligned.
-fn void _transform(Sha256* self, uint* incoming = null) @local @noinline => _do_transform(self, incoming, true);
-fn void _transform_unaligned(Sha256* self, uint* incoming = null) @local @noinline => _do_transform(self, incoming, false);
-
-macro _do_transform(Sha256* self, uint* incoming = null, bool $aligned = true) @local
+// Transformations on `self.buffer` (when incoming == null) are always aligned due to `@align(ulong::size)`.
+fn void _transform(Sha256* self, uint* incoming = null, bool aligned = true) @local @noinline
 {
 	uint a, b, c, d, e, f, g, h, t1, t2 @noinit;
 	uint[64] m @noinit;
@@ -135,8 +128,14 @@ macro _do_transform(Sha256* self, uint* incoming = null, bool $aligned = true) @
 	$if env::BIG_ENDIAN:
 		@as_char_view(m)[:BLOCK_SIZE] = @as_char_view(incoming)[:BLOCK_SIZE];
 	$else
-		// Unrolling this seems to make the hash slower.
-		for (i = 0; i < 16; ++i) m[i] = bswap($aligned ??? incoming[i] : mem::load(&incoming[i], 1));
+		if (aligned)
+		{
+			for (i = 0; i < 16; ++i) m[i] = bswap(incoming[i]);
+		}
+		else
+		{
+			for (i = 0; i < 16; ++i) m[i] = bswap(mem::load(&incoming[i], 1));
+		}
 	$endif
 
 	for (i = 16; i < 64; i++) m[i] = @sigma1(m[i - 2]) + m[i - 7] + @sigma0(m[i - 15]) + m[i - 16];

--- a/lib/std/hash/sha256.c3
+++ b/lib/std/hash/sha256.c3
@@ -117,7 +117,7 @@ fn char[HASH_SIZE] Sha256.final(&self)
 }
 
 // Transformations on `self.buffer` (when incoming == null) are always aligned due to `@align(ulong::size)`.
-fn void _transform(Sha256* self, uint* incoming = null, bool aligned = true) @local @noinline
+fn void _transform(Sha256* self, uint* incoming = null, bool aligned = true) @local
 {
 	uint a, b, c, d, e, f, g, h, t1, t2 @noinit;
 	uint[64] m @noinit;


### PR DESCRIPTION
- Replaces repetitive macro expansions in Streebog and BLAKE3 with shared `@noinline` functions and pointer passing.
- Unifies aligned/unaligned SHA-256 transform paths to avoid duplicate 64-round bodies.
- Breaks up monolithic ZIP (`open`, `close`, `open_reader`) and Deflate (`emit_block`, `pkg_merge`) functions into private helpers.

Reduces frontend IR instruction counts without affecting runtime performance or behavior.

<img width="2980" height="1180" alt="instruction_reduction_results" src="https://github.com/user-attachments/assets/84c61dbd-244c-465f-9f96-6759fb6fbd7c" />

