### PR TITLE
Use tree merge for single-module LLVM linking

### DIFF
--- a/scripts/tools/ci_tests.sh
+++ b/scripts/tools/ci_tests.sh
@@ -102,6 +102,7 @@ run_examples() {
     run_c3c compile examples/hash.c3
     run_c3c compile examples/http_server.c3
     run_c3c compile-only examples/levenshtein.c3
+    run_c3c compile-only --single-module=yes examples/levenshtein.c3 # --single-module test
     run_c3c compile examples/load_world.c3
     run_c3c compile-only examples/map.c3
     run_c3c compile examples/mandelbrot.c3

--- a/src/compiler/llvm_codegen.c
+++ b/src/compiler/llvm_codegen.c
@@ -1692,11 +1692,25 @@ void **llvm_gen(Module** modules, int module_count)
 			vec_add(gen_contexts, llvm_gen_tests(modules, module_count, context));
 		}
 		int count = vec_size(gen_contexts);
-		for (int i = 1; i < count; i++)
+		while (count > 1)
 		{
-			GenContext *other = gen_contexts[i];
-			LLVMLinkModules2(first->module, other->module);
-			gencontext_destroy(other);
+			int new_count = 0;
+			for (int i = 0; i < count; i += 2)
+			{
+				if (i + 1 < count)
+				{
+					GenContext *dst = gen_contexts[i];
+					GenContext *src = gen_contexts[i + 1];
+					LLVMLinkModules2(dst->module, src->module);
+					gencontext_destroy(src);
+					gen_contexts[new_count++] = dst;
+				}
+				else
+				{
+					gen_contexts[new_count++] = gen_contexts[i];
+				}
+			}
+			count = new_count;
 		}
 		vec_resize(gen_contexts, 1);
 		return (void**)gen_contexts;


### PR DESCRIPTION
Instead of merging every module one-by-one into the first one (which gets slower and slower as it grows), merge them in pairs across multiple passes.

+20% on single-module -O0