### PR TITLE
Add std::collections::Ref

### DIFF
--- a/lib/std/collections/ref.c3
+++ b/lib/std/collections/ref.c3
@@ -1,0 +1,46 @@
+module std::collections::ref <Type>;
+import std::io;
+
+<* A non null reference *>
+typedef Ref = inline Type*;
+
+excuse NULL_REF;
+
+<*
+	@require [val] val != null
+*>
+fn Ref from(Type* val) @inline => (Ref)val;
+
+fn Ref? try_from(Type* val) @inline => (Ref)val ?: NULL_REF~;
+
+<*
+	@require [self] (Type*)*self != null
+*>
+fn sz? Ref.to_format(&self, Formatter* f) @dynamic
+{
+  return f.printf("%s", *((Type*)*self));
+}
+
+<*
+	@require [val] val != null
+*>
+fn void Ref.set(&self, Type* val) @inline
+{
+	*self = (Ref)val;
+}
+
+fn void? Ref.try_set(&self, Type* val) @inline
+{
+	if (!val) return NULL_REF~;
+	*self = (Ref)val;
+}
+
+<*
+	@ensure return != null
+*>
+fn Type* Ref.get(self) @inline => (Type*)self;
+
+fn bool Ref.equals(self, Ref other) @operator(==) @if(types::is_equatable_type(Type))
+{
+	return ((Type*)self) == ((Type*)other);
+}

--- a/releasenotes.md
+++ b/releasenotes.md
@@ -1,5 +1,14 @@
 # C3C Release Notes
 
+## 0.8.5 Change list
+
+### Changes / improvements
+
+### Stdlib changes
+- Add `std::collections::Ref`
+
+### Fixes
+
 ## 0.8.4 Change list
 
 ### Changes / improvements

--- a/test/unit/stdlib/collections/ref.c3
+++ b/test/unit/stdlib/collections/ref.c3
@@ -1,0 +1,87 @@
+module reftest @test;
+
+import std::collections::ref;
+import std::core::types;
+
+alias IntRef = ref::Ref{int};
+
+struct Unequatable
+{
+	int value;
+}
+
+alias UnequatableRef = ref::Ref{Unequatable};
+
+fn void test_from()
+{
+	int x    = 42;
+	IntRef r = ref::from{int}(&x);
+	assert(r.get() == &x);
+	assert(*r.get() == 42);
+}
+
+fn void test_try_from()
+{
+	int x    = 7;
+	IntRef r = ref::try_from{int}(&x)!!;
+	assert(r.get() == &x);
+	assert(@catch(ref::try_from{int}(null)) == ref::NULL_REF);
+}
+
+fn void test_get_mutates_target()
+{
+	int x    = 1;
+	IntRef r = ref::from{int}(&x);
+	*r.get() = 5;
+	assert(x == 5);
+}
+
+fn void test_set()
+{
+	int x    = 1;
+	int y    = 2;
+	IntRef r = ref::from{int}(&x);
+	r.set(&y);
+	assert(r.get() == &y);
+	assert(*r.get() == 2);
+}
+
+fn void test_try_set()
+{
+	int x    = 1;
+	int y    = 2;
+	IntRef r = ref::from{int}(&x);
+	r.try_set(&y)!!;
+	assert(r.get() == &y);
+	assert(@catch(r.try_set(null)) == ref::NULL_REF);
+	// Failed set leaves the ref untouched.
+	assert(r.get() == &y);
+}
+
+fn void test_equals()
+{
+	$assert(types::is_equatable_type(IntRef));
+	int x      = 1;
+	int y      = 1;
+	IntRef rx  = ref::from{int}(&x);
+	IntRef rx2 = ref::from{int}(&x);
+	IntRef ry  = ref::from{int}(&y);
+	assert(rx == rx2);
+	assert(rx != ry);
+	assert(ry != rx);
+}
+
+fn void test_struct()
+{
+	Unequatable u    = { 3 };
+	UnequatableRef r = ref::from{Unequatable}(&u);
+	r.get().value = 10;
+	assert(u.value == 10);
+}
+
+fn void test_format()
+{
+	int x    = 42;
+	IntRef r = ref::from{int}(&x);
+	test::eq(string::tformat("%s", r), "42");
+}


### PR DESCRIPTION
Added `std::collections::Ref` with test cases and the releasenote entry.

This is a zero-cost abstraction to hold a non-null pointer (aka a reference) so we can more easily express that invariant in a struct field or in a parameter without having to wrap a pointer in a costly `Maybe` struct.