### PR TITLE
fix: drop support of unused Win32_WIN32_FIND_DATAW fields

### DIFF
--- a/lib/std/os/win32/files.c3
+++ b/lib/std/os/win32/files.c3
@@ -29,14 +29,8 @@ struct Win32_WIN32_FIND_DATAW
 	Win32_DWORD         nFileSizeLow;
 	Win32_DWORD         dwReserved0;
 	Win32_DWORD         dwReserved1;
-	Win32_WCHAR[260]    cFileName;
+	Win32_WCHAR[MAX_PATH] cFileName;
 	Win32_WCHAR[14]     cAlternateFileName;
-	<* Obsolete. Do not use. *>
-	Win32_DWORD         dwFileType;
-	<* Obsolete. Do not use *>
-	Win32_DWORD         dwCreatorType;
-	<* Obsolete. Do not use *>
-	Win32_WORD          wFinderFlags;
 }
 
 alias Win32_LPWIN32_FIND_DATAW = Win32_WIN32_FIND_DATAW*;


### PR DESCRIPTION
The `dwFileType`, `dwCreatorType` and `wFinderFlags` fields only existed behind `#ifdef _MAC`, and current Windows SDKs do not declare them at all. Including them made this struct 604 bytes: harmless when only a pointer is passed to `FindFirstFileW`, but wrong for anything that embeds it or measures it.

10.0.26100.0/um/minwinbase.h:

```c
typedef struct _WIN32_FIND_DATAW {
    DWORD dwFileAttributes;
    FILETIME ftCreationTime;
    FILETIME ftLastAccessTime;
    FILETIME ftLastWriteTime;
    DWORD nFileSizeHigh;
    DWORD nFileSizeLow;
    DWORD dwReserved0;
    DWORD dwReserved1;
    _Field_z_ WCHAR  cFileName[ MAX_PATH ];
    _Field_z_ WCHAR  cAlternateFileName[ 14 ];
} WIN32_FIND_DATAW, *PWIN32_FIND_DATAW, *LPWIN32_FIND_DATAW;
```