### PR TITLE
Adding support of libFuzzer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,7 @@ if(C3_WITH_LLVM)
         if (llvm_dir)
             file(GLOB_RECURSE RT_ASAN_DYNAMIC "${llvm_dir}/*libclang_rt.asan_osx_dynamic.dylib")
             file(GLOB_RECURSE RT_TSAN_DYNAMIC "${llvm_dir}/*libclang_rt.tsan_osx_dynamic.dylib")
+            file(GLOB_RECURSE RT_FUZZER_DYNAMIC "${llvm_dir}/*libclang_rt.fuzzer_osx_dynamic.dylib")
         endif()
 
         if (NOT RT_ASAN_DYNAMIC OR NOT RT_TSAN_DYNAMIC)
@@ -432,18 +433,29 @@ if(C3_WITH_LLVM)
             endif()
         endif()
 
+        if (NOT RT_FUZZER_DYNAMIC)
+            find_file(RT_FUZZER_DYNAMIC_PATH NAMES libclang_rt.fuzzer_osx_dynamic.dylib PATHS ${LLVM_LIBRARY_DIRS} PATH_SUFFIXES "clang/${LLVM_MAJOR_VERSION}/lib/darwin" "clang/${LLVM_PACKAGE_VERSION}/lib/darwin")
+            if (RT_FUZZER_DYNAMIC_PATH)
+                set(RT_FUZZER_DYNAMIC ${RT_FUZZER_DYNAMIC_PATH})
+            endif()
+        endif()
+
         if (RT_ASAN_DYNAMIC)
             list(GET RT_ASAN_DYNAMIC 0 RT_ASAN_DYNAMIC)
         endif()
         if (RT_TSAN_DYNAMIC)
             list(GET RT_TSAN_DYNAMIC 0 RT_TSAN_DYNAMIC)
         endif()
+        if (RT_FUZZER_DYNAMIC)
+            list(GET RT_FUZZER_DYNAMIC 0 RT_FUZZER_DYNAMIC)
+        endif()
 
-        if (RT_ASAN_DYNAMIC AND RT_TSAN_DYNAMIC)
-            set(sanitizer_runtime_libraries
-                    ${RT_ASAN_DYNAMIC}
-                    ${RT_TSAN_DYNAMIC}
-            )
+        if (RT_FUZZER_DYNAMIC)
+            if (RT_ASAN_DYNAMIC AND RT_TSAN_DYNAMIC)
+                list(APPEND sanitizer_runtime_libraries ${RT_FUZZER_DYNAMIC})
+            else()
+                set(sanitizer_runtime_libraries ${RT_FUZZER_DYNAMIC})
+            endif()
         endif()
     endif()
 

--- a/src/build/build.h
+++ b/src/build/build.h
@@ -506,6 +506,7 @@ typedef struct
 		bool sanitize_address : 1;
 		bool sanitize_memory : 1;
 		bool sanitize_thread : 1;
+		bool sanitize_fuzzer : 1;
 		ImplicitFloat implicit_float : 3;
 		FpOpt fp_math;
 		SafetyLevel safe_mode;

--- a/src/build/build_internal.h
+++ b/src/build/build_internal.h
@@ -181,11 +181,12 @@ static const char *reloc_models[5] = {
 	[RELOC_BIG_PIE] = "PIE",
 };
 
