### PR TITLE
fix: duplicate libminiz.a and section alignment warnings from apple ld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
     cmake_policy(SET CMP0135 NEW)
 endif()
 
+if (POLICY CMP0156)
+    cmake_policy(SET CMP0156 NEW)
+endif()
+
 if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
     if (WIN32)
         set(CMAKE_INSTALL_LIBDIR "c:\\c3c\\lib")

--- a/src/utils/unzipper.c
+++ b/src/utils/unzipper.c
@@ -8,8 +8,8 @@
 #define ZIP_BUFFER_SIZE 65536
 #define FILE_OUTBUF_LEN 65536
 
-uint8_t internal_buffer[ZIP_BUFFER_SIZE]; // limits maximum zip descriptor size
-uint8_t file_out_buffer[FILE_OUTBUF_LEN];
+static uint8_t internal_buffer[ZIP_BUFFER_SIZE]; // limits maximum zip descriptor size
+static uint8_t file_out_buffer[FILE_OUTBUF_LEN];
 
 typedef PACK(struct
 {
@@ -356,4 +356,3 @@ const char *zip_file_write(FILE *zip, ZipFile *file, const char *dir, bool overw
 	inflateEnd(&strm);
 	return NULL;
 }
-


### PR DESCRIPTION
- https://github.com/c3lang/c3c/actions/runs/33393830188/job/99493513692?pr=3479#step:6:197
- https://github.com/c3lang/c3c/actions/runs/33393830188/job/99493513692?pr=3479#step:6:198