-static const char *sanitize_modes[4] = {
+static const char *sanitize_modes[5] = {
 	[SANITIZE_NONE] = "none",
 	[SANITIZE_ADDRESS] = "address",
 	[SANITIZE_MEMORY] = "memory",
 	[SANITIZE_THREAD] = "thread",
+	[SANITIZE_FUZZER] = "fuzzer",
 };
 
 JSONObject *project_json_load(const char **filename_ref);

--- a/src/build/build_options.c
+++ b/src/build/build_options.c
@@ -248,7 +248,7 @@ static void usage(bool full)
 		PRINTF("");
 		print_opt("--bsd-sysroot <dir>", "Set the BSD sysroot directory.");
 		PRINTF("");
-		print_opt("--sanitize=<option>", "Enable sanitizer: address, memory, thread.");
+		print_opt("--sanitize=<option>", "Enable sanitizer: address, memory, thread or fuzzer.");
 	}
 	if (!full)
 	{

--- a/src/build/builder.c
+++ b/src/build/builder.c
@@ -775,10 +775,12 @@ BUILD:
 			target->feature.sanitize_address = false;
 			target->feature.sanitize_memory = false;
 			target->feature.sanitize_thread = false;
+			target->feature.sanitize_fuzzer = false;
 			break;
 		case SANITIZE_ADDRESS: target->feature.sanitize_address = true; break;
 		case SANITIZE_MEMORY: target->feature.sanitize_memory = true; break;
 		case SANITIZE_THREAD: target->feature.sanitize_thread = true; break;
+		case SANITIZE_FUZZER: target->feature.sanitize_fuzzer = true; break;
 		default: UNREACHABLE_VOID;
 	}
 

--- a/src/build/project.c
+++ b/src/build/project.c
@@ -58,7 +58,7 @@ const char *project_default_keys[][2] = {
 		{"riscv-cpu", "Set general level of RISC-V cpu: `rvi`, `rvimac`, `rvimafc`, `rvgc` or `rvgcv`."},
 		{"run-dir", "Override run directory for 'run'."},
 		{"safe", "Set safety (contracts, runtime bounds checking, null pointer checks etc) on or off."},
-		{"sanitize", "Enable sanitizer: none, address, memory, thread."},
+		{"sanitize", "Enable sanitizer: none, address, memory, thread or fuzzer."},
 		{"script-dir", "The directory where 'exec' scripts are found."},
 		{"exec-dir", "The directory where 'exec' is run."},
 		{"show-backtrace", "Print backtrace on signals."},
@@ -156,7 +156,7 @@ const char* project_target_keys[][2] = {
 		{"riscv-abi", "RiscV ABI: int-only, float, double."},
 		{"run-dir", "Override run directory for 'run'."},
 		{"safe", "Set safety (contracts, runtime bounds checking, null pointer checks etc) on or off."},
-		{"sanitize", "Enable sanitizer: none, address, memory, thread."},
+		{"sanitize", "Enable sanitizer: none, address, memory, thread or fuzzer."},
 		{"script-dir", "The directory where scripts are found."},
 		{"exec-dir", "The directory where 'exec' is run."},
 		{"show-backtrace", "Print backtrace on signals."},
@@ -429,7 +429,7 @@ static void load_into_build_target(BuildParseContext context, JSONObject *json, 
 	if (reloc != RELOC_DEFAULT) target->reloc_model = reloc;
 
 	// Sanitize
-	SanitizeMode sanitize_mode = GET_SETTING(SanitizeMode, "sanitize", sanitize_modes, "'none', 'address', 'memory' or 'thread'.");
+	SanitizeMode sanitize_mode = GET_SETTING(SanitizeMode, "sanitize", sanitize_modes, "'none', 'address', 'memory', 'thread' or 'fuzzer'.");
 	switch (sanitize_mode)
 	{
 		case SANITIZE_NOT_SET: break;
@@ -437,10 +437,12 @@ static void load_into_build_target(BuildParseContext context, JSONObject *json, 
 			target->feature.sanitize_address = false;
 			target->feature.sanitize_memory = false;
 			target->feature.sanitize_thread = false;
+			target->feature.sanitize_fuzzer = false;
 			break;
 		case SANITIZE_ADDRESS: target->feature.sanitize_address = true; break;
 		case SANITIZE_MEMORY: target->feature.sanitize_memory = true; break;
 		case SANITIZE_THREAD: target->feature.sanitize_thread = true; break;
+		case SANITIZE_FUZZER: target->feature.sanitize_fuzzer = true; break;
 		default: UNREACHABLE_VOID;
 	}
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1482,11 +1482,58 @@ static void check_thread_sanitizer_options(BuildTarget *target)
 			error_exit("Thread sanitizer is only supported on 64-bit Linux, NetBSD, FreeBSD and Darwin.");
 	}
 }
+static void check_fuzzer_options(BuildTarget *target)
+{
+#if !LLVM_AVAILABLE
+	error_exit("Fuzzer support requires a c3c build with the LLVM backend.");
+#endif
+	if (target->linker_type == LINKER_TYPE_BUILTIN)
+	{
+		error_exit("Fuzzer support requires linking with the system compiler driver, please remove `--linker=builtin`.");
+	}
+	if (compiler.platform.os != OS_TYPE_LINUX || target->arch_os_target != default_target)
+	{
+		error_exit("Fuzzer support is currently only available when compiling for the native Linux target.");
+	}
+	const char *cc = target->cc;
+	if (!cc)
+	{
+		const char *cc_env = getenv("C3C_CC");
+		if (cc_env && cc_env[0]) cc = cc_env;
+	}
+	if (!cc)
+	{
+		// No C compiler driver was configured: pick clang automatically so
+		// `--sanitize=fuzzer` works out of the box whenever clang is available.
+		if (file_executable_in_path("clang"))
+		{
+			target->cc = "clang";
+			return;
+		}
+		char clang_version[16];
+		for (int version = 24; version >= 17; version--)
+		{
+			sprintf(clang_version, "clang-%d", version);
+			if (file_executable_in_path(clang_version))
+			{
+				target->cc = str_dup(clang_version);
+				return;
+			}
+		}
+		error_exit("Fuzzer support requires clang as the C compiler driver, but no clang was found in the PATH. Install clang or set the C3C_CC environment variable to a clang binary.");
+	}
+	if (!file_executable_in_path(cc) || !strstr(cc, "clang"))
+	{
+		error_exit("Fuzzer support requires clang as the C compiler driver, please use `--cc <clang>` or set the C3C_CC environment variable to a clang binary.");
+	}
+}
+
 static void check_sanitizer_options(BuildTarget *target)
 {
 	if (target->feature.sanitize_address) check_address_sanitizer_options(target);
 	if (target->feature.sanitize_memory) check_memory_sanitizer_options(target);
 	if (target->feature.sanitize_thread) check_thread_sanitizer_options(target);
+	if (target->feature.sanitize_fuzzer) check_fuzzer_options(target);
 
 	if (target->type == TARGET_TYPE_BENCHMARK)
 	{
@@ -1711,6 +1758,7 @@ INLINE void update_feature_flags(void)
 	if (compiler.build.feature.sanitize_address) add_feat("ASAN");
 	if (compiler.build.feature.sanitize_memory) add_feat("MSAN");
 	if (compiler.build.feature.sanitize_thread) add_feat("TSAN");
+	if (compiler.build.feature.sanitize_fuzzer) add_feat("FUZZER");
 	if (compiler.build.feature.panic_level != PANIC_OFF) add_feat("PRINT_PANIC");
 }
 

--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -1491,40 +1491,41 @@ static void check_fuzzer_options(BuildTarget *target)
 	{
 		error_exit("Fuzzer support requires linking with the system compiler driver, please remove `--linker=builtin`.");
 	}
-	if (compiler.platform.os != OS_TYPE_LINUX || target->arch_os_target != default_target)
+	if ((compiler.platform.os != OS_TYPE_LINUX && compiler.platform.os != OS_TYPE_MACOSX) || target->arch_os_target != default_target)
 	{
-		error_exit("Fuzzer support is currently only available when compiling for the native Linux target.");
+		error_exit("Fuzzer support is currently only available when compiling for the native Linux or macOS target.");
 	}
-	const char *cc = target->cc;
-	if (!cc)
+	if (compiler.platform.os == OS_TYPE_LINUX)
 	{
-		const char *cc_env = getenv("C3C_CC");
-		if (cc_env && cc_env[0]) cc = cc_env;
-	}
-	if (!cc)
-	{
-		// No C compiler driver was configured: pick clang automatically so
-		// `--sanitize=fuzzer` works out of the box whenever clang is available.
-		if (file_executable_in_path("clang"))
+		const char *cc = target->cc;
+		if (!cc)
 		{
-			target->cc = "clang";
-			return;
+			const char *cc_env = getenv("C3C_CC");
+			if (cc_env && cc_env[0]) cc = cc_env;
 		}
-		char clang_version[16];
-		for (int version = 24; version >= 17; version--)
+		if (!cc)
 		{
-			sprintf(clang_version, "clang-%d", version);
-			if (file_executable_in_path(clang_version))
+			if (file_executable_in_path("clang"))
 			{
-				target->cc = str_dup(clang_version);
+				target->cc = "clang";
 				return;
 			}
+			char clang_version[16];
+			for (int version = 24; version >= 17; version--)
+			{
+				sprintf(clang_version, "clang-%d", version);
+				if (file_executable_in_path(clang_version))
+				{
+					target->cc = str_dup(clang_version);
+					return;
+				}
+			}
+			error_exit("Fuzzer support requires clang as the C compiler driver, but no clang was found in the PATH. Install clang or set the C3C_CC environment variable to a clang binary.");
 		}
-		error_exit("Fuzzer support requires clang as the C compiler driver, but no clang was found in the PATH. Install clang or set the C3C_CC environment variable to a clang binary.");
-	}
-	if (!file_executable_in_path(cc) || !strstr(cc, "clang"))
-	{
-		error_exit("Fuzzer support requires clang as the C compiler driver, please use `--cc <clang>` or set the C3C_CC environment variable to a clang binary.");
+		if (!file_executable_in_path(cc) || !strstr(cc, "clang"))
+		{
+			error_exit("Fuzzer support requires clang as the C compiler driver, please use `--cc <clang>` or set the C3C_CC environment variable to a clang binary.");
+		}
 	}
 }
 

--- a/src/compiler/enums.h
+++ b/src/compiler/enums.h
@@ -393,6 +393,7 @@ typedef enum
 	SANITIZE_ADDRESS,
 	SANITIZE_MEMORY,
 	SANITIZE_THREAD,
+	SANITIZE_FUZZER,
 } SanitizeMode;
 
 typedef enum

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -1092,6 +1092,10 @@ static bool linker_setup(const char ***args_ref, const char **files_to_link, int
 		if (compiler.build.feature.sanitize_address) add_plain_arg("-fsanitize=address");
 		if (compiler.build.feature.sanitize_memory) add_plain_arg("-fsanitize=memory");
 		if (compiler.build.feature.sanitize_thread) add_plain_arg("-fsanitize=thread");
+		if (compiler.build.feature.sanitize_fuzzer && linker_type == LINKER_CC)
+		{
+			add_plain_arg("-fsanitize=fuzzer");
+		}
 	}
 
 	return true;

--- a/src/compiler/linker.c
+++ b/src/compiler/linker.c
@@ -1070,7 +1070,7 @@ static bool linker_setup(const char ***args_ref, const char **files_to_link, int
 	// Link sanitizer runtime libraries
 	if (compiler.platform.os == OS_TYPE_MACOSX)
 	{
-		if (compiler.build.feature.sanitize_address || compiler.build.feature.sanitize_thread)
+		if (compiler.build.feature.sanitize_address || compiler.build.feature.sanitize_thread || compiler.build.feature.sanitize_fuzzer)
 		{
 			const char *compiler_path = find_executable_path();
 			if (compiler.build.feature.sanitize_address)
@@ -1080,6 +1080,10 @@ static bool linker_setup(const char ***args_ref, const char **files_to_link, int
 			if (compiler.build.feature.sanitize_thread)
 			{
 				add_concat_file_arg(compiler_path, "c3c_rt/libclang_rt.tsan_osx_dynamic.dylib");
+			}
+			if (compiler.build.feature.sanitize_fuzzer)
+			{
+				add_concat_file_arg(compiler_path, "c3c_rt/libclang_rt.fuzzer_osx_dynamic.dylib");
 			}
 
 			// Add rpath for sanitizer runtime libraries last, after user-provided link args have been added.

--- a/src/compiler/llvm_codegen.c
+++ b/src/compiler/llvm_codegen.c
@@ -1109,7 +1109,8 @@ static inline void llvm_optimize(GenContext *c)
 			.opt.merge_functions = compiler.build.merge_functions == MERGE_FUNCTIONS_ON,
 			.sanitizer.address_sanitize = compiler.build.feature.sanitize_address,
 			.sanitizer.mem_sanitize = compiler.build.feature.sanitize_memory,
-			.sanitizer.thread_sanitize = compiler.build.feature.sanitize_thread
+			.sanitizer.thread_sanitize = compiler.build.feature.sanitize_thread,
+			.sanitizer.fuzzer = compiler.build.feature.sanitize_fuzzer
 	};
 	if (!llvm_run_passes(c->module, c->machine, &passes))
 	{

--- a/wrapper/include/c3_llvm.h
+++ b/wrapper/include/c3_llvm.h
@@ -55,6 +55,7 @@ typedef struct
 		bool asan_use_after_return;
 		bool asan_use_global_dstor;
 		bool hwaddress_sanitize;
+		bool fuzzer;
 	} sanitizer;
 	struct
 	{

--- a/wrapper/src/wrapper.cpp
+++ b/wrapper/src/wrapper.cpp
@@ -26,6 +26,7 @@
 #include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
 #include "llvm/Transforms/Instrumentation/ThreadSanitizer.h"
 #include "llvm/Transforms/Instrumentation/HWAddressSanitizer.h"
+#include "llvm/Transforms/Instrumentation/SanitizerCoverage.h"
 #include "llvm/Transforms/Scalar/EarlyCSE.h"
 #include "llvm/Transforms/Scalar/GVN.h"
 #include "llvm/Transforms/Scalar/JumpThreading.h"
@@ -270,6 +271,17 @@ bool llvm_run_passes(LLVMModuleRef m, LLVMTargetMachineRef tm, LLVMPasses *passe
 			passes->sanitizer.recover,
 			passes->opt_level == LLVM_O0
 		}));
+	}
+	if (passes->sanitizer.fuzzer)
+	{
+		llvm::SanitizerCoverageOptions options;
+		options.CoverageType = llvm::SanitizerCoverageOptions::SCK_Edge;
+		options.Inline8bitCounters = true;
+		options.PCTable = true;
+		options.IndirectCalls = true;
+		options.TraceCmp = true;
+		options.StackDepth = true;
+		MPM.addPass(llvm::SanitizerCoveragePass(options));
 	}
 	// MPM.addPass(DataFlowSanitizerPass(LangOpts.NoSanitizeFiles));
 


### PR DESCRIPTION
Hi, I'd like to post throaway POC PR for demonstrating fuzzing capabilities. Currently I added it in Linux and MacOS (**untested**!).  This PR is backing for #3505 proposal.  It's made with AI support, take is with grain of salt. I'm open for criticism. 

The escence of this PR is in small addition in the ` wrapper/src/wrapper.cpp`.

This is sample C3 fuzzing program: 
```c3

module fuzz_target;

extern fn void abort() @cname("abort");

// Called by libFuzzer for every input. Returns 0 on success; a crash or
// abort() reports a finding.
fn int llvm_fuzzer_test_one_input(char* data, usz size) @export("LLVMFuzzerTestOneInput")
{
    // Pretend protocol: [0..2] = "GET", [3] = '/', [4] = body length,
    // [5..] = body bytes. A body shorter than the declared length is a bug.
    if (size < 5) return 0;
    if (data[0] != 'G') return 0;
    if (data[1] != 'E') return 0;
    if (data[2] != 'T') return 0;
    if (data[3] != '/') return 0;
    usz len = (usz)data[4];
    if (size >= 5 + len) return 0; // body complete: input is fine.
    // Deliberate bug: truncated body accepted. In real code this would be
    // an out-of-bounds read; here it is simulated with abort() so the fuzzer
    // run terminates with a reportable crash.
    abort();
    return 0;
}

```

Run fuzzer with:
```sh
build/c3c compile --sanitize=fuzzer --no-entry fuzz_target.c3 -o fuzz
./fuzz
```

Fuzzer output on Linux:
```
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 2053795620
INFO: Loaded 1 modules   (5530 inline 8-bit counters): 5530 [0x55b5c1aee6d0, 0x55b5c1aefc6a),
INFO: Loaded 1 PC tables (5530 PCs): 5530 [0x55b5c1aefc70,0x55b5c1b05610),
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
#2      INITED cov: 2 ft: 2 corp: 1/1b exec/s: 0 rss: 28Mb
#203    NEW    cov: 3 ft: 3 corp: 2/7b lim: 6 exec/s: 0 rss: 28Mb L: 6/6 MS: 1 InsertRepeatedBytes-
#210    REDUCE cov: 3 ft: 3 corp: 2/6b lim: 6 exec/s: 0 rss: 28Mb L: 5/5 MS: 2 ShuffleBytes-EraseBytes-
#18476  REDUCE cov: 4 ft: 4 corp: 3/11b lim: 184 exec/s: 0 rss: 28Mb L: 5/5 MS: 1 ChangeByte-
#37889  NEW    cov: 5 ft: 5 corp: 4/17b lim: 373 exec/s: 0 rss: 28Mb L: 6/6 MS: 3 ShuffleBytes-ChangeByte-InsertByte-
#38020  NEW    cov: 6 ft: 6 corp: 5/94b lim: 373 exec/s: 0 rss: 28Mb L: 77/77 MS: 1 InsertRepeatedBytes-
#38066  REDUCE cov: 6 ft: 6 corp: 5/93b lim: 373 exec/s: 0 rss: 28Mb L: 5/77 MS: 1 EraseBytes-
#38213  REDUCE cov: 6 ft: 6 corp: 5/60b lim: 373 exec/s: 0 rss: 28Mb L: 44/44 MS: 2 CopyPart-EraseBytes-
#38283  REDUCE cov: 6 ft: 6 corp: 5/43b lim: 373 exec/s: 0 rss: 28Mb L: 27/27 MS: 5 CrossOver-ChangeByte-ChangeByte-ChangeBit-EraseBytes-
#38579  REDUCE cov: 6 ft: 6 corp: 5/36b lim: 373 exec/s: 0 rss: 28Mb L: 20/20 MS: 1 EraseBytes-
#38651  REDUCE cov: 6 ft: 6 corp: 5/34b lim: 373 exec/s: 0 rss: 28Mb L: 18/18 MS: 2 ChangeBit-EraseBytes-
#38799  REDUCE cov: 6 ft: 6 corp: 5/33b lim: 373 exec/s: 0 rss: 28Mb L: 17/17 MS: 3 CopyPart-InsertByte-EraseBytes-
#39003  REDUCE cov: 6 ft: 6 corp: 5/32b lim: 373 exec/s: 0 rss: 28Mb L: 16/16 MS: 4 ChangeBinInt-ShuffleBytes-CrossOver-EraseBytes-
#39035  REDUCE cov: 6 ft: 6 corp: 5/31b lim: 373 exec/s: 0 rss: 28Mb L: 15/15 MS: 2 InsertByte-EraseBytes-
#39057  REDUCE cov: 6 ft: 6 corp: 5/27b lim: 373 exec/s: 0 rss: 28Mb L: 11/11 MS: 2 ShuffleBytes-EraseBytes-
#39071  REDUCE cov: 6 ft: 6 corp: 5/23b lim: 373 exec/s: 0 rss: 28Mb L: 7/7 MS: 4 ChangeBit-ChangeByte-ChangeByte-EraseBytes-
#39150  REDUCE cov: 6 ft: 6 corp: 5/21b lim: 373 exec/s: 0 rss: 28Mb L: 5/5 MS: 4 InsertByte-InsertByte-InsertByte-CrossOver-
==1241518== ERROR: libFuzzer: deadly signal
    #0 0x55b5c1a2e5b8 in __sanitizer_print_stack_trace (/home/ubertrader/code/c3c/fuzz+0x975b8) (BuildId: 6e468bf54b605a9d36c1dfe5e255726aff893ca6)
    #1 0x55b5c1a0118c in fuzzer::PrintStackTrace() (/home/ubertrader/code/c3c/fuzz+0x6a18c) (BuildId: 6e468bf54b605a9d36c1dfe5e255726aff893ca6)
    #2 0x55b5c19e6107 in fuzzer::Fuzzer::CrashCallback() (/home/ubertrader/code/c3c/fuzz+0x4f107) (BuildId: 6e468bf54b605a9d36c1dfe5e255726aff893ca6)
    #3 0x7f75d544bdef  (/lib/x86_64-linux-gnu/libc.so.6+0x3fdef) (BuildId: c495b62edadd6c356265942ec1282d98058a7b41)
    #4 0x7f75d54a095b in __pthread_kill_implementation nptl/pthread_kill.c:43:17
    #5 0x7f75d544bcc1 in raise signal/../sysdeps/posix/raise.c:26:13
    #6 0x7f75d54344ab in abort stdlib/abort.c:77:3
    #7 0x55b5c1abec2f in LLVMFuzzerTestOneInput /home/ubertrader/code/c3c/scripts/tools/fuzz_target.c3:41:5
    #8 0x55b5c19e780a in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/ubertrader/code/c3c/fuzz+0x5080a) (BuildId: 6e468bf54b605a9d36c1dfe5e255726aff893ca6)
    #9 0x55b5c19e6e19 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) (/home/ubertrader/code/c3c/fuzz+0x4fe19) (BuildId: 6e468bf54b605a9d36c1dfe5e255726aff893ca6)
    #10 0x55b5c19e88e5 in fuzzer::Fuzzer::MutateAndTestOne() (/home/ubertrader/code/c3c/fuzz+0x518e5) (BuildId: 6e468bf54b605a9d36c1dfe5e255726aff893ca6)
    #11 0x55b5c19e93d5 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (/home/ubertrader/code/c3c/fuzz+0x523d5) (BuildId: 6e468bf54b605a9d36c1dfe5e255726aff893ca6)
    #12 0x55b5c19d5995 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/ubertrader/code/c3c/fuzz+0x3e995) (BuildId: 6e468bf54b605a9d36c1dfe5e255726aff893ca6)
    #13 0x55b5c1a01cf6 in main (/home/ubertrader/code/c3c/fuzz+0x6acf6) (BuildId: 6e468bf54b605a9d36c1dfe5e255726aff893ca6)
    #14 0x7f75d5435ca7 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #15 0x7f75d5435d64 in __libc_start_main csu/../csu/libc-start.c:360:3
    #16 0x55b5c19c9cf0 in _start (/home/ubertrader/code/c3c/fuzz+0x32cf0) (BuildId: 6e468bf54b605a9d36c1dfe5e255726aff893ca6)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 2 CrossOver-InsertByte-; base unit: d2481f848d163d7661d70867e8d2bb73d151dbda
0x47,0x45,0x54,0x2f,0x40,0x61,0x47,0x63,0xa,0x63,0x63,
GET/@aGc\012cc
artifact_prefix='./'; Test unit written to ./crash-ec416b85430932ebfbea63fb7010a99092e25976
Base64: R0VUL0BhR2MKY2M=

